### PR TITLE
partial fix for anthropic tool calling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file("."))
     name := "llm4s",
     libraryDependencies ++= List(
       "com.azure"      % "azure-ai-openai" % "1.0.0-beta.15",
-      "com.anthropic"  % "anthropic-java"  % "0.8.0",
+      "com.anthropic"  % "anthropic-java"  % "0.9.1",
       "ch.qos.logback" % "logback-classic" % "1.5.18",
       "com.lihaoyi"   %% "upickle"         % "4.1.0",
       "com.lihaoyi"   %% "requests"        % "0.9.0",

--- a/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -14,8 +14,9 @@ object LLMConnect {
    * Get an LLMClient based on environment variables
    */
   def getClient(): LLMClient = {
-    val model = readEnv("LLM_MODEL").getOrElse(
-      throw new IllegalArgumentException("LLM_MODEL not set, set this to define default model")
+    val LLM_MODEL_ENV_KEY = "LLM_MODEL"
+    val model = readEnv(LLM_MODEL_ENV_KEY).getOrElse(
+      throw new IllegalArgumentException(s"Please set the `$LLM_MODEL_ENV_KEY` environment variable to specify the default model")
     )
 
     if (model.startsWith("openai/")) {


### PR DESCRIPTION
(required/optional params are not separated)

The problem reason: original code encoded entire `input schema` not as JSON object, 
but as JSON string literal. Thus the server complaining about input format. 