### PR TITLE
Using uPickle to avoid hand crafting json payloads

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val root = (project in file("."))
       "com.anthropic"      % "anthropic-java"  % "1.1.0",
       "ch.qos.logback"     % "logback-classic" % "1.5.18",
       "com.knuddels"       % "jtokkit"         % "1.1.0",
-      "com.lihaoyi"       %% "upickle"         % "4.1.0",
+      "com.lihaoyi"       %% "upickle"         % "4.2.1",
       "com.lihaoyi"       %% "requests"        % "0.9.0",
       "org.java-websocket" % "Java-WebSocket"  % "1.5.3",
       "org.scalatest"     %% "scalatest"       % "3.2.19" % Test

--- a/src/main/scala/org/llm4s/imagegeneration/provider/HuggingClientPayload.scala
+++ b/src/main/scala/org/llm4s/imagegeneration/provider/HuggingClientPayload.scala
@@ -1,0 +1,26 @@
+package org.llm4s.imagegeneration.provider
+
+import org.llm4s.imagegeneration.ImageGenerationOptions
+
+
+case class HuggingClientPayload(
+                                 inputs: String,
+                                 parameters: Parameters
+                               )
+
+object HuggingClientPayload {
+  import Parameters._
+  def apply(prompt: String, options: ImageGenerationOptions): HuggingClientPayload = {
+    HuggingClientPayload(
+      inputs = prompt,
+      parameters = Parameters(
+        guidance_scale = options.guidanceScale,
+        inferenceSteps = options.inferenceSteps,
+        negative_prompt = options.negativePrompt.map(_.toString),
+        seed = options.seed
+      )
+    )
+  }
+  // The variable e could be replaced with _ - works well in Scala 3 but gives error for Scala 2
+  implicit val e: upickle.default.ReadWriter[HuggingClientPayload] = upickle.default.macroRW[HuggingClientPayload]
+}

--- a/src/main/scala/org/llm4s/imagegeneration/provider/Parameters.scala
+++ b/src/main/scala/org/llm4s/imagegeneration/provider/Parameters.scala
@@ -1,0 +1,14 @@
+package org.llm4s.imagegeneration.provider
+
+case class Parameters(
+                       guidance_scale: Double,
+                       inferenceSteps: Int,
+                       negative_prompt: Option[String],
+                       seed: Option[Long]
+                     )
+
+object Parameters {
+  // The variable e could be replaced with _ - works well in Scala 3 but gives error for Scala 2
+  implicit val e: upickle.default.ReadWriter[Parameters] = upickle.default.macroRW[Parameters]
+}
+  

--- a/src/test/scala/org/llm4s/imagegeneration/provider/HuggingFaceClientTest.scala
+++ b/src/test/scala/org/llm4s/imagegeneration/provider/HuggingFaceClientTest.scala
@@ -1,0 +1,99 @@
+package org.llm4s.imagegeneration.provider
+
+import org.llm4s.imagegeneration.{ HuggingFaceConfig, ImageGenerationOptions }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import upickle.default._
+
+class HuggingFaceClientTest extends AnyFlatSpec with Matchers {
+
+  "buildPayload" should "create a valid JSON payload with all parameters" in {
+    // Arrange
+    val client = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"))
+    val prompt = "A beautiful sunset over mountains"
+    val options = ImageGenerationOptions(
+      guidanceScale = 7.5,
+      inferenceSteps = 50,
+      negativePrompt = Some("blurry, low quality"),
+      seed = Some(42L)
+    )
+
+    // Act
+    val payload = client.createJsonPayload(HuggingClientPayload(prompt, options))
+
+    // Assert
+    // Parse the JSON to verify its structure
+    val parsedPayload = read[HuggingClientPayload](payload)
+    parsedPayload.inputs shouldBe prompt
+    parsedPayload.parameters.guidance_scale shouldBe 7.5
+    parsedPayload.parameters.inferenceSteps shouldBe 50
+    parsedPayload.parameters.negative_prompt shouldBe Some("blurry, low quality")
+    parsedPayload.parameters.seed shouldBe Some(42L)
+  }
+
+  it should "create a payload with minimal options" in {
+    // Arrange
+    val client = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"))
+    val prompt = "A minimalist landscape"
+    val options = ImageGenerationOptions() // Default options
+
+    // Act
+    val payload = client.createJsonPayload(HuggingClientPayload(prompt, options))
+
+    // Assert
+    val parsedPayload = read[HuggingClientPayload](payload)
+    parsedPayload.inputs shouldBe prompt
+    parsedPayload.parameters.guidance_scale shouldBe 7.5 // Default value
+    parsedPayload.parameters.inferenceSteps shouldBe 20 // Default value
+    parsedPayload.parameters.negative_prompt shouldBe None
+    parsedPayload.parameters.seed shouldBe None
+  }
+
+  it should "handle special characters in the prompt" in {
+    // Arrange
+    val client = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"))
+    val prompt = "A scene with \"quotes\" and special ch@r@cters!"
+    val options = ImageGenerationOptions()
+
+    // Act
+    val payload = client.createJsonPayload(HuggingClientPayload(prompt, options))
+
+    // Assert
+    val parsedPayload = read[HuggingClientPayload](payload)
+    parsedPayload.inputs shouldBe prompt
+  }
+
+  it should "create a payload with custom guidance scale and inference steps" in {
+    // Arrange
+    val client = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"))
+    val prompt = "A futuristic cityscape"
+    val options = ImageGenerationOptions(
+      guidanceScale = 9.0,
+      inferenceSteps = 75
+    )
+
+    // Act
+    val payload = client.createJsonPayload(HuggingClientPayload(prompt, options))
+
+    // Assert
+    val parsedPayload = read[HuggingClientPayload](payload)
+    parsedPayload.parameters.guidance_scale shouldBe 9.0
+    parsedPayload.parameters.inferenceSteps shouldBe 75
+  }
+
+  it should "create a payload with a specific seed" in {
+    // Arrange
+    val client = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"))
+    val prompt = "A reproducible image generation"
+    val options = ImageGenerationOptions(
+      seed = Some(12345L)
+    )
+
+    // Act
+    val payload = client.createJsonPayload(HuggingClientPayload(prompt, options))
+
+    // Assert
+    val parsedPayload = read[HuggingClientPayload](payload)
+    parsedPayload.parameters.seed shouldBe Some(12345L)
+  }
+}


### PR DESCRIPTION
1. upgraded upickle library version from 4.1.0 to 4.2.1 
2. Using upickle's case class support to generate json string (https://com-lihaoyi.github.io/upickle/#CaseClasses)
3. Separated pure and side effecting (logging) functions - for easier testability
4. Added unit tests - uses upickle to parse & check the generated json string 