### PR TITLE
Fixed a typo in the crosstest README.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ sbt testCross
 sbt fullCrossTest
 ```
 
-> **Note:** For detailed information about our cross-testing strategy and setup, see [crosstest/README.md](crosstest/README.md)
+> **Note:** For detailed information about our cross-testing strategy and setup, see [crossTest/README.md](crossTest/README.md)
 >
 ## Roadmap
 


### PR DESCRIPTION
There is a typo in the README.md... The link is crosstest/README.md - instead it needs to be crossTest/README.md  