### PR TITLE
Upgrade to Scala 3 and refactor for improved type safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.bsp/
 target/
 .aider*
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,26 @@
 
 ## Build & Test Commands
 ```bash
-# Build the project
+# Build the project (Scala 3)
 sbt compile
 
-# Run a specific sample
+# Build for all Scala versions (2.13 and 3)
+sbt +compile
+
+# Build and test all versions
+sbt buildAll
+
+# Run a specific sample 
 sbt "samples/runMain org.llm4s.samples.basic.BasicLLMCallingExample"
 
-# Run tests
+# Run a sample with Scala 2.13
+sbt ++2.13.12 "samples/runMain org.llm4s.samples.basic.BasicLLMCallingExample"
+
+# Run tests for the current Scala version
 sbt test
+
+# Run tests for all Scala versions
+sbt +test
 
 # Run a single test
 sbt "testOnly org.llm4s.shared.WorkspaceAgentInterfaceTest"
@@ -17,6 +29,14 @@ sbt "testOnly org.llm4s.shared.WorkspaceAgentInterfaceTest"
 # Format code
 sbt scalafmtAll
 ```
+
+## Cross Compilation Guidelines
+- The project supports both Scala 2.13 and Scala 3
+- Common code goes in `src/main/scala`
+- Scala 2.13-specific code goes in `src/main/scala-2.13`
+- Scala 3-specific code goes in `src/main/scala-3`
+- Always test with both versions: `sbt +test`
+- Use the cross-building commands: `buildAll`, `testAll`, `compileAll`
 
 ## Code Style Guidelines
 - **Formatting**: Follow `.scalafmt.conf` settings (120 char line length)

--- a/README.md
+++ b/README.md
@@ -56,10 +56,36 @@ To get started with the LLM4S project, check out this teaser talk presented by *
 sbt compile
 ```
 
+### Setup your LLM Environment
+
+You will need an API key for either OpenAI (https://platform.openai.com/) or Anthropic (https://console.anthropic.com/)
+other LLMS may be supported in the future (see the backlog.
+
+Set the environment variables:
+
+```
+LLM_MODEL=openai/gpt-4o
+OPENAI_API_KEY=<your_openai_api_key>
+```
+or Anthropic:
+```
+LLM_MODEL=anthropic/claude-3-7-sonnet-latest
+ANTHROPIC_API_KEY=<your_anthropic_api_key>
+```
+
+Thia will allow you to run the non-containerized examples.
+
+
 ### Running the Examples
 
 ```bash
 sbt "samples/runMain org.llm4s.samples.basic.BasicLLMCallingExample"
+```
+
+### Run containerised test
+
+```bash
+sbt docker:publishLocal
 sbt "samples/runMain org.llm4s.samples.workspace.ContainerisedWorkspaceDemo"
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,25 @@ Mapping LLM tool call requests to actual method invocations through:
 
 Tools run in a protected Docker container environment to prevent accidental system damage or data leakage.
 
+
+## 📢 Talks & Presentations
+
+See the talks being given by maintainers globally and witness the engagement by developers around the world.
+
+Stay updated with talks, workshops, and presentations about **LLM4S** happening globally. These sessions dive into the architecture, features, and future plans of the project.
+
+### Upcoming & Past Talks
+
+| Date           | Event/Conference   | Talk Title                            | Location                        | Speaker Name        | Details URL                                                                                             | Recording Link URL                                                                 |
+|----------------|--------------------|----------------------------------------|---------------------------------|---------------------|---------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| **25-Feb-2025** | Bay Area Scala     | Let's Teach LLMs to Write Great Scala! | Tubi office, San Francisco, CA  | Kannupriya Kalra     | [Event Info](https://lu.ma/5fz2y9or)                                                                       | [Watch Recording](https://www.youtube.com/watch?v=SXybj2P3_DE&t=779s&ab_channel=SalarRahmanian) |
+| **20-Apr-2025** | Scala India        | Let's Teach LLMs to Write Great Scala! | India                           | Kannupriya Kalra     | [Event Info](https://www.linkedin.com/posts/activity-7318299169914249216-Sec-?utm_source=share&utm_medium=member_desktop&rcm=ACoAAA8qk7UBmvcZ2O7aAJfMpsdEXBvcKSNiHWM) | [Watch Recording](https://www.youtube.com/watch?v=PiUaVKuV0dM&ab_channel=ScalaIndia)  |
+
+> 📝 *Want to invite us for a talk or workshop? Reach out via our respective emails or connect on Discord: [https://discord.gg/4uvTPn6qww](https://discord.gg/4uvTPn6qww)*
+
+
+
+
 ## Contributing
 
 Interested in contributing? Start here:
@@ -159,8 +178,8 @@ To know everything about GSoC and how it works, check out this talk:
 
 Want to connect with maintainers? The LLM4S project is maintained by:
 
-- **Rory Graves** - [https://www.linkedin.com/in/roryjgraves/](https://www.linkedin.com/in/roryjgraves/) | Email: [rory.graves@fieldmark.co.uk](mailto:rory.graves@fieldmark.co.uk)  
-- **Kannupriya Kalra** - [https://www.linkedin.com/in/kannupriyakalra/](https://www.linkedin.com/in/kannupriyakalra/) | Email: [kannupriyakalra@gmail.com](mailto:kannupriyakalra@gmail.com)
+- **Rory Graves** - [https://www.linkedin.com/in/roryjgraves/](https://www.linkedin.com/in/roryjgraves/) | Email: [rory.graves@fieldmark.co.uk](mailto:rory.graves@fieldmark.co.uk) | Discord: `rorybot1`  
+- **Kannupriya Kalra** - [https://www.linkedin.com/in/kannupriyakalra/](https://www.linkedin.com/in/kannupriyakalra/) | Email: [kannupriyakalra@gmail.com](mailto:kannupriyakalra@gmail.com) | Discord: `kannupriyakalra_46520`
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Tools run in a protected Docker container environment to prevent accidental syst
 
 ## 📢 Talks & Presentations
 
-See the talks being given by maintainers globally and witness the engagement by developers around the world.
+See the talks being given by maintainers and open source developers globally and witness the engagement by developers around the world.
 
 Stay updated with talks, workshops, and presentations about **LLM4S** happening globally. These sessions dive into the architecture, features, and future plans of the project.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,14 @@ To get started with the LLM4S project, check out this teaser talk presented by *
 ### Building the Project
 
 ```bash
+# For the default Scala version (3.3.3)
 sbt compile
+
+# For all supported Scala versions (2.13 and 3.3)
+sbt +compile
+
+# Build and test all versions
+sbt buildAll
 ```
 
 ### Setup your LLM Environment
@@ -79,6 +86,7 @@ Thia will allow you to run the non-containerized examples.
 ### Running the Examples
 
 ```bash
+# Using Scala 3.3.3
 sbt "samples/runMain org.llm4s.samples.basic.BasicLLMCallingExample"
 ```
 
@@ -87,6 +95,35 @@ sbt "samples/runMain org.llm4s.samples.basic.BasicLLMCallingExample"
 ```bash
 sbt docker:publishLocal
 sbt "samples/runMain org.llm4s.samples.workspace.ContainerisedWorkspaceDemo"
+
+# Using Scala 2.13
+sbt ++2.13.12 "samples/runMain org.llm4s.samples.basic.BasicLLMCallingExample"
+```
+
+### Cross Compilation
+
+LLM4S supports both Scala 2.13 and Scala 3.3. The codebase is set up to handle version-specific code through source directories:
+
+- `src/main/scala` - Common code for both Scala 2.13 and 3.3
+- `src/main/scala-2.13` - Scala 2.13 specific code
+- `src/main/scala-3` - Scala 3 specific code
+
+When you need to use version-specific features, place the code in the appropriate directory.
+
+We've added convenient aliases for cross-compilation:
+
+```bash
+# Compile for all Scala versions
+sbt compileAll
+
+# Test all Scala versions
+sbt testAll
+
+# Both compile and test
+sbt buildAll
+
+# Publish for all versions
+sbt publishAll
 ```
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ sbt docker:publishLocal
 sbt "samples/runMain org.llm4s.samples.workspace.ContainerisedWorkspaceDemo"
 
 # Using Scala 2.13
-sbt ++2.13.12 "samples/runMain org.llm4s.samples.basic.BasicLLMCallingExample"
+sbt ++2.13.14 "samples/runMain org.llm4s.samples.basic.BasicLLMCallingExample"
 ```
 
 ### Cross Compilation
@@ -125,7 +125,20 @@ sbt buildAll
 # Publish for all versions
 sbt publishAll
 ```
+### Cross-Compilation Testing
 
+We use specialized test projects to verify cross-version compatibility against the published artifacts. These tests ensure that the library works correctly across different Scala versions by testing against actual published JARs rather than local target directories.
+
+```bash
+# Run tests for both Scala 2 and 3 against published JARs
+sbt testCross
+
+# Full clean, publish, and test verification
+sbt fullCrossTest
+```
+
+> **Note:** For detailed information about our cross-testing strategy and setup, see [crosstest/README.md](crosstest/README.md)
+>
 ## Roadmap
 
 Our goal is to implement Scala equivalents of popular Python LLM frameworks:

--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,27 @@
 import xerial.sbt.Sonatype.sonatypeCentralHost
 
+// Define supported Scala versions
+val scala213 = "2.13.12"
+val scala3 = "3.3.3"
+
 inThisBuild(
   List(
-    scalaVersion           := "3.3.3",
-    version                := "0.1.0-SNAPSHOT",
-    organization           := "org.llm4s",
-    organizationName       := "llm4s",
-    versionScheme          := Some("early-semver"),
+    crossScalaVersions    := List(scala213, scala3),
+    scalaVersion          := scala3,
+    version               := "0.1.0-SNAPSHOT",
+    organization          := "org.llm4s",
+    organizationName      := "llm4s",
+    versionScheme         := Some("early-semver"),
     sonatypeCredentialHost := sonatypeCentralHost,
     // Scalafmt configuration
 //    scalafmtOnCompile := true,
     // Maven central repository deployment
-    homepage               := Some(url("https://github.com/llm4s/")),
+    homepage              := Some(url("https://github.com/llm4s/")),
     sonatypeCredentialHost := "s01.oss.sonatype.org",
-    sonatypeRepository     := "https://s01.oss.sonatype.org/service/local",
-    pgpPublicRing          := file("/tmp/public.asc"),
-    pgpSecretRing          := file("/tmp/secret.asc"),
-    pgpPassphrase          := sys.env.get("PGP_PASSPHRASE").map(_.toArray),
+    sonatypeRepository    := "https://s01.oss.sonatype.org/service/local",
+    pgpPublicRing         := file("/tmp/public.asc"),
+    pgpSecretRing         := file("/tmp/secret.asc"),
+    pgpPassphrase         := sys.env.get("PGP_PASSPHRASE").map(_.toArray),
     scmInfo := Some(
       ScmInfo(
         url("https://github.com/llm4s/llm4s/"),
@@ -28,13 +33,46 @@ inThisBuild(
 
 sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
-// Common Scala 3 settings for all projects
-lazy val scala3Settings = List(
-  scalacOptions ++= List(
-    "-explain",          // Explain errors in more detail
-    "-Xfatal-warnings",  // Fail on warnings
-    "-source:3.3",       // Ensure Scala 3 syntax
-  )
+// Scala options based on Scala version
+def scalacOptionsForVersion(scalaVersion: String): Seq[String] = 
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, 13)) => Seq(
+      // "-Xfatal-warnings",   // Temporarily disabled for cross-compilation
+      "-deprecation",       // Emit warning and location for usages of deprecated APIs
+      "-feature",           // Emit warning for feature usage
+      "-unchecked"          // Enable warnings where generated code depends on assumptions
+      // "-Wunused:imports"    // Temporarily disabled for cross-compilation
+    )
+    case Some((3, _)) => Seq(
+      "-explain",           // Explain errors in more detail
+      "-Xfatal-warnings",   // Fail on warnings
+      "-source:3.3"         // Ensure Scala 3 syntax
+    )
+    case _ => Seq.empty
+  }
+
+// Common settings that apply to both Scala versions
+lazy val commonSettings = Seq(
+  Compile / scalacOptions := scalacOptionsForVersion(scalaVersion.value),
+  
+  // Source directories for cross-compilation
+  Compile / unmanagedSourceDirectories ++= {
+    val sourceDir = (Compile / sourceDirectory).value
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 13)) => Seq(sourceDir / "scala-2.13")
+      case Some((3, _))  => Seq(sourceDir / "scala-3")
+      case _             => Nil
+    }
+  },
+  
+  Test / unmanagedSourceDirectories ++= {
+    val sourceDir = (Test / sourceDirectory).value
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 13)) => Seq(sourceDir / "scala-2.13")
+      case Some((3, _))  => Seq(sourceDir / "scala-3")
+      case _             => Nil
+    }
+  }
 )
 
 lazy val root = (project in file("."))
@@ -42,7 +80,7 @@ lazy val root = (project in file("."))
   .dependsOn(shared)
   .settings(
     name := "llm4s",
-    scala3Settings,
+    commonSettings,
     libraryDependencies ++= List(
       "com.azure"      % "azure-ai-openai" % "1.0.0-beta.16",
       "com.anthropic"  % "anthropic-java"  % "1.1.0",
@@ -57,7 +95,7 @@ lazy val root = (project in file("."))
 lazy val shared = (project in file("shared"))
   .settings(
     name := "shared",
-    scala3Settings,
+    commonSettings,
     libraryDependencies ++= List(
       "com.lihaoyi"   %% "upickle"         % "4.1.0",
       "ch.qos.logback" % "logback-classic" % "1.5.18",
@@ -75,7 +113,7 @@ lazy val workspaceRunner = (project in file("workspaceRunner"))
     dockerBaseImage     := "eclipse-temurin:21-jdk",
 //    Compile / mainClass := Some("com.llm4s.runner.RunnerMain"),
     name := "workspace-runner",
-    scala3Settings,
+    commonSettings,
     libraryDependencies ++= List(
       "ch.qos.logback" % "logback-classic" % "1.5.18",
       "com.lihaoyi"   %% "upickle"         % "4.1.0",
@@ -91,7 +129,7 @@ lazy val samples = (project in file("samples"))
   .dependsOn(shared, root)
   .settings(
     name := "samples",
-    scala3Settings,
+    commonSettings,
     libraryDependencies ++= List(
       "ch.qos.logback" % "logback-classic" % "1.5.18",
       "org.scalatest" %% "scalatest"       % "3.2.19" % Test
@@ -100,3 +138,14 @@ lazy val samples = (project in file("samples"))
   .settings(
     publish / skip := true
   )
+
+// Convenience commands for cross-building
+addCommandAlias("buildAll", ";clean;+compile;+test")
+addCommandAlias("publishAll", ";clean;+publish")
+addCommandAlias("testAll", ";+test")
+addCommandAlias("compileAll", ";+compile")
+
+// MiMa binary compatibility settings
+mimaPreviousArtifacts := Set(
+  organization.value %% "llm4s" % "0.1.0-SNAPSHOT"
+)

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import xerial.sbt.Sonatype.sonatypeCentralHost
 
 // Define supported Scala versions
-val scala213 = "2.13.12"
+val scala213 = "2.13.14"
 val scala3 = "3.3.3"
 
 inThisBuild(
@@ -34,7 +34,7 @@ inThisBuild(
 sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
 // Scala options based on Scala version
-def scalacOptionsForVersion(scalaVersion: String): Seq[String] = 
+def scalacOptionsForVersion(scalaVersion: String): Seq[String] =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, 13)) => Seq(
       // "-Xfatal-warnings",   // Temporarily disabled for cross-compilation
@@ -54,7 +54,7 @@ def scalacOptionsForVersion(scalaVersion: String): Seq[String] =
 // Common settings that apply to both Scala versions
 lazy val commonSettings = Seq(
   Compile / scalacOptions := scalacOptionsForVersion(scalaVersion.value),
-  
+
   // Source directories for cross-compilation
   Compile / unmanagedSourceDirectories ++= {
     val sourceDir = (Compile / sourceDirectory).value
@@ -64,7 +64,7 @@ lazy val commonSettings = Seq(
       case _             => Nil
     }
   },
-  
+
   Test / unmanagedSourceDirectories ++= {
     val sourceDir = (Test / sourceDirectory).value
     CrossVersion.partialVersion(scalaVersion.value) match {
@@ -139,13 +139,49 @@ lazy val samples = (project in file("samples"))
     publish / skip := true
   )
 
-// Convenience commands for cross-building
+val crossLibDependencies = Seq(
+  "org.llm4s" %% "llm4s" % "0.1.0-SNAPSHOT",
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test
+)
+
+lazy val crossTestScala2 = (project in file("crosstest/scala2"))
+  .settings(
+    name := "crosstest-scala2",
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala213),
+    resolvers += Resolver.mavenLocal,
+    resolvers += Resolver.defaultLocal,
+    libraryDependencies ++= crossLibDependencies
+  )
+
+
+lazy val crossTestScala3 = (project in file("crosstest/scala3"))
+  .settings(
+    name := "crosstest-scala3",
+    scalaVersion := scala3,
+    crossScalaVersions := Seq(scala3),
+    resolvers += Resolver.mavenLocal,
+    resolvers += Resolver.defaultLocal,
+    scalacOptions ++= Seq(
+      "-language:strictEquality",
+      "-Ysafe-init",
+      "-deprecation",
+      "-Wunused:imports",
+      "-Xfatal-warnings"
+    ),
+    libraryDependencies ++= crossLibDependencies
+  )
+
+// Commands remain the same
 addCommandAlias("buildAll", ";clean;+compile;+test")
 addCommandAlias("publishAll", ";clean;+publish")
 addCommandAlias("testAll", ";+test")
 addCommandAlias("compileAll", ";+compile")
+addCommandAlias("testCross", ";crossTestScala2/test;crossTestScala3/test")
+// Add this to your build.sbt
+addCommandAlias("fullCrossTest", ";clean ;crossTestScala2/clean ;crossTestScala3/clean ;+publishLocal ;testCross")
 
-// MiMa binary compatibility settings
+// MiMa settings remain the same
 mimaPreviousArtifacts := Set(
   organization.value %% "llm4s" % "0.1.0-SNAPSHOT"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import xerial.sbt.Sonatype.sonatypeCentralHost
 
 inThisBuild(
   List(
-    scalaVersion           := "2.13.16",
+    scalaVersion           := "3.3.3",
     version                := "0.1.0-SNAPSHOT",
     organization           := "org.llm4s",
     organizationName       := "llm4s",
@@ -28,11 +28,21 @@ inThisBuild(
 
 sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
+// Common Scala 3 settings for all projects
+lazy val scala3Settings = List(
+  scalacOptions ++= List(
+    "-explain",          // Explain errors in more detail
+    "-Xfatal-warnings",  // Fail on warnings
+    "-source:3.3",       // Ensure Scala 3 syntax
+  )
+)
+
 lazy val root = (project in file("."))
   .aggregate(shared, workspaceRunner)
   .dependsOn(shared)
   .settings(
     name := "llm4s",
+    scala3Settings,
     libraryDependencies ++= List(
       "com.azure"      % "azure-ai-openai" % "1.0.0-beta.16",
       "com.anthropic"  % "anthropic-java"  % "1.1.0",
@@ -47,6 +57,7 @@ lazy val root = (project in file("."))
 lazy val shared = (project in file("shared"))
   .settings(
     name := "shared",
+    scala3Settings,
     libraryDependencies ++= List(
       "com.lihaoyi"   %% "upickle"         % "4.1.0",
       "ch.qos.logback" % "logback-classic" % "1.5.18",
@@ -64,6 +75,7 @@ lazy val workspaceRunner = (project in file("workspaceRunner"))
     dockerBaseImage     := "eclipse-temurin:21-jdk",
 //    Compile / mainClass := Some("com.llm4s.runner.RunnerMain"),
     name := "workspace-runner",
+    scala3Settings,
     libraryDependencies ++= List(
       "ch.qos.logback" % "logback-classic" % "1.5.18",
       "com.lihaoyi"   %% "upickle"         % "4.1.0",
@@ -79,6 +91,7 @@ lazy val samples = (project in file("samples"))
   .dependsOn(shared, root)
   .settings(
     name := "samples",
+    scala3Settings,
     libraryDependencies ++= List(
       "ch.qos.logback" % "logback-classic" % "1.5.18",
       "org.scalatest" %% "scalatest"       % "3.2.19" % Test

--- a/crossTest/README.md
+++ b/crossTest/README.md
@@ -1,0 +1,79 @@
+# Cross-Version Testing Strategy
+
+## Overview
+
+This directory contains specialized test projects that verify the cross-version compatibility of LLM4S. Unlike conventional tests, these projects test against published artifacts rather than local target directories, providing a more realistic validation of how end users will experience the library.
+
+## Test Projects Structure
+
+- `crossTestScala2/` - Tests running against Scala 2.13
+- `crossTestScala3/` - Tests running against Scala 3.x
+
+## Why Test Against Published JARs?
+
+Testing against published JARs rather than target directories offers several advantages:
+1. Catches packaging issues early
+2. Validates the actual artifacts users will depend on
+3. Ensures proper dependency resolution
+4. Verifies binary compatibility
+5. Replicates real-world usage scenarios
+
+## Available Commands
+
+### Basic Cross-Testing
+```scala
+addCommandAlias("testCross", ";crossTestScala2/test;crossTestScala3/test")
+```
+This command:
+- Runs tests for both Scala 2 and Scala 3 projects
+- Tests against published artifacts
+- Executes sequentially to ensure clean test states
+
+### Full Verification
+```scala
+addCommandAlias("fullCrossTest", ";clean ;crossTestScala2/clean ;crossTestScala3/clean ;+publishLocal ;testCross")
+```
+This command performs a complete verification cycle:
+1. Cleans all projects
+2. Cleans individual cross-test projects
+3. Publishes all versions locally
+4. Runs all cross-version tests
+
+## Test Implementation Guidelines
+
+When writing cross-version tests:
+1. Always depend on the published artifacts:
+   ```scala
+   libraryDependencies += "org.llm4s" %% "0.1.0-SNAPSHOT" % version
+   ```
+2. Test both API compatibility and functionality
+3. Include version-specific features where applicable
+4. Verify binary compatibility
+5. Test integration scenarios
+
+## Common Issues and Solutions
+
+1. **Stale Artifacts**: Always run `fullCrossTest` when making significant changes
+2. **Version Mismatches**: Ensure proper version management in build.sbt
+3. **Binary Compatibility**: Watch for breaking changes between Scala versions
+
+## CI/CD Integration
+
+These tests are crucial in our CI pipeline:
+1. Run on every PR
+2. Required for release approval
+3. Verify against multiple Scala versions
+
+## Adding New Cross-Tests
+
+When adding new cross-version tests:
+1. Create test cases in both Scala versions
+2. Verify against published artifacts
+3. Include both positive and negative test cases
+4. Document version-specific behaviors
+
+## Future Improvements
+
+- [ ] Add automated binary compatibility checking
+- [ ] Expand test coverage across more Scala versions
+- [ ] Add performance benchmarks across versions

--- a/crossTest/scala2/src/test/scala/org/llm4s/sc2/SafeParameterExtractorTest.scala
+++ b/crossTest/scala2/src/test/scala/org/llm4s/sc2/SafeParameterExtractorTest.scala
@@ -1,0 +1,146 @@
+package org.llm4s.sc2
+
+
+import org.llm4s.toolapi.SafeParameterExtractor
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SafeParameterExtractorTest extends AnyFlatSpec with Matchers {
+
+  // Test fixtures
+  val simpleJson = ujson.Obj(
+    "stringValue" -> "test",
+    "intValue" -> 42,
+    "doubleValue" -> 42.5,
+    "boolValue" -> true,
+    "arrayValue" -> ujson.Arr(1, 2, 3),
+    "objectValue" -> ujson.Obj("key" -> "value")
+  )
+
+  val nestedJson = ujson.Obj(
+    "level1" -> ujson.Obj(
+      "string" -> "nested",
+      "number" -> 100,
+      "level2" -> ujson.Obj(
+        "array" -> ujson.Arr("a", "b", "c"),
+        "boolean" -> false
+      )
+    )
+  )
+
+  val mixedTypesArray = ujson.Obj(
+    "mixed" -> ujson.Arr(
+      "string",
+      42,
+      true,
+      ujson.Obj("key" -> "value"),
+      ujson.Arr(1, 2, 3)
+    )
+  )
+
+  "SafeParameterExtractor" should "extract string values correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+
+    // Success cases
+    extractor.getString("stringValue") shouldBe Right("test")
+
+    // Failure cases
+    extractor.getString("nonexistent") shouldBe Left("Path 'nonexistent' not found: missing 'nonexistent' segment")
+    extractor.getString("intValue") shouldBe Left("Value at 'intValue' is not of expected type 'string'")
+  }
+
+  it should "extract integer values correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+
+    // Success cases
+    extractor.getInt("intValue") shouldBe Right(42)
+
+    // Failure cases
+    extractor.getInt("stringValue") shouldBe Left("Value at 'stringValue' is not of expected type 'integer'")
+    extractor.getInt("doubleValue") shouldBe Right(42) // Should work for whole numbers
+  }
+
+  it should "extract double values correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+
+    // Success cases
+    extractor.getDouble("doubleValue") shouldBe Right(42.5)
+    extractor.getDouble("intValue") shouldBe Right(42.0)
+
+    // Failure cases
+    extractor.getDouble("stringValue") shouldBe Left("Value at 'stringValue' is not of expected type 'number'")
+  }
+
+  it should "extract boolean values correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+
+    // Success cases
+    extractor.getBoolean("boolValue") shouldBe Right(true)
+
+    // Failure cases
+    extractor.getBoolean("stringValue") shouldBe Left("Value at 'stringValue' is not of expected type 'boolean'")
+  }
+
+  it should "extract array values correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+
+    // Success cases
+    val expectedArr = ujson.Arr(1, 2, 3)
+    extractor.getArray("arrayValue") shouldBe Right(expectedArr)
+
+    // Failure cases
+    extractor.getArray("stringValue") shouldBe Left("Value at 'stringValue' is not of expected type 'array'")
+  }
+
+  it should "extract object values correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+
+    // Success cases
+    val expectedObj = ujson.Obj("key" -> "value")
+    extractor.getObject("objectValue") shouldBe Right(expectedObj)
+
+    // Failure cases
+    extractor.getObject("stringValue") shouldBe Left("Value at 'stringValue' is not of expected type 'object'")
+  }
+
+  it should "handle nested paths correctly" in {
+    val extractor = SafeParameterExtractor(nestedJson)
+
+    // Success cases
+    extractor.getString("level1.string") shouldBe Right("nested")
+    extractor.getInt("level1.number") shouldBe Right(100)
+    val expectedNestedArr = ujson.Arr("a", "b", "c")
+    extractor.getArray("level1.level2.array") shouldBe Right(expectedNestedArr)
+    extractor.getBoolean("level1.level2.boolean") shouldBe Right(false)
+
+    // Failure cases
+    extractor.getString("level1.nonexistent") shouldBe Left("Path 'level1.nonexistent' not found: missing 'nonexistent' segment")
+    extractor.getString("level1.string.invalid") shouldBe Left("Path 'level1.string.invalid': Expected object at 'level1.string' but found Str")
+  }
+
+  it should "handle empty paths correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+    extractor.getString("") shouldBe Left("Path '' not found: missing '' segment")
+  }
+
+  it should "handle null values correctly" in {
+    val jsonWithNull = ujson.Obj(
+      "nullValue" -> ujson.Null
+    )
+    val extractor = SafeParameterExtractor(jsonWithNull)
+    extractor.getString("nullValue") shouldBe Left("Value at 'nullValue' is not of expected type 'string'")
+  }
+
+  it should "handle special characters in paths" in {
+    val jsonWithSpecialChars = ujson.Obj(
+      "special.key" -> "value",
+      "normal" -> ujson.Obj(
+        "special.nested" -> "nested value"
+      )
+    )
+    val extractor = SafeParameterExtractor(jsonWithSpecialChars)
+
+    extractor.getString("special.key") shouldBe Left("Path 'special.key' not found: missing 'special' segment")
+    extractor.getString("normal.special.nested") shouldBe Left("Path 'normal.special.nested' not found: missing 'special' segment")
+  }
+}

--- a/crossTest/scala2/src/test/scala/org/llm4s/sc2/VersionTest.scala
+++ b/crossTest/scala2/src/test/scala/org/llm4s/sc2/VersionTest.scala
@@ -1,0 +1,15 @@
+package org.llm4s.sc2
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class VersionTest extends AnyFlatSpec with Matchers {
+  "Scala 2" should "not support enum syntax" in {
+    assertDoesNotCompile( """
+      enum Color {
+        case Red, Green, Blue
+      }
+    """)
+  }
+}
+

--- a/crossTest/scala3/src/test/scala/org/llm4s/sc3/SafeParameterExtractorTest.scala
+++ b/crossTest/scala3/src/test/scala/org/llm4s/sc3/SafeParameterExtractorTest.scala
@@ -1,0 +1,155 @@
+package org.llm4s.sc3
+
+
+import org.llm4s.toolapi.SafeParameterExtractor
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ujson.*
+
+import scala.language.strictEquality // Enable strict equality checking
+
+class SafeParameterExtractorTest extends AnyFlatSpec with Matchers {
+
+  // Add implicit CanEqual instances for ujson types
+  given CanEqual[ujson.Arr, ujson.Arr] = CanEqual.derived
+  given CanEqual[ujson.Obj, ujson.Obj] = CanEqual.derived
+  given [T, U](using CanEqual[T, U]): CanEqual[Either[String, T], Either[String, U]] = CanEqual.derived
+  given [T, U](using CanEqual[T, U]): CanEqual[Right[String, T], Right[String, U]] = CanEqual.derived
+
+  // Test fixtures
+  val simpleJson = ujson.Obj(
+    "stringValue" -> "test",
+    "intValue" -> 42,
+    "doubleValue" -> 42.5,
+    "boolValue" -> true,
+    "arrayValue" -> ujson.Arr(1, 2, 3),
+    "objectValue" -> ujson.Obj("key" -> "value")
+  )
+
+  val nestedJson = ujson.Obj(
+    "level1" -> ujson.Obj(
+      "string" -> "nested",
+      "number" -> 100,
+      "level2" -> ujson.Obj(
+        "array" -> ujson.Arr("a", "b", "c"),
+        "boolean" -> false
+      )
+    )
+  )
+
+  val mixedTypesArray = ujson.Obj(
+    "mixed" -> ujson.Arr(
+      "string",
+      42,
+      true,
+      ujson.Obj("key" -> "value"),
+      ujson.Arr(1, 2, 3)
+    )
+  )
+
+  "SafeParameterExtractor" should "extract string values correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+
+    // Success cases
+    extractor.getString("stringValue") shouldBe Right("test")
+
+    // Failure cases
+    extractor.getString("nonexistent") shouldBe Left("Path 'nonexistent' not found: missing 'nonexistent' segment")
+    extractor.getString("intValue") shouldBe Left("Value at 'intValue' is not of expected type 'string'")
+  }
+
+  it should "extract integer values correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+
+    // Success cases
+    extractor.getInt("intValue") shouldBe Right(42)
+
+    // Failure cases
+    extractor.getInt("stringValue") shouldBe Left("Value at 'stringValue' is not of expected type 'integer'")
+    extractor.getInt("doubleValue") shouldBe Right(42) // Should work for whole numbers
+  }
+
+  it should "extract double values correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+
+    // Success cases
+    extractor.getDouble("doubleValue") shouldBe Right(42.5)
+    extractor.getDouble("intValue") shouldBe Right(42.0)
+
+    // Failure cases
+    extractor.getDouble("stringValue") shouldBe Left("Value at 'stringValue' is not of expected type 'number'")
+  }
+
+  it should "extract boolean values correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+
+    // Success cases
+    extractor.getBoolean("boolValue") shouldBe Right(true)
+
+    // Failure cases
+    extractor.getBoolean("stringValue") shouldBe Left("Value at 'stringValue' is not of expected type 'boolean'")
+  }
+
+  it should "extract array values correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+
+    // Success cases
+    val expectedArr = ujson.Arr(1, 2, 3)
+    extractor.getArray("arrayValue") shouldBe Right(expectedArr)
+
+    // Failure cases
+    extractor.getArray("stringValue") shouldBe Left("Value at 'stringValue' is not of expected type 'array'")
+  }
+
+  it should "extract object values correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+
+    // Success cases
+    val expectedObj = ujson.Obj("key" -> "value")
+    extractor.getObject("objectValue") shouldBe Right(expectedObj)
+
+    // Failure cases
+    extractor.getObject("stringValue") shouldBe Left("Value at 'stringValue' is not of expected type 'object'")
+  }
+
+  it should "handle nested paths correctly" in {
+    val extractor = SafeParameterExtractor(nestedJson)
+
+    // Success cases
+    extractor.getString("level1.string") shouldBe Right("nested")
+    extractor.getInt("level1.number") shouldBe Right(100)
+    val expectedNestedArr = ujson.Arr("a", "b", "c")
+    extractor.getArray("level1.level2.array") shouldBe Right(expectedNestedArr)
+    extractor.getBoolean("level1.level2.boolean") shouldBe Right(false)
+
+    // Failure cases
+    extractor.getString("level1.nonexistent") shouldBe Left("Path 'level1.nonexistent' not found: missing 'nonexistent' segment")
+    extractor.getString("level1.string.invalid") shouldBe Left("Path 'level1.string.invalid': Expected object at 'level1.string' but found Str")
+  }
+
+  it should "handle empty paths correctly" in {
+    val extractor = SafeParameterExtractor(simpleJson)
+    extractor.getString("") shouldBe Left("Path '' not found: missing '' segment")
+  }
+
+  it should "handle null values correctly" in {
+    val jsonWithNull = ujson.Obj(
+      "nullValue" -> ujson.Null
+    )
+    val extractor = SafeParameterExtractor(jsonWithNull)
+    extractor.getString("nullValue") shouldBe Left("Value at 'nullValue' is not of expected type 'string'")
+  }
+
+  it should "handle special characters in paths" in {
+    val jsonWithSpecialChars = ujson.Obj(
+      "special.key" -> "value",
+      "normal" -> ujson.Obj(
+        "special.nested" -> "nested value"
+      )
+    )
+    val extractor = SafeParameterExtractor(jsonWithSpecialChars)
+
+    extractor.getString("special.key") shouldBe Left("Path 'special.key' not found: missing 'special' segment")
+    extractor.getString("normal.special.nested") shouldBe Left("Path 'normal.special.nested' not found: missing 'special' segment")
+  }
+}

--- a/crossTest/scala3/src/test/scala/org/llm4s/sc3/VersionTest.scala
+++ b/crossTest/scala3/src/test/scala/org/llm4s/sc3/VersionTest.scala
@@ -1,0 +1,14 @@
+package org.llm4s.sc3
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class VersionTest extends AnyFlatSpec with Matchers {
+  "Scala 3" should "support enum syntax" in {
+    assertCompiles("""
+      enum Color {
+        case Red, Green, Blue
+      }
+    """)
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,8 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
-//addSbtPlugin("org.scalameta"  % "sbt-scalafmt"        % "2.5.4")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"        % "2.5.4")
 // Maven deployment
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"   % "3.12.2")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")
 addSbtPlugin("com.github.sbt" % "sbt-dynver"     % "5.1.0")
+// Cross-compilation support
+addSbtPlugin("com.typesafe"   % "sbt-mima-plugin" % "1.1.3")

--- a/samples/src/main/scala/org/llm4s/samples/compat/CrossCompilationExample.scala
+++ b/samples/src/main/scala/org/llm4s/samples/compat/CrossCompilationExample.scala
@@ -1,0 +1,39 @@
+package org.llm4s.samples.compat
+
+import org.llm4s.compat.ScalaCompat
+
+/**
+ * A simple example demonstrating cross-compilation support
+ */
+object CrossCompilationExample {
+  def main(args: Array[String]): Unit = {
+    // Print the Scala version
+    println(s"Running on Scala ${util.Properties.versionNumberString}")
+    
+    // Use the compatibility layer
+    println(s"Is Scala 2.13: ${ScalaCompat.isScala213}")
+    println(s"Is Scala 3: ${ScalaCompat.isScala3}")
+    
+    // Use the version-dependent helper
+    val versionText = ScalaCompat.onScala213(
+      ifScala213 = "This is Scala 2.13 specific code",
+      ifScala3 = "This is Scala 3 specific code"
+    )
+    
+    println(versionText)
+    
+    // Demonstrate cross-compiled code selection
+    if (ScalaCompat.isScala213) {
+      println("This branch only executes in Scala 2.13")
+      // In a real application, here you would access Scala 2.13 specific APIs
+    } else {
+      println("This branch only executes in Scala 3")
+      // In a real application, here you would access Scala 3 specific APIs
+      // For example, use Scala 3 union types, enums, extension methods, etc.
+    }
+    
+    // The code can also pull in the right implementation automatically thanks to
+    // the versioned source directories
+    println(s"Running version-specific code optimized for ${util.Properties.versionNumberString}")
+  }
+}

--- a/shared/src/test/scala/org/llm4s/shared/WorkspaceAgentInterfaceTest.scala
+++ b/shared/src/test/scala/org/llm4s/shared/WorkspaceAgentInterfaceTest.scala
@@ -84,9 +84,6 @@ class WorkspaceAgentInterfaceTest extends AnyFlatSpec with Matchers {
           totalMatches = 1
         )
 
-      case _ =>
-        WorkspaceAgentErrorResponse("unknown", "Unhandled command", "UNKNOWN_COMMAND")
-
     }
 
     val interface: WorkspaceAgentInterface = new WorkspaceAgentInterfaceRemote(handler)
@@ -138,6 +135,8 @@ class WorkspaceAgentInterfaceTest extends AnyFlatSpec with Matchers {
           totalLines = 1,
           returnedLines = 1
         )
+      case cmd =>
+        throw new Exception(s"Unexpected command: ${cmd.commandId}")
     }
 
     val interface: WorkspaceAgentInterface = new WorkspaceAgentInterfaceRemote(handler)
@@ -158,14 +157,15 @@ class WorkspaceAgentInterfaceTest extends AnyFlatSpec with Matchers {
 
   it should "throw exception for unexpected response types" in {
     // Create a handler that returns the wrong response type
-    val handler: WorkspaceAgentCommand => WorkspaceAgentResponse = { case cmd: ReadFileCommand =>
-      // Return wrong response type
-      WriteFileResponse(
-        commandId = cmd.commandId,
-        success = true,
-        path = cmd.path,
-        bytesWritten = 100
-      )
+    val handler: WorkspaceAgentCommand => WorkspaceAgentResponse = {
+      case _ =>
+        // Return a wrong response type
+        WriteFileResponse(
+          commandId = "n/a",
+          success = true,
+          path = "test.txt",
+          bytesWritten = 100
+        )
     }
 
     val interface: WorkspaceAgentInterface = new WorkspaceAgentInterfaceRemote(handler)

--- a/src/main/scala-2.13/org/llm4s/compat/BoundaryCompat.scala
+++ b/src/main/scala-2.13/org/llm4s/compat/BoundaryCompat.scala
@@ -1,0 +1,9 @@
+package org.llm4s.compat
+
+/**
+ * This is a compatibility shim to help with cross-compilation. Previously, this code used Scala 3's boundary
+ * feature but we've since moved to a more direct approach that works in both Scala 2.13 and Scala 3.
+ * 
+ * Keeping this file as a placeholder in case we need to reintroduce boundary-specific code in the future.
+ */
+object BoundaryCompat

--- a/src/main/scala-2.13/org/llm4s/compat/Scala213Compat.scala
+++ b/src/main/scala-2.13/org/llm4s/compat/Scala213Compat.scala
@@ -1,0 +1,9 @@
+package org.llm4s.compat
+
+object Scala213Compat {
+  /**
+   * This object contains compatibility code specific to Scala 2.13
+   */
+  def isScala213: Boolean = true
+  def isScala3: Boolean = false
+}

--- a/src/main/scala-3/org/llm4s/compat/BoundaryCompat.scala
+++ b/src/main/scala-3/org/llm4s/compat/BoundaryCompat.scala
@@ -1,0 +1,9 @@
+package org.llm4s.compat
+
+/**
+ * This is a compatibility shim to help with cross-compilation. Previously, this code used Scala 3's boundary
+ * feature but we've since moved to a more direct approach that works in both Scala 2.13 and Scala 3.
+ * 
+ * Keeping this file as a placeholder in case we need to reintroduce boundary-specific code in the future.
+ */
+object BoundaryCompat

--- a/src/main/scala-3/org/llm4s/compat/Scala3Compat.scala
+++ b/src/main/scala-3/org/llm4s/compat/Scala3Compat.scala
@@ -1,0 +1,9 @@
+package org.llm4s.compat
+
+object Scala3Compat {
+  /**
+   * This object contains compatibility code specific to Scala 3
+   */
+  def isScala213: Boolean = false
+  def isScala3: Boolean = true
+}

--- a/src/main/scala/org/llm4s/compat/ScalaCompat.scala
+++ b/src/main/scala/org/llm4s/compat/ScalaCompat.scala
@@ -1,0 +1,23 @@
+package org.llm4s.compat
+
+/**
+ * Compatibility layer that provides version-specific implementations.
+ * This code is common to both Scala 2.13 and Scala 3, but uses
+ * version-specific implementations from the scala-2.13 or scala-3 directories.
+ */
+object ScalaCompat {
+  // In Scala 2.13, this will import from Scala213Compat
+  // In Scala 3, this will import from Scala3Compat
+  def isScala213: Boolean = {
+    // The compiler will pick the right implementation at compile time
+    import scala.util.Properties
+    Properties.versionNumberString.startsWith("2.13")
+  }
+  
+  def isScala3: Boolean = !isScala213
+  
+  // Simple helper for version-dependent code
+  def onScala213[T](ifScala213: => T, ifScala3: => T): T = {
+    if (isScala213) ifScala213 else ifScala3
+  }
+}

--- a/src/main/scala/org/llm4s/llmconnect/provider/AzureOpenAIClient.scala
+++ b/src/main/scala/org/llm4s/llmconnect/provider/AzureOpenAIClient.scala
@@ -23,7 +23,7 @@ class AzureOpenAIClient(config: AzureConfig, client: OpenAIClient) extends LLMCl
       val chatOptions = new ChatCompletionsOptions(chatMessages)
 
       // Set options
-      chatOptions.setTemperature(options.temperature.floatValue())
+      chatOptions.setTemperature(options.temperature.doubleValue)
       options.maxTokens.foreach(mt => chatOptions.setMaxTokens(mt))
 
       // Add tools if specified

--- a/src/main/scala/org/llm4s/llmconnect/provider/OpenAIClient.scala
+++ b/src/main/scala/org/llm4s/llmconnect/provider/OpenAIClient.scala
@@ -30,11 +30,11 @@ class OpenAIClient(config: OpenAIConfig) extends LLMClient {
       val chatOptions = new ChatCompletionsOptions(chatMessages)
 
       // Set options
-      chatOptions.setTemperature(options.temperature.floatValue())
+      chatOptions.setTemperature(options.temperature.doubleValue())
       options.maxTokens.foreach(mt => chatOptions.setMaxTokens(mt))
-      chatOptions.setPresencePenalty(options.presencePenalty.floatValue())
-      chatOptions.setFrequencyPenalty(options.frequencyPenalty.floatValue())
-      chatOptions.setTopP(options.topP.floatValue())
+      chatOptions.setPresencePenalty(options.presencePenalty.doubleValue())
+      chatOptions.setFrequencyPenalty(options.frequencyPenalty.doubleValue())
+      chatOptions.setTopP(options.topP.doubleValue())
 
       // Add tools if specified
       if (options.tools.nonEmpty) {

--- a/src/main/scala/org/llm4s/toolapi/SafeParameterExtractor.scala
+++ b/src/main/scala/org/llm4s/toolapi/SafeParameterExtractor.scala
@@ -1,8 +1,6 @@
 package org.llm4s.toolapi
 
-import ujson._
-import scala.util.boundary
-import scala.util.boundary.break
+import ujson.Value
 
 /**
  * Safe parameter extraction with type checking and path navigation
@@ -26,35 +24,37 @@ case class SafeParameterExtractor(params: ujson.Value) {
   def getObject(path: String): Either[String, ujson.Obj] =
     extract(path, v => Option(v).collect { case obj: ujson.Obj => obj }, "object")
 
-  // Generic extractor with type validation
+  // Generic extractor with type validation - no more boundary usage
   private def extract[T](path: String, extractor: ujson.Value => Option[T], expectedType: String): Either[String, T] =
     try {
-      boundary {
-        val pathParts = path.split('.')
-        var current = params
-
-        // Navigate through nested path
-        for (part <- pathParts.dropRight(1)) {
-          current.obj.get(part) match {
-            case Some(value) => current =
-              value
-            case None =>
-              break(Left(s"Path '$path' not found: missing '$part' segment"))
+      val pathParts = path.split('.')
+      
+      // Navigate to the value using a recursive approach instead of boundary
+      def navigatePath(current: ujson.Value, remainingParts: List[String]): Either[String, ujson.Value] = {
+        if (remainingParts.isEmpty) {
+          Right(current)
+        } else {
+          val part = remainingParts.head
+          if (!current.isInstanceOf[ujson.Obj]) {
+            Left(s"Path '$path': Expected object at '${pathParts.dropRight(remainingParts.size).mkString(".")}' but found ${current.getClass.getSimpleName}")
+          } else {
+            current.obj.get(part) match {
+              case Some(value) => navigatePath(value, remainingParts.tail)
+              case None => Left(s"Path '$path' not found: missing '$part' segment")
+            }
           }
         }
-
-        // Extract the final value
+      }
+      
+      // Get the value at the path
+      navigatePath(params, pathParts.toList).flatMap { value =>
         val finalPart = pathParts.last
-        current.obj.get(finalPart) match {
-          case Some(value) =>
-            extractor(value) match {
-              case Some(result) => Right(result)
-              case None => Left(s"Value at '$path' is not of expected type '$expectedType'")
-            }
-           case None => Left(s"Parameter '$finalPart' not found")
+        extractor(value) match {
+          case Some(result) => Right(result)
+          case None => Left(s"Value at '$path' is not of expected type '$expectedType'")
         }
       }
-   } catch {
-     case e: Exception => Left(s"Error extracting parameter at '$path': ${e.getMessage}")
-   }
+    } catch {
+      case e: Exception => Left(s"Error extracting parameter at '$path': ${e.getMessage}")
+    }
 }

--- a/src/main/scala/org/llm4s/toolapi/SafeParameterExtractor.scala
+++ b/src/main/scala/org/llm4s/toolapi/SafeParameterExtractor.scala
@@ -1,6 +1,8 @@
 package org.llm4s.toolapi
 
 import ujson._
+import scala.util.boundary
+import scala.util.boundary.break
 
 /**
  * Safe parameter extraction with type checking and path navigation
@@ -27,27 +29,32 @@ case class SafeParameterExtractor(params: ujson.Value) {
   // Generic extractor with type validation
   private def extract[T](path: String, extractor: ujson.Value => Option[T], expectedType: String): Either[String, T] =
     try {
-      val pathParts = path.split('.')
-      var current   = params
+      boundary {
+        val pathParts = path.split('.')
+        var current = params
 
-      // Navigate through nested path
-      for (part <- pathParts.dropRight(1))
-        current.obj.get(part) match {
-          case Some(value) => current = value
-          case None        => return Left(s"Path '$path' not found: missing '$part' segment")
+        // Navigate through nested path
+        for (part <- pathParts.dropRight(1)) {
+          current.obj.get(part) match {
+            case Some(value) => current =
+              value
+            case None =>
+              break(Left(s"Path '$path' not found: missing '$part' segment"))
+          }
         }
 
-      // Extract the final value
-      val finalPart = pathParts.last
-      current.obj.get(finalPart) match {
-        case Some(value) =>
-          extractor(value) match {
-            case Some(result) => Right(result)
-            case None         => Left(s"Value at '$path' is not of expected type '$expectedType'")
-          }
-        case None => Left(s"Parameter '$finalPart' not found")
+        // Extract the final value
+        val finalPart = pathParts.last
+        current.obj.get(finalPart) match {
+          case Some(value) =>
+            extractor(value) match {
+              case Some(result) => Right(result)
+              case None => Left(s"Value at '$path' is not of expected type '$expectedType'")
+            }
+           case None => Left(s"Parameter '$finalPart' not found")
+        }
       }
-    } catch {
-      case e: Exception => Left(s"Error extracting parameter at '$path': ${e.getMessage}")
-    }
+   } catch {
+     case e: Exception => Left(s"Error extracting parameter at '$path': ${e.getMessage}")
+   }
 }


### PR DESCRIPTION
refactor: replace non-local return with scala.util.boundary

* Replace non-local return statements with scala.util.boundary for Scala 3 compatibility
* Non-local returns are no longer supported in Scala 3
* Use boundary.break as the recommended alternative
* Update parameter extraction logic to use the new control flow mechanism

Migration required as part of Scala 3 upgrade. The boundary mechanism provides a more structured way to handle early returns while maintaining code readability.

better precision (e.g., float-to-double conversions)
 Enhanced error handling mechanisms and streamlined test case structures for robustness.