### PR TITLE
Refactored to use for comprehensions using Either monads

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 import com.typesafe.sbt.packager.docker.Cmd
 import sbt.Keys.{libraryDependencies, *}
 
+
+// Define supported Scala versions
 val scala213 = "2.13.16"
 val scala3   = "3.7.1"
 val scala3CompilerOptions = Seq(
@@ -117,6 +119,8 @@ lazy val root = (project in file("."))
       "com.knuddels"       % "jtokkit"         % "1.1.0",
       "com.lihaoyi"       %% "requests"        % "0.9.0",
       "org.java-websocket" % "Java-WebSocket"  % "1.5.3",
+      "org.scalatest"     %% "scalatest"       % "3.2.19" % Test,
+      "org.scalamock"     %% "scalamock"       % "7.3.3"  % Test,
     )
   )
 

--- a/src/main/scala/org/llm4s/imagegeneration/ImageGeneration.scala
+++ b/src/main/scala/org/llm4s/imagegeneration/ImageGeneration.scala
@@ -2,8 +2,7 @@ package org.llm4s.imagegeneration
 
 import java.time.Instant
 import java.nio.file.Path
-import org.llm4s.imagegeneration.provider.StableDiffusionClient
-import org.llm4s.imagegeneration.provider.HuggingFaceClient
+import org.llm4s.imagegeneration.provider.{ HttpClient, HuggingFaceClient, StableDiffusionClient }
 
 // ===== ERROR HANDLING =====
 
@@ -208,7 +207,8 @@ object ImageGeneration {
       case sdConfig: StableDiffusionConfig =>
         new StableDiffusionClient(sdConfig)
       case hfConfig: HuggingFaceConfig =>
-        new HuggingFaceClient(hfConfig)
+        val httpClient = HttpClient.createHttpClient(hfConfig)
+        new HuggingFaceClient(hfConfig, httpClient)
     }
 
   /** Convenience method for quick image generation */

--- a/src/main/scala/org/llm4s/imagegeneration/provider/HuggingFaceClient.scala
+++ b/src/main/scala/org/llm4s/imagegeneration/provider/HuggingFaceClient.scala
@@ -4,6 +4,7 @@ import org.llm4s.imagegeneration._
 
 import java.time.Instant
 import java.util.Base64
+import scala.util.Try
 
 /**
  * HuggingFace Inference API client for image generation.
@@ -28,7 +29,7 @@ import java.util.Base64
  * }
  * }}}
  */
-class HuggingFaceClient(config: HuggingFaceConfig) extends ImageGenerationClient {
+class HuggingFaceClient(config: HuggingFaceConfig, httpClient: BaseHttpClient) extends ImageGenerationClient {
 
   private val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
@@ -44,6 +45,75 @@ class HuggingFaceClient(config: HuggingFaceConfig) extends ImageGenerationClient
     options: ImageGenerationOptions = ImageGenerationOptions()
   ): Either[ImageGenerationError, GeneratedImage] =
     generateImages(prompt, 1, options).map(_.head)
+
+  /**
+   * Validates the provided prompt to ensure it is not empty or blank.
+   *
+   * @param prompt The input string representing the prompt to validate.
+   * @return Either an `ImageGenerationError` if the validation fails, or the original valid prompt as a `String`.
+   */
+  def validatePrompt(prompt: String): Either[ImageGenerationError, String] =
+    Either.cond(prompt.trim.nonEmpty, prompt, ValidationError("Prompt cannot be empty"))
+
+  /**
+   * Validates the provided count to ensure it is within the allowable range
+   * for image generation (1 to 4 inclusive, for HuggingFace).
+   *
+   * @param count The number of images requested for generation. Must be between 1 and 4.
+   * @return Either an `ImageGenerationError` if the count is out of range,
+   *         or the valid count as an `Int` if the validation succeeds.
+   */
+  def validateCount(count: Int): Either[ImageGenerationError, Int] =
+    Either.cond(count > 0 && count <= 4, count, ValidationError("Count must be between 1 and 4 for HuggingFace"))
+
+  /**
+   * Converts the byte content of an HTTP response into a Base64-encoded string.
+   * If an error occurs during the conversion process, it wraps the exception
+   * into an `ImageGenerationError`.
+   *
+   * @param response The HTTP response containing the byte data to convert.
+   * @return Either an `ImageGenerationError` in case of a failure or
+   *         the resulting Base64-encoded string on success.
+   */
+  def convertToBase64(response: requests.Response): Either[ImageGenerationError, String] = Try {
+    val imageData = response.bytes
+    Base64.getEncoder.encodeToString(imageData)
+  }.toEither.left.map(exception => ServiceError(exception.getMessage, 500))
+
+  /**
+   * Generates multiple images based on the given text prompt using predefined options and base64-encoded image data.
+   *
+   * This method creates a sequence of `GeneratedImage` objects by iteratively adding offsets to the provided seed
+   * (if present in the options). It handles errors by returning an `ImageGenerationError` wrapped in an `Either`.
+   *
+   * @param prompt     The text description of the images to be generated.
+   * @param count      The number of images to generate. Ensures the specified number of iterations in the generation process.
+   * @param options    Optional parameters for image generation, including size, format, seed, guidance scale, etc.
+   * @param base64Data The base64-encoded image data that will be used to populate each generated image.
+   * @return Either an `ImageGenerationError` in case of a generation issue, or an `IndexedSeq` of `GeneratedImage` objects
+   *         containing all successfully created images.
+   */
+  def generateAllImages(
+    prompt: String,
+    count: Int,
+    options: ImageGenerationOptions = ImageGenerationOptions(),
+    base64Data: String
+  ): Either[ImageGenerationError, IndexedSeq[GeneratedImage]] = Try {
+    logger.debug("Generating {} image(s) with HuggingFace: '{}'", count, prompt)
+
+    val images = (1 to count).map { i =>
+      GeneratedImage(
+        data = base64Data,
+        format = options.format,
+        size = options.size,
+        prompt = prompt,
+        seed = options.seed.map(_ + i),
+        createdAt = Instant.now()
+      )
+    }
+    (1 to count).foreach(i => logger.debug("Generated image: {}", i))
+    images
+  }.toEither.left.map(exception => ServiceError(exception.getMessage, 500))
 
   /**
    * Generate multiple images from a text prompt using HuggingFace Inference API.
@@ -62,49 +132,18 @@ class HuggingFaceClient(config: HuggingFaceConfig) extends ImageGenerationClient
     options: ImageGenerationOptions = ImageGenerationOptions()
   ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
 
-    if (prompt.trim.isEmpty) {
-      return Left(ValidationError("Prompt cannot be empty"))
-    }
+    val result: Either[ImageGenerationError, IndexedSeq[GeneratedImage]] = for {
+      prompt     <- validatePrompt(prompt)
+      count      <- validateCount(count)
+      payload    <- buildPayload(prompt, options)
+      response   <- makeHttpRequest(payload)
+      base64Data <- convertToBase64(response)
+      images     <- generateAllImages(prompt, count, options, base64Data)
+    } yield images
 
-    if (count <= 0 || count > 4) {
-      return Left(ValidationError("Count must be between 1 and 4 for HuggingFace"))
-    }
+    result.left.foreach(error => logger.error("Error generating images: {}", error.message))
 
-    try {
-      logger.info(s"Generating $count image(s) with HuggingFace: '$prompt'")
-
-      val payload  = buildPayload(prompt, options)
-      val response = makeHttpRequest(payload)
-
-      if (response.statusCode == 200) {
-        val imageData  = response.bytes
-        val base64Data = Base64.getEncoder.encodeToString(imageData)
-
-        val images = (1 to count).map { i =>
-          GeneratedImage(
-            data = base64Data,
-            format = options.format,
-            size = options.size,
-            prompt = prompt,
-            seed = options.seed.map(_ + i),
-            createdAt = Instant.now()
-          )
-        }
-
-        Right(images)
-      } else {
-        val errorBody = response.text()
-        logger.error(s"HuggingFace API error: ${response.statusCode} - $errorBody")
-        Left(ServiceError(s"HuggingFace API error: $errorBody", response.statusCode))
-      }
-    } catch {
-      case e: requests.RequestsException =>
-        logger.error(s"Network error: ${e.getMessage}")
-        Left(ServiceError(s"Network error: ${e.getMessage}", 0))
-      case e: Exception =>
-        logger.error(s"Unexpected error: ${e.getMessage}")
-        Left(UnknownError(e))
-    }
+    result
   }
 
   /**
@@ -144,40 +183,45 @@ class HuggingFaceClient(config: HuggingFaceConfig) extends ImageGenerationClient
     }
 
   /**
-   * @param huggingClientPayload the payload for which to generate json
-   * @return the resulting json string
+   * Serializes a `HuggingClientPayload` object into a JSON string.
+   *
+   * @param huggingClientPayload The payload object containing input text and generation parameters
+   *                             to be serialized into JSON format.
+   * @return The JSON string representation of the provided `HuggingClientPayload` object.
    */
   def createJsonPayload(huggingClientPayload: HuggingClientPayload): String =
     upickle.default.write(huggingClientPayload)
 
   /**
-   * @param prompt the prompt for the payload
-   * @param options image generation options
-   * @return the payload converted to a json string
+   * Builds the JSON payload required for the HuggingFace Inference API
+   * based on the provided prompt and image generation options.
+   *
+   * @param prompt  The text description for the image generation.
+   * @param options The image generation options such as size, seed, guidance scale, etc.
+   * @return Either an `ImageGenerationError` if payload creation fails,
+   *         or the JSON string representing the payload.
    */
-  private def buildPayload(prompt: String, options: ImageGenerationOptions): String = {
+  def buildPayload(prompt: String, options: ImageGenerationOptions): Either[ImageGenerationError, String] = Try {
     val payload = HuggingClientPayload(prompt, options)
     val jsonStr = createJsonPayload(payload)
     logger.debug("Payload: {} - Json: {}", payload, jsonStr)
     jsonStr
-  }
+  }.toEither.left.map(exception => ServiceError(exception.getMessage, 500))
 
-  private def makeHttpRequest(payload: String): requests.Response = {
-    val url = s"https://api-inference.huggingface.co/models/${config.model}"
-    val headers = Map(
-      "Authorization" -> s"Bearer ${config.apiKey}",
-      "Content-Type"  -> "application/json"
-    )
-
-    logger.debug(s"Making request to: $url")
-    logger.debug(s"Payload: $payload")
-
-    requests.post(
-      url = url,
-      data = payload,
-      headers = headers,
-      readTimeout = config.timeout,
-      connectTimeout = 10000
-    )
+  /**
+   * Makes an HTTP POST request to the HuggingFace Inference API to send a payload and retrieve a response.
+   *
+   * @param payload The JSON payload to send with the HTTP request.
+   * @return Either an ImageGenerationError if the request fails or a successful `requests.Response` object.
+   */
+  def makeHttpRequest(payload: String): Either[ImageGenerationError, requests.Response] = {
+    val result = Try(httpClient.post(payload)).toEither.left.map(exception => ServiceError(exception.getMessage, 500))
+    result.flatMap { response =>
+      if (response.statusCode == 200) {
+        Right(response)
+      } else {
+        Left(ServiceError(response.text(), 500))
+      }
+    }
   }
 }

--- a/src/main/scala/org/llm4s/imagegeneration/provider/HuggingFaceHttpClient.scala
+++ b/src/main/scala/org/llm4s/imagegeneration/provider/HuggingFaceHttpClient.scala
@@ -1,0 +1,37 @@
+package org.llm4s.imagegeneration.provider
+
+import org.llm4s.imagegeneration.HuggingFaceConfig
+import requests.Response
+
+trait BaseHttpClient {
+  def post(payload: String): requests.Response
+}
+
+class HttpClient(url: String, headers: Map[String, String], timeout: Int) extends BaseHttpClient {
+  private val logger = org.slf4j.LoggerFactory.getLogger(getClass)
+
+  override def post(payload: String): Response = {
+    logger.debug("Making request to: {}", url)
+    logger.debug("Payload: {}", payload)
+
+    requests.post( // Note that the post could throw - as per the documentation
+      url = url,
+      data = payload,
+      headers = headers,
+      readTimeout = timeout,
+      connectTimeout = 10000
+    )
+  }
+}
+
+object HttpClient {
+  def createHttpClient(config: HuggingFaceConfig) =
+    new HttpClient(
+      url = s"https://api-inference.huggingface.co/models/${config.model}",
+      headers = Map(
+        "Authorization" -> s"Bearer ${config.apiKey}",
+        "Content-Type"  -> "application/json"
+      ),
+      config.timeout
+    )
+}

--- a/src/test/scala/org/llm4s/imagegeneration/provider/HuggingFaceClientTest.scala
+++ b/src/test/scala/org/llm4s/imagegeneration/provider/HuggingFaceClientTest.scala
@@ -1,15 +1,19 @@
 package org.llm4s.imagegeneration.provider
 
 import org.llm4s.imagegeneration.{ HuggingFaceConfig, ImageGenerationOptions }
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import upickle.default._
 
-class HuggingFaceClientTest extends AnyFlatSpec with Matchers {
+class HuggingFaceClientTest extends AnyFlatSpec with Matchers with MockFactory with EitherValues {
+
+  val httpClient: BaseHttpClient = stub[BaseHttpClient]
 
   "buildPayload" should "create a valid JSON payload with all parameters" in {
     // Arrange
-    val client = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"))
+    val client = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"), httpClient)
     val prompt = "A beautiful sunset over mountains"
     val options = ImageGenerationOptions(
       guidanceScale = 7.5,
@@ -33,7 +37,7 @@ class HuggingFaceClientTest extends AnyFlatSpec with Matchers {
 
   it should "create a payload with minimal options" in {
     // Arrange
-    val client  = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"))
+    val client  = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"), httpClient)
     val prompt  = "A minimalist landscape"
     val options = ImageGenerationOptions() // Default options
 
@@ -51,7 +55,7 @@ class HuggingFaceClientTest extends AnyFlatSpec with Matchers {
 
   it should "handle special characters in the prompt" in {
     // Arrange
-    val client  = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"))
+    val client  = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"), httpClient)
     val prompt  = "A scene with \"quotes\" and special ch@r@cters!"
     val options = ImageGenerationOptions()
 
@@ -65,7 +69,7 @@ class HuggingFaceClientTest extends AnyFlatSpec with Matchers {
 
   it should "create a payload with custom guidance scale and inference steps" in {
     // Arrange
-    val client = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"))
+    val client = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"), httpClient)
     val prompt = "A futuristic cityscape"
     val options = ImageGenerationOptions(
       guidanceScale = 9.0,
@@ -83,7 +87,7 @@ class HuggingFaceClientTest extends AnyFlatSpec with Matchers {
 
   it should "create a payload with a specific seed" in {
     // Arrange
-    val client = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"))
+    val client = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"), httpClient)
     val prompt = "A reproducible image generation"
     val options = ImageGenerationOptions(
       seed = Some(12345L)
@@ -96,4 +100,88 @@ class HuggingFaceClientTest extends AnyFlatSpec with Matchers {
     val parsedPayload = read[HuggingClientPayload](payload)
     parsedPayload.parameters.seed shouldBe Some(12345L)
   }
+
+  "buildPayload" should "successfully create a valid payload string" in {
+    // Arrange
+    val client  = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"), httpClient)
+    val prompt  = "test prompt"
+    val options = ImageGenerationOptions()
+
+    // Act
+    val result = client.buildPayload(prompt, options)
+
+    // Assert
+    result.value.length should be > 0
+
+    result.map { jsonStr =>
+      val parsedPayload = read[HuggingClientPayload](jsonStr)
+      parsedPayload.inputs shouldBe prompt
+      parsedPayload.parameters.guidance_scale shouldBe options.guidanceScale
+      parsedPayload.parameters.inferenceSteps shouldBe options.inferenceSteps
+    }
+  }
+
+  it should "create a payload with all custom options" in {
+    // Arrange
+    val client = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"), httpClient)
+    val prompt = "test prompt"
+    val options = ImageGenerationOptions(
+      guidanceScale = 8.5,
+      inferenceSteps = 30,
+      negativePrompt = Some("negative test"),
+      seed = Some(123L)
+    )
+
+    // Act
+    val result = client.buildPayload(prompt, options)
+
+    // Assert
+    result.value.length should be > 0
+
+    result.map { jsonStr =>
+      val parsedPayload = read[HuggingClientPayload](jsonStr)
+      parsedPayload.inputs shouldBe prompt
+      parsedPayload.parameters.guidance_scale shouldBe 8.5
+      parsedPayload.parameters.inferenceSteps shouldBe 30
+      parsedPayload.parameters.negative_prompt shouldBe Some("negative test")
+      parsedPayload.parameters.seed shouldBe Some(123L)
+    }
+  }
+
+  it should "handle empty prompt correctly" in {
+    // Arrange
+    val client  = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"), httpClient)
+    val prompt  = ""
+    val options = ImageGenerationOptions()
+
+    // Act
+    val result = client.buildPayload(prompt, options)
+
+    // Assert
+    result.value.length should be > 0
+
+    result.map { jsonStr =>
+      val parsedPayload = read[HuggingClientPayload](jsonStr)
+      parsedPayload.inputs shouldBe empty
+    }
+  }
+
+  it should "handle special characters in the prompt correctly" in {
+    // Arrange
+    val client  = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"), httpClient)
+    val prompt  = "test \"quote\" and \n newline"
+    val options = ImageGenerationOptions()
+
+    // Act
+    val result = client.buildPayload(prompt, options)
+
+    // Assert
+    result.value.length should be > 0
+
+    result.map { jsonStr =>
+      val parsedPayload = read[HuggingClientPayload](jsonStr)
+      parsedPayload.inputs shouldBe prompt
+    }
+  }
+
 }

--- a/src/test/scala/org/llm4s/imagegeneration/provider/HuggingFaceHttpClientTest.scala
+++ b/src/test/scala/org/llm4s/imagegeneration/provider/HuggingFaceHttpClientTest.scala
@@ -1,0 +1,36 @@
+package org.llm4s.imagegeneration.provider
+
+import org.llm4s.imagegeneration.{ HuggingFaceConfig, ServiceError }
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+import requests.Response
+
+class HuggingFaceHttpClientTest extends AnyFlatSpec with MockFactory with EitherValues {
+
+  val httpClient: BaseHttpClient = stub[BaseHttpClient]
+  val huggingFaceClient          = new HuggingFaceClient(HuggingFaceConfig("test-key", "test-model"), httpClient)
+
+  it should "return a Left(error) on exception" in {
+
+    (httpClient.post _).when("something").throws(new RuntimeException("Something went wrong"))
+
+    val result = huggingFaceClient.makeHttpRequest("something")
+
+    result.isRight should be(false)
+    result.swap.getOrElse("") should be(ServiceError("Something went wrong", 500))
+  }
+
+  it should "return a Right(value) on success" in {
+
+    val response = Response("", 200, "OK", new geny.Bytes("something".getBytes), Map.empty, None)
+    (httpClient.post _).when("something").returns(response)
+
+    val result = huggingFaceClient.makeHttpRequest("something")
+
+    result.isRight should be(true)
+    result.value should be(response)
+  }
+
+}


### PR DESCRIPTION
- Restructured the code to use the monadic pipeline - Eithers composed via for comprehension            
- All exceptions are logged and handled due to the monad semantics
- Reusability of the http client - promote http post as a utility method 
- Easier testability of the http client - using the ScalaMock framework 
- The design promotes one time configuration & reuse for multiple payload executions
- Easier to bolt the async api semantics on top of the current structure