### PR TITLE
Basic model metadata and tokenizer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ lazy val root = (project in file("."))
       "com.azure"      % "azure-ai-openai" % "1.0.0-beta.14",
       "com.anthropic"  % "anthropic-java"  % "0.7.0",
       "ch.qos.logback" % "logback-classic" % "1.5.17",
+      "com.knuddels"   % "jtokkit"         % "1.1.0",
       "com.lihaoyi"   %% "upickle"         % "4.1.0",
       "com.lihaoyi"   %% "requests"        % "0.9.0",
       "org.scalatest" %% "scalatest"       % "3.2.19" % Test

--- a/samples/src/main/scala/org/llm4s/samples/tokens/TokenizerExample.scala
+++ b/samples/src/main/scala/org/llm4s/samples/tokens/TokenizerExample.scala
@@ -1,0 +1,11 @@
+package org.llm4s.samples.tokens
+
+import org.llm4s.metadata.vendors.GPT_4o_2024_08_06
+import org.llm4s.token.Tokenizer
+
+object TokenizerExample {
+  def main(args: Array[String]): Unit = {
+    val tokenizer = Tokenizer.lookupStringTokenizer(GPT_4o_2024_08_06.vocabulary.get).get
+    println(tokenizer.encode("Hello Scala!"))
+  }
+}

--- a/src/main/scala/org/llm4s/metadata/Metadata.scala
+++ b/src/main/scala/org/llm4s/metadata/Metadata.scala
@@ -66,19 +66,32 @@ trait ModelVersion {
 
   def displayName: String = name
 
-  def vocabulary: Option[Vocabulary] = None
+  def vocabulary: Option[Vocabulary]
 
   def inputs: Set[MediaType]
 
   def outputs: Set[MediaType]
 
-  def features: Option[Set[Feature]] = None
+  def features: Option[Set[Feature]]
 
-  def endpoints: Option[Set[Endpoint]] = None
+  def endpoints: Option[Set[Endpoint]]
 
-  def contextWindowSize: Option[Int] = None
+  def contextWindowSize: Option[Int]
 
-  def maxOutputTokens: Option[Int] = None
+  def maxOutputTokens: Option[Int]
 
-  def knowledgeCutoff: Option[LocalDate] = None
+  def knowledgeCutoff: Option[LocalDate]
 }
+
+case class CustomModelVersion(
+  model: ModelSeries,
+  name: String,
+  vocabulary: Option[Vocabulary] = None,
+  inputs: Set[MediaType],
+  outputs: Set[MediaType],
+  features: Option[Set[Feature]] = None,
+  endpoints: Option[Set[Endpoint]] = None,
+  contextWindowSize: Option[Int],
+  maxOutputTokens: Option[Int],
+  knowledgeCutoff: Option[LocalDate]
+) extends ModelVersion

--- a/src/main/scala/org/llm4s/metadata/Metadata.scala
+++ b/src/main/scala/org/llm4s/metadata/Metadata.scala
@@ -57,6 +57,7 @@ trait Vocabulary {
   def name: String
   def displayName: String = name
 }
+case class CustomVocabulary(name: String) extends Vocabulary
 
 /*sealed*/
 trait ModelVersion {

--- a/src/main/scala/org/llm4s/metadata/Metadata.scala
+++ b/src/main/scala/org/llm4s/metadata/Metadata.scala
@@ -1,0 +1,84 @@
+package org.llm4s.metadata
+
+import java.time.LocalDate
+
+/*sealed*/
+trait Vendor {
+  def name: String
+
+  def displayName: String = name
+}
+case class CustomVendor(name: String) extends Vendor {}
+
+/*sealed*/
+trait ModelSeries {
+  def vendor: Vendor
+  def displayName: String = name
+  def name: String
+}
+case class CustomSeries(name: String, vendor: Vendor) extends ModelSeries {}
+
+sealed trait MediaType
+object MediaType {
+  case object Text  extends MediaType
+  case object Image extends MediaType
+  case object Audio extends MediaType
+}
+
+sealed trait Feature
+object Feature {
+  case object Streaming         extends Feature
+  case object FunctionCalling   extends Feature
+  case object StructuredOutputs extends Feature
+  case object FineTuning        extends Feature
+  case object Distillation      extends Feature
+  case object PredictedOutputs  extends Feature
+}
+
+sealed trait Endpoint
+object Endpoint {
+  case object ChatCompletions   extends Endpoint
+  case object Responses         extends Endpoint
+  case object Realtime          extends Endpoint
+  case object Assistants        extends Endpoint
+  case object Batch             extends Endpoint
+  case object FineTuning        extends Endpoint
+  case object Embeddings        extends Endpoint
+  case object ImageGeneration   extends Endpoint
+  case object SpeechGeneration  extends Endpoint
+  case object Transcription     extends Endpoint
+  case object Translation       extends Endpoint
+  case object Moderation        extends Endpoint
+  case object CompletionsLegacy extends Endpoint
+}
+
+/*sealed*/
+trait Vocabulary {
+  def name: String
+  def displayName: String = name
+}
+
+/*sealed*/
+trait ModelVersion {
+  def model: ModelSeries
+
+  def name: String
+
+  def displayName: String = name
+
+  def vocabulary: Option[Vocabulary] = None
+
+  def inputs: Set[MediaType]
+
+  def outputs: Set[MediaType]
+
+  def features: Option[Set[Feature]] = None
+
+  def endpoints: Option[Set[Endpoint]] = None
+
+  def contextWindowSize: Option[Int] = None
+
+  def maxOutputTokens: Option[Int] = None
+
+  def knowledgeCutoff: Option[LocalDate] = None
+}

--- a/src/main/scala/org/llm4s/metadata/vendors/Anthropic.scala
+++ b/src/main/scala/org/llm4s/metadata/vendors/Anthropic.scala
@@ -1,0 +1,9 @@
+package org.llm4s.metadata.vendors
+
+import org.llm4s.metadata.Vendor
+
+case object Anthropic extends Vendor {
+  override def name: String = "anthropic"
+
+  override def displayName: String = "Anthropic"
+}

--- a/src/main/scala/org/llm4s/metadata/vendors/Azure.scala
+++ b/src/main/scala/org/llm4s/metadata/vendors/Azure.scala
@@ -1,0 +1,9 @@
+package org.llm4s.metadata.vendors
+
+import org.llm4s.metadata.Vendor
+
+case object Azure extends Vendor {
+  override def name: String = "azure"
+
+  override def displayName: String = "Azure"
+}

--- a/src/main/scala/org/llm4s/metadata/vendors/OpenAI.scala
+++ b/src/main/scala/org/llm4s/metadata/vendors/OpenAI.scala
@@ -1,0 +1,70 @@
+package org.llm4s.metadata.vendors
+
+import org.llm4s.metadata.Endpoint.{ Assistants, Batch, ChatCompletions, Responses }
+import org.llm4s.metadata.Feature.{ FunctionCalling, Streaming, StructuredOutputs }
+import org.llm4s.metadata.MediaType.{ Image, Text }
+import org.llm4s.metadata.{ Endpoint, Feature, MediaType, ModelSeries, ModelVersion, Vendor, Vocabulary }
+
+import java.time.LocalDate
+
+case object OpenAI extends Vendor {
+  override def name: String = "openai"
+
+  override def displayName: String = "OpenAI"
+}
+
+case object R50K_BASE   extends Vocabulary { override def name = "r50k_base"   }
+case object P50K_BASE   extends Vocabulary { override def name = "p50k_base"   }
+case object P50K_EDIT   extends Vocabulary { override def name = "p50k_edit"   }
+case object CL100K_BASE extends Vocabulary { override def name = "cl100k_base" }
+case object O200K_BASE  extends Vocabulary { override def name = "o200k_base"  }
+
+case object GPT_4o extends ModelSeries {
+
+  override def vendor: Vendor = OpenAI
+
+  override def name: String = "gpt-4o"
+}
+
+case object GPT_4o_2024_08_06 extends ModelVersion {
+  override def model: ModelSeries = GPT_4o
+  override def name: String       = "gpt-4o-2024-08-06"
+
+  override def vocabulary: Option[Vocabulary] = Some(CL100K_BASE)
+
+  override def inputs: Set[MediaType] = Set(Text, Image)
+
+  override def outputs: Set[MediaType] = Set(Text)
+
+  override def contextWindowSize: Option[Int] = Some(128_000)
+
+  override def maxOutputTokens: Option[Int] = Some(16_384)
+
+  override def knowledgeCutoff: Option[LocalDate] = Some(LocalDate.of(2023, 10, 1))
+}
+
+case object GPT_4_5_Preview extends ModelSeries {
+  override def vendor: Vendor = OpenAI
+
+  override def name: String = "gpt-4.5-preview"
+}
+
+case object GPT_4_5_Preview_2025_02_27 extends ModelVersion {
+  override def model: ModelSeries = GPT_4_5_Preview
+
+  override def name: String = "gpt-4.5-preview-2025-02-27"
+
+  override def inputs: Set[MediaType] = Set(Text, Image)
+
+  override def outputs: Set[MediaType] = Set(Text)
+
+  override def features: Some[Set[Feature]] = Some(Set(Streaming, StructuredOutputs, FunctionCalling))
+
+  override def endpoints: Some[Set[Endpoint]] = Some(Set(ChatCompletions, Batch, Responses, Assistants))
+
+  override def contextWindowSize: Option[Int] = Some(128_000)
+
+  override def maxOutputTokens: Option[Int] = Some(16_384)
+
+  override def knowledgeCutoff: Option[LocalDate] = Some(LocalDate.of(2023, 10, 1))
+}

--- a/src/main/scala/org/llm4s/metadata/vendors/OpenAI.scala
+++ b/src/main/scala/org/llm4s/metadata/vendors/OpenAI.scala
@@ -36,6 +36,10 @@ case object GPT_4o_2024_08_06 extends ModelVersion {
 
   override def outputs: Set[MediaType] = Set(Text)
 
+  override def features: Option[Set[Feature]] = None
+
+  override def endpoints: Option[Set[Endpoint]] = None
+
   override def contextWindowSize: Option[Int] = Some(128_000)
 
   override def maxOutputTokens: Option[Int] = Some(16_384)
@@ -53,6 +57,8 @@ case object GPT_4_5_Preview_2025_02_27 extends ModelVersion {
   override def model: ModelSeries = GPT_4_5_Preview
 
   override def name: String = "gpt-4.5-preview-2025-02-27"
+
+  override def vocabulary: Option[Vocabulary] = None
 
   override def inputs: Set[MediaType] = Set(Text, Image)
 

--- a/src/main/scala/org/llm4s/token/StringTokenizer.scala
+++ b/src/main/scala/org/llm4s/token/StringTokenizer.scala
@@ -1,0 +1,28 @@
+package org.llm4s.token
+
+import com.knuddels.jtokkit.Encodings
+import com.knuddels.jtokkit.api.EncodingType
+import org.llm4s.metadata.Vocabulary
+import org.llm4s.metadata.vendors.CL100K_BASE
+
+case class Token(tokenId: Int) {
+  override def toString: String = s"$tokenId"
+}
+
+trait StringTokenizer {
+  def encode(text: String): List[Token]
+}
+
+object Tokenizer {
+  private val registry = Encodings.newDefaultEncodingRegistry
+
+  def lookupStringTokenizer(vocabulary: Vocabulary): Option[StringTokenizer] =
+    if (vocabulary == CL100K_BASE) {
+      val encoder = registry.getEncoding(EncodingType.CL100K_BASE)
+      // noinspection ConvertExpressionToSAM
+      Some(new StringTokenizer {
+        override def encode(text: String): List[Token] =
+          encoder.encode(text).toArray.map(tokenId => Token(tokenId)).toList
+      })
+    } else None
+}


### PR DESCRIPTION
This PR intends to introduce some basic design to be evolved. 
Sure, some aspects are doubtful and to be clarified within next steps. 

Many (metadata) model properties are Option, with an assumption we not always know their exact values (this might be wrong assumption or the granularity might be wrong). 

In fact, we might now know a vocabulary/tokenizer for particular model (e.g. have not found any for GPT 4.5)

Also, the StringTokenizer API is set to be minimal so far, as adding mode detail will add lots more work -- and the basic use case to token number estimation is covered (but sure, `decode` method should likely be added).

So far `jtokkit` library is used for implementation, but it covers only OpenAI models so far.