### PR TITLE
Refactor/update mcp spec

### DIFF
--- a/samples/src/main/scala/org/llm4s/samples/agent/MCPAgentExample.scala
+++ b/samples/src/main/scala/org/llm4s/samples/agent/MCPAgentExample.scala
@@ -11,32 +11,26 @@ import scala.concurrent.duration._
  * Example demonstrating agent execution with MCP tool integration
  *
  * This example shows how an LLM agent can seamlessly use both local tools 
- * and remote MCP tools to complete complex multi-step tasks.
+ * and remote MCP tools with automatic fallback between transport protocols.
  *
- * Start the MCPServer first - see DemonstrationMCPServer documentation for instructions
+ * Start the MCPServer first: sbt "samples/runMain org.llm4s.samples.mcp.DemonstrationMCPServer"
  * Then run: sbt "samples/runMain org.llm4s.samples.agent.MCPAgentExample"
  */
 object MCPAgentExample {
   private val logger = LoggerFactory.getLogger(getClass)
   
   def main(args: Array[String]): Unit = {
-    logger.info("🚀 MCP Agent Example")
-    logger.info("📋 Demonstrating agent execution with MCP integration")
+    logger.info("🚀 MCP Agent Example - Agent with MCP Tools")
     
-    // Get LLM client
-    val client = LLM.client()
-    
-    // Create MCP server configuration
-    val serverConfig = MCPServerConfig.sse(
-      name = "test-mcp-server", 
-      url = "http://localhost:8080",
+    // Set up MCP server configuration (automatically tries latest protocol with fallback)
+    val serverConfig = MCPServerConfig.streamableHTTP(
+      name = "mcp-tools-server", 
+      url = "http://localhost:8080/mcp",
       timeout = 30.seconds
     )
     
-    // Set up tool registry with local and MCP tools
-    logger.info("🔧 Setting up tool registry...")
+    // Create tool registry combining local and MCP tools
     val localWeatherTool = WeatherTool.tool
-    
     val mcpRegistry = new MCPToolRegistry(
       mcpServers = Seq(serverConfig),
       localTools = Seq(localWeatherTool),
@@ -47,82 +41,51 @@ object MCPAgentExample {
     val allTools = mcpRegistry.getAllTools
     logger.info(s"📦 Available tools (${allTools.size} total):")
     allTools.zipWithIndex.foreach { case (tool, index) =>
-      logger.info(s"   ${index + 1}. ${tool.name}: ${tool.description}")
+      val source = if (tool.description == "Retrieves current weather for the given location.") "local" else "MCP"
+      logger.info(s"   ${index + 1}. ${tool.name} ($source): ${tool.description}")
     }
     
-    // Create and run agent
-    runAgentQueries(client, mcpRegistry)
+    // Test with agent
+    runAgentExample(mcpRegistry)
     
+    // Clean up
     mcpRegistry.closeMCPClients()
-    
-    logger.info("✨ Agent example completed!")
+    logger.info("✨ MCP Agent Example completed!")
   }
   
-  // Run multiple agent queries to test different capabilities
-  private def runAgentQueries(client: org.llm4s.llmconnect.LLMClient, registry: MCPToolRegistry): Unit = {
+  private def runAgentExample(registry: MCPToolRegistry): Unit = {
+    val client = LLM.client()
     val agent = new Agent(client)
     
-    // Define test queries
-    val queries = Seq(
-      "What's the weather like in Tokyo, and then convert 100 USD to EUR?",
-      "Could convert 43 british pounds into american dollars ? Also give me the exchange rate please ",
-      "Could you convert 50 turkish lira to euro ?"
-    )
+    val query = "Convert 100 USD to EUR and then check the weather in Paris"
     
-    // Execute each query with full tracing
-    queries.zipWithIndex.foreach { case (query, index) =>
-      val queryNum = index + 1
-      val traceFile = s"mcp-agent-query-$queryNum.md"
-      
-      logger.info(s"${"=" * 60}")
-      logger.info(s"🎯 Query $queryNum: $query")
-      logger.info(s"📝 Trace: $traceFile")
-      logger.info(s"${"=" * 60}")
-      
-      // Run the agent
-      agent.run(
-        query = query,
-        tools = registry,
-        maxSteps = Some(8),
-        traceLogPath = Some(traceFile)
-      ) match {
-        case Right(finalState) =>
-          logger.info(s"✅ Query $queryNum completed: ${finalState.status}")
-          
-          // Show final answer
-          finalState.conversation.messages.reverse.find(_.role == "assistant") match {
-            case Some(msg) =>
-              logger.info("💬 Final Answer:")
-              logger.info(s"${msg.content}")
-            case None => 
-              logger.warn("❌ No final answer found")
-          }
-          
-          // Show execution summary
-          logger.info(s"📊 Summary:")
-          logger.info(s"   Steps: ${finalState.logs.size}")
-          logger.info(s"   Messages: ${finalState.conversation.messages.size}")
-          
-          // Show tools used
-          val toolCalls = finalState.logs.filter(_.contains("[tool]"))
-          if (toolCalls.nonEmpty) {
-            logger.info("   Tools used:")
-            toolCalls.foreach { log =>
-              val toolName = log.split("\\s+").drop(1).headOption.getOrElse("unknown")
-              logger.info(s"     - $toolName")
-            }
-          }
-          
-        case Left(error) =>
-          logger.error(s"❌ Query $queryNum failed: $error")
-      }
-      
-      // Pause between queries
-      if (queryNum < queries.size) {
-        Thread.sleep(1000)
-      }
+    logger.info(s"🎯 Running agent query: $query")
+    
+    val startTime = System.currentTimeMillis()
+    
+    agent.run(
+      query = query,
+      tools = registry,
+      maxSteps = Some(5),
+      traceLogPath = Some("mcp-agent-example.md")
+    ) match {
+      case Right(finalState) =>
+        val duration = System.currentTimeMillis() - startTime
+        logger.info(s"✅ Query completed in ${duration}ms")
+        
+        // Show final answer
+        finalState.conversation.messages.reverse.find(_.role == "assistant") match {
+          case Some(msg) =>
+            logger.info(s"💬 Agent Response: ${msg.content}")
+          case None => 
+            logger.warn("❌ No final answer found")
+        }
+        
+        // Show execution summary
+        logger.info(s"📊 Summary: ${finalState.logs.size} execution steps")
+        
+      case Left(error) =>
+        logger.error(s"❌ Query failed: $error")
     }
-    
   }
-  
 }

--- a/samples/src/main/scala/org/llm4s/samples/mcp/DemonstrationMCPServer.scala
+++ b/samples/src/main/scala/org/llm4s/samples/mcp/DemonstrationMCPServer.scala
@@ -2,274 +2,398 @@ package org.llm4s.samples.mcp
 
 import com.sun.net.httpserver.{HttpServer, HttpHandler, HttpExchange}
 import java.net.InetSocketAddress
-import java.io.OutputStream
 import org.slf4j.LoggerFactory
 import upickle.default.{read => upickleRead, write => upickleWrite}
 import org.llm4s.mcp._
 import ujson.{Obj, Str, Num, Arr}
 import scala.util.{Try, Success, Failure}
+import java.util.UUID
+import scala.collection.mutable
 
 /**
- * A Sample MCP Server for testing.
- * This server implements SSE interface in line with MCP Spec (2024-11-05) that follows JSON-RPC 2.0 protocol.
+ * MCP Server implementing the 2025-03-26 Streamable HTTP specification.
  * 
- * Runs on port 8080
- * To run: sbt "runMain org.llm4s.samples.mcp.DemonstrationMCPServer"
+ * Key features demonstrated:
+ * - Server-generated session management with Mcp-Session-Id headers  
+ * - Single /mcp endpoint supporting POST, GET, and DELETE methods
+ * - Content negotiation between application/json and text/event-stream
+ * - Automatic protocol version fallback to 2024-11-05
+ * - Stateless and stateful operation modes
+ * 
+ * Run: sbt "samples/runMain org.llm4s.samples.mcp.DemonstrationMCPServer"
  */
 object DemonstrationMCPServer {
   private val logger = LoggerFactory.getLogger(getClass)
-  
+
   def main(args: Array[String]): Unit = {
-    val port = 8080
-    val server = HttpServer.create(new InetSocketAddress(port), 0)
+    val server = HttpServer.create(new InetSocketAddress(8080), 0)
     
-    logger.info(s"🚀 Starting Proper MCP Server on http://localhost:$port")
-    logger.info("Protocol: JSON-RPC 2.0 over HTTP")
-    logger.info("Available tools: get_weather, currency_convert")
-    
-    // Handle MCP endpoint for JSON-RPC communication
-    server.createContext("/sse", new MCPHandler())
-    
+    server.createContext("/mcp", new MCPHandler())
     server.setExecutor(null)
     server.start()
+
+    logger.info("🚀 MCP Server started on http://localhost:8080/mcp")
+    logger.info("✨ 2025-03-26 Streamable HTTP with session management")
+    logger.info("🔧 Available tools: get_weather, currency_convert")
     
-    logger.info("✨ MCP Server ready!")
-    
-    // Keep server running
     Thread.currentThread().join()
   }
+
+  // Session management for 2025-03-26 specification
+  case class Session(
+    id: String, 
+    protocolVersion: String,
+    created: Long = System.currentTimeMillis()
+  )
   
+  object SessionStore {
+    private val sessions = mutable.Map[String, Session]()
+    
+    def createSession(protocolVersion: String): Session = {
+      val session = Session(UUID.randomUUID().toString, protocolVersion)
+      sessions(session.id) = session
+      logger.debug(s"🆔 Created session: ${session.id} for protocol $protocolVersion")
+      session
+    }
+    
+    def getSession(id: String): Option[Session] = sessions.get(id)
+    
+    def removeSession(id: String): Boolean = {
+      val existed = sessions.remove(id).isDefined
+      if (existed) logger.debug(s"🗑️ Removed session: $id")
+      existed
+    }
+    
+    def sessionCount: Int = sessions.size
+  }
+
   class MCPHandler extends HttpHandler {
     override def handle(exchange: HttpExchange): Unit = {
-      if (exchange.getRequestMethod == "POST") {
-        Try {
-          // Read JSON-RPC request
-          val requestBody = scala.io.Source.fromInputStream(exchange.getRequestBody).mkString
-          val jsonRpcRequest = upickleRead[JsonRpcRequest](requestBody)
-          
-          logger.debug(s"📨 Received JSON-RPC request: ${jsonRpcRequest.method} (id: ${jsonRpcRequest.id})")
-          
-          // Handle the JSON-RPC method
-          val response = handleJsonRpcMethod(jsonRpcRequest)
-          
-          // Send JSON-RPC response
-          sendJsonRpcResponse(exchange, response)
-          
-        } match {
-          case Success(_) => // Request handled successfully
-          case Failure(exception) =>
-            logger.error(s"❌ Error handling request: ${exception.getMessage}", exception)
-            val errorResponse = JsonRpcResponse(
-              id = "unknown",
-              error = Some(JsonRpcError(-32700, "Parse error", None))
-            )
-            sendJsonRpcResponse(exchange, errorResponse)
+      val method = exchange.getRequestMethod
+      logger.debug(s"📥 ${method} ${exchange.getRequestURI}")
+
+      try {
+        method match {
+          case "POST" => handlePOST(exchange)
+          case "GET" => handleGET(exchange) 
+          case "DELETE" => handleDELETE(exchange)
+          case _ => sendErrorResponse(exchange, 405, "Method not allowed")
         }
-      } else {
-        sendResponse(exchange, 405, "Method not allowed")
+      } catch {
+        case e: Exception =>
+          logger.error(s"❌ Unhandled error in ${method}: ${e.getMessage}", e)
+          sendErrorResponse(exchange, 500, "Internal server error")
       }
     }
-    
-    private def handleJsonRpcMethod(request: JsonRpcRequest): JsonRpcResponse = {
-      request.method match {
-        case "initialize" =>
-          logger.info("🤝 Handling initialization handshake")
-          val initResponse = InitializeResponse(
-            protocolVersion = "2024-11-05",
-            capabilities = MCPCapabilities(
-              tools = Some(Obj())
-            ),
-            serverInfo = ServerInfo(
-              name = "MCPServer",
-              version = "1.0.0"
-            )
-          )
+
+    private def handlePOST(exchange: HttpExchange): Unit = {
+      val result = for {
+        body <- Try(scala.io.Source.fromInputStream(exchange.getRequestBody).mkString)
+        request <- Try(upickleRead[JsonRpcRequest](body))
+      } yield request
+
+      result match {
+        case Success(request) => 
+          logger.debug(s"📨 Request: ${request.method} (id: ${request.id})")
           
-          JsonRpcResponse(
-            id = request.id,
-            result = Some(upickle.default.writeJs(initResponse))
-          )
+          val sessionId = Option(exchange.getRequestHeaders.getFirst("mcp-session-id"))
           
-        case "tools/list" =>
-          logger.info("📋 Handling tools list request")
-          val tools = Seq(
-            // Weather tool
-            MCPTool(
-              name = "get_weather",
-              description = "Get current weather for any city (MCP version)",
-              inputSchema = Obj(
-                "type" -> Str("object"),
-                "properties" -> Obj(
-                  "location" -> Obj(
-                    "type" -> Str("string"),
-                    "description" -> Str("City name (e.g., 'Paris, France')")
-                  ),
-                  "units" -> Obj(
-                    "type" -> Str("string"),
-                    "description" -> Str("Temperature units (celsius or fahrenheit)"),
-                    "enum" -> Arr(Str("celsius"), Str("fahrenheit"))
-                  )
-                ),
-                "required" -> Arr(Str("location"))
+          request.method match {
+            case "initialize" =>
+              handleInitialize(exchange, request)
+            case "tools/list" =>
+              handleWithSession(exchange, request, sessionId, handleToolsList)
+            case "tools/call" =>
+              handleWithSession(exchange, request, sessionId, handleToolsCall)
+            case _ =>
+              sendJsonRpcError(exchange, request.id, -32601, "Method not found")
+          }
+          
+        case Failure(e) =>
+          logger.error(s"❌ Failed to parse request: ${e.getMessage}")
+          sendJsonRpcError(exchange, "unknown", -32700, "Parse error")
+      }
+    }
+
+    private def handleInitialize(
+      exchange: HttpExchange, 
+      request: JsonRpcRequest
+    ): Unit = {
+      // Parse initialization request
+      val initRequest = request.params.flatMap { params =>
+        Try(upickleRead[InitializeRequest](params.toString)).toOption
+      }.getOrElse(InitializeRequest("2024-11-05", MCPCapabilities(), ClientInfo("unknown", "1.0")))
+
+      // Determine protocol version
+      val clientVersion = initRequest.protocolVersion
+      val protocolVersion = if (clientVersion.startsWith("2025-03-26")) "2025-03-26" else "2024-11-05"
+      
+      logger.info(s"🤝 Initializing with protocol: $protocolVersion")
+
+      // Create session for 2025-03-26 (server-generated session IDs)
+      val sessionOpt = if (protocolVersion == "2025-03-26") {
+        Some(SessionStore.createSession(protocolVersion))
+      } else None
+
+      // Prepare response
+      val response = JsonRpcResponse(
+        id = request.id,
+        result = Some(upickle.default.writeJs(InitializeResponse(
+          protocolVersion = protocolVersion,
+          capabilities = MCPCapabilities(tools = Some(Obj())),
+          serverInfo = ServerInfo(name = "Demo MCP Server", version = "2.0.0")
+        )))
+      )
+
+      // Send response with session header if applicable
+      sendJsonRpcResponse(exchange, response, sessionOpt.map(_.id))
+      
+      sessionOpt.foreach { session =>
+        logger.info(s"🆔 Session created: ${session.id} (total: ${SessionStore.sessionCount})")
+      }
+    }
+
+    private def handleWithSession(
+      exchange: HttpExchange,
+      request: JsonRpcRequest,
+      sessionId: Option[String],
+      handler: JsonRpcRequest => JsonRpcResponse
+    ): Unit = {
+      // For 2025-03-26, validate session if provided
+      sessionId.foreach { id =>
+        SessionStore.getSession(id) match {
+          case Some(session) => 
+            logger.debug(s"✅ Using session: ${session.id}")
+          case None =>
+            logger.warn(s"⚠️ Unknown session: $id")
+        }
+      }
+      
+      val response = handler(request)
+      sendJsonRpcResponse(exchange, response, sessionId)
+    }
+
+    private def handleGET(exchange: HttpExchange): Unit = {
+      // SSE endpoint for real-time communication (2025-03-26 feature)
+      val acceptHeader = Option(exchange.getRequestHeaders.getFirst("Accept")).getOrElse("")
+      
+      if (!acceptHeader.contains("text/event-stream")) {
+        sendErrorResponse(exchange, 406, "GET requires Accept: text/event-stream")
+        return
+      }
+
+      val sessionId = Option(exchange.getRequestHeaders.getFirst("mcp-session-id"))
+      
+      sessionId match {
+        case Some(id) if SessionStore.getSession(id).isDefined =>
+          logger.info(s"📡 Starting SSE stream for session: $id")
+          sendSSEStream(exchange, id)
+        case Some(id) =>
+          sendErrorResponse(exchange, 400, s"Invalid session: $id")
+        case None =>
+          sendErrorResponse(exchange, 400, "Missing mcp-session-id header for SSE")
+      }
+    }
+
+    private def handleDELETE(exchange: HttpExchange): Unit = {
+      // Session termination (2025-03-26 feature)
+      val sessionId = Option(exchange.getRequestHeaders.getFirst("mcp-session-id"))
+      
+      sessionId match {
+        case Some(id) =>
+          if (SessionStore.removeSession(id)) {
+            logger.info(s"🗑️ Session terminated: $id")
+            sendResponse(exchange, 200, "application/json", """{"status":"session_terminated"}""")
+          } else {
+            sendErrorResponse(exchange, 404, "Session not found")
+          }
+        case None =>
+          sendErrorResponse(exchange, 400, "Missing mcp-session-id header")
+      }
+    }
+
+    private def handleToolsList(request: JsonRpcRequest): JsonRpcResponse = {
+      logger.info("📋 Listing tools")
+      
+      val tools = Seq(
+        MCPTool(
+          name = "get_weather",
+          description = "Get current weather for any city",
+          inputSchema = Obj(
+            "type" -> Str("object"),
+            "properties" -> Obj(
+              "city" -> Obj(
+                "type" -> Str("string"),
+                "description" -> Str("City name")
               )
             ),
-            
-            // Currency conversion tool
-            MCPTool(
-              name = "currency_convert",
-              description = "Convert money between currencies",
-              inputSchema = Obj(
-                "type" -> Str("object"),
-                "properties" -> Obj(
-                  "amount" -> Obj(
-                    "type" -> Str("number"),
-                    "description" -> Str("Amount to convert")
-                  ),
-                  "from" -> Obj(
-                    "type" -> Str("string"),
-                    "description" -> Str("Source currency (e.g., 'USD', 'EUR', 'GBP')")
-                  ),
-                  "to" -> Obj(
-                    "type" -> Str("string"),
-                    "description" -> Str("Target currency (e.g., 'USD', 'EUR', 'GBP')")
-                  )
-                ),
-                "required" -> Arr(Str("amount"), Str("from"), Str("to"))
-              )
-            )
-            
+            "required" -> Arr(Str("city"))
           )
-          
-          val toolsResponse = ToolsListResponse(tools)
-          
-          JsonRpcResponse(
-            id = request.id,
-            result = Some(upickle.default.writeJs(toolsResponse))
+        ),
+        MCPTool(
+          name = "currency_convert",
+          description = "Convert between currencies",
+          inputSchema = Obj(
+            "type" -> Str("object"),
+            "properties" -> Obj(
+              "amount" -> Obj("type" -> Str("number")),
+              "from_currency" -> Obj("type" -> Str("string")),
+              "to_currency" -> Obj("type" -> Str("string"))
+            ),
+            "required" -> Arr(Str("amount"), Str("from_currency"), Str("to_currency"))
           )
+        )
+      )
+      
+      JsonRpcResponse(
+        id = request.id,
+        result = Some(upickle.default.writeJs(ToolsListResponse(tools)))
+      )
+    }
+
+    private def handleToolsCall(request: JsonRpcRequest): JsonRpcResponse = {
+      val callRequest = request.params.flatMap { params =>
+        Try(upickleRead[ToolsCallRequest](params.toString)).toOption
+      }
+      
+      callRequest match {
+        case Some(ToolsCallRequest(toolName, args)) =>
+          logger.info(s"🔧 Calling tool: $toolName")
           
-        case "tools/call" =>
-          logger.info("🔧 Handling tool call request")
-          request.params match {
-            case Some(params) =>
-              Try {
-                val toolCallRequest = upickleRead[ToolsCallRequest](params.toString)
-                val toolName = toolCallRequest.name
-                val arguments = toolCallRequest.arguments.getOrElse(Obj())
-                
-                logger.debug(s"   Tool: $toolName")
-                logger.debug(s"   Args: ${arguments.render()}")
-                
-                val result = executeTool(toolName, arguments)
-                val content = Seq(MCPContent("text", result.render()))
-                val toolResponse = ToolsCallResponse(content)
-                
-                JsonRpcResponse(
-                  id = request.id,
-                  result = Some(upickle.default.writeJs(toolResponse))
-                )
-              } match {
-                case Success(response) => response
-                case Failure(e) =>
-                  logger.error(s"   Error parsing tool call: ${e.getMessage}", e)
-                  JsonRpcResponse(
-                    id = request.id,
-                    error = Some(JsonRpcError(-32602, "Invalid params", Some(Str(e.getMessage))))
-                  )
+                    toolName match {
+            case "get_weather" =>
+              val city = args match {
+                case Some(ujson.Obj(obj)) => obj.get("city") match {
+                  case Some(ujson.Str(city)) => city
+                  case Some(value) => value.toString
+                  case None => "Unknown"
+                }
+                case _ => "Unknown"
               }
-              
-            case None =>
               JsonRpcResponse(
                 id = request.id,
-                error = Some(JsonRpcError(-32602, "Invalid params", None))
+                result = Some(upickle.default.writeJs(ToolsCallResponse(
+                  content = Seq(MCPContent(
+                    `type` = "text",
+                    text = s"🌤️ Weather in $city: 20°C, partly cloudy (MCP server response)"
+                  ))
+                )))
+              )
+              
+             case "currency_convert" =>
+               args match {
+                 case Some(ujson.Obj(obj)) =>
+                   val amount = obj.get("amount") match {
+                     case Some(ujson.Num(value)) => value
+                     case Some(value) => value.toString.toDoubleOption.getOrElse(0.0)
+                     case None => 0.0
+                   }
+                   val from = obj.get("from_currency") match {
+                     case Some(ujson.Str(value)) => value
+                     case Some(value) => value.toString
+                     case None => "USD"
+                   }
+                   val to = obj.get("to_currency") match {
+                     case Some(ujson.Str(value)) => value
+                     case Some(value) => value.toString
+                     case None => "EUR"
+                   }
+                   val converted = amount * 0.85 // Mock conversion rate
+                   
+                   JsonRpcResponse(
+                     id = request.id,
+                     result = Some(upickle.default.writeJs(ToolsCallResponse(
+                       content = Seq(MCPContent(
+                         `type` = "text", 
+                         text = s"💱 $amount $from = ${converted} $to"
+                       ))
+                     )))
+                   )
+                 case _ =>
+                   JsonRpcResponse(
+                     id = request.id,
+                     error = Some(JsonRpcError(-32602, "Invalid currency conversion arguments", None))
+                   )
+               }
+              
+            case _ =>
+              JsonRpcResponse(
+                id = request.id,
+                error = Some(JsonRpcError(-32602, s"Unknown tool: $toolName", None))
               )
           }
           
-        case _ =>
-          logger.warn(s"❓ Unknown method: ${request.method}")
+        case None =>
           JsonRpcResponse(
             id = request.id,
-            error = Some(JsonRpcError(-32601, "Method not found", None))
+            error = Some(JsonRpcError(-32602, "Invalid tool call parameters", None))
           )
       }
     }
-    
-    private def executeTool(toolName: String, arguments: ujson.Value): ujson.Value = {
-      toolName match {
-        case "get_weather" =>
-          val location = arguments("location").str
-          val units = arguments.obj.get("units").map(_.str).getOrElse("celsius")
-          val temp = if (units == "fahrenheit") 70 else 20
-          
-          Obj(
-            "location" -> Str(location),
-            "temperature" -> Num(temp),
-            "units" -> Str(units),
-            "conditions" -> Str("Partly cloudy (from MCP server)"),
-            "humidity" -> Str("65%"),
-            "wind" -> Str("8 mph"),
-            "source" -> Str("MCP server")
-          )
-          
-        case "currency_convert" =>
-          val amount = arguments("amount").num
-          val from = arguments("from").str.toUpperCase
-          val to = arguments("to").str.toUpperCase
-          
-          // Simple exchange rate lookup table
-          val exchangeRates = Map(
-            ("USD", "EUR") -> 0.85,
-            ("EUR", "USD") -> 1.18,
-            ("USD", "GBP") -> 0.75,
-            ("GBP", "USD") -> 1.33,
-            ("EUR", "GBP") -> 0.88,
-            ("GBP", "EUR") -> 1.14,
-            ("USD", "JPY") -> 110.0,
-            ("JPY", "USD") -> 0.009
-          )
-          
-          exchangeRates.get((from, to)) match {
-            case Some(rate) =>
-              // Success response
-              Obj(
-                "success" -> ujson.True,
-                "original_amount" -> Num(amount),
-                "from_currency" -> Str(from),
-                "to_currency" -> Str(to),
-                "converted_amount" -> Num(amount * rate),
-                "exchange_rate" -> Num(rate),
-                "source" -> Str("MCP server currency API")
-              )
-            case None =>
-              // Error response for unsupported pairs
-              Obj(
-                "success" -> ujson.False,
-                "error" -> Str("UNSUPPORTED_CURRENCY_PAIR"),
-                "message" -> Str(s"Currency conversion from $from to $to is not supported"),
-                "from_currency" -> Str(from),
-                "to_currency" -> Str(to),
-                "supported_currencies" -> Arr(Str("USD"), Str("EUR"), Str("GBP"), Str("JPY")),
-                "source" -> Str("MCP server currency API")
-              )
-          }
-        
-        case _ =>
-          Obj("error" -> Str(s"Unknown tool: $toolName"))
-      }
-    }
-    
-    private def sendJsonRpcResponse(exchange: HttpExchange, response: JsonRpcResponse): Unit = {
-      val responseJson = upickleWrite(response)
-      exchange.getResponseHeaders.set("Content-Type", "application/json")
-      sendResponse(exchange, 200, responseJson)
+
+    private def sendJsonRpcResponse(
+      exchange: HttpExchange, 
+      response: JsonRpcResponse, 
+      sessionId: Option[String] = None
+    ): Unit = {
+      val json = upickleWrite(response)
       
-      logger.debug(s"📤 Sent JSON-RPC response (id: ${response.id})")
+      // Set session header if provided (before sendResponseHeaders)
+      sessionId.foreach(id => exchange.getResponseHeaders.set("mcp-session-id", id))
+      
+      sendResponse(exchange, 200, "application/json", json)
     }
-    
-    private def sendResponse(exchange: HttpExchange, status: Int, response: String): Unit = {
-      exchange.sendResponseHeaders(status, response.length)
-      val os: OutputStream = exchange.getResponseBody
-      os.write(response.getBytes)
-      os.close()
+
+    private def sendJsonRpcError(
+      exchange: HttpExchange, 
+      id: String, 
+      code: Int, 
+      message: String
+    ): Unit = {
+      val error = JsonRpcResponse(
+        id = id,
+        error = Some(JsonRpcError(code, message, None))
+      )
+      sendJsonRpcResponse(exchange, error)
+    }
+
+    private def sendSSEStream(exchange: HttpExchange, sessionId: String): Unit = {
+      exchange.getResponseHeaders.set("Content-Type", "text/event-stream")
+      exchange.getResponseHeaders.set("Cache-Control", "no-cache")
+      exchange.getResponseHeaders.set("Connection", "keep-alive")
+      exchange.getResponseHeaders.set("mcp-session-id", sessionId)
+      
+      val sseData = 
+        ": SSE stream opened\n\n" +
+        "data: {\"jsonrpc\":\"2.0\",\"method\":\"notification/stream_started\",\"params\":{\"session\":\"" + sessionId + "\"}}\n\n"
+      
+      sendResponse(exchange, 200, "text/event-stream", sseData)
+    }
+
+    private def sendErrorResponse(exchange: HttpExchange, code: Int, message: String): Unit = {
+      sendResponse(exchange, code, "text/plain", message)
+    }
+
+    private def sendResponse(
+      exchange: HttpExchange, 
+      statusCode: Int, 
+      contentType: String, 
+      body: String
+    ): Unit = {
+      val bytes = body.getBytes("UTF-8")
+      
+      exchange.getResponseHeaders.set("Content-Type", contentType)
+      exchange.getResponseHeaders.set("Content-Length", bytes.length.toString)
+      
+      exchange.sendResponseHeaders(statusCode, bytes.length.toLong)
+      
+      val outputStream = exchange.getResponseBody
+      try {
+        outputStream.write(bytes)
+        outputStream.flush()
+      } finally {
+        outputStream.close()
+      }
     }
   }
-}
+} 

--- a/samples/src/main/scala/org/llm4s/samples/mcp/MCPToolExample.scala
+++ b/samples/src/main/scala/org/llm4s/samples/mcp/MCPToolExample.scala
@@ -1,0 +1,107 @@
+package org.llm4s.samples.mcp
+
+import org.llm4s.mcp._
+import org.llm4s.toolapi._
+import org.llm4s.toolapi.tools._
+import org.slf4j.LoggerFactory
+import scala.concurrent.duration._
+
+/**
+ * Example demonstrating basic MCP tool usage with automatic fallback
+ * 
+ * This example shows how to use MCP tools directly via the tool registry.
+ * The client automatically detects the best transport protocol with fallback.
+ * 
+ * Start the MCPServer first: sbt "samples/runMain org.llm4s.samples.mcp.DemonstrationMCPServer"
+ * Then run: sbt "samples/runMain org.llm4s.samples.mcp.MCPToolExample"
+ */
+object MCPToolExample {
+  private val logger = LoggerFactory.getLogger(getClass)
+  
+  def main(args: Array[String]): Unit = {
+    logger.info("🚀 MCP Tool Example - Basic MCP Tool Usage")
+    
+    // Create MCP server configuration (automatically tries latest protocol with fallback)
+    val serverConfig = MCPServerConfig.streamableHTTP(
+      name = "mcp-tools-server",
+      url = "http://localhost:8080/mcp",
+      timeout = 30.seconds
+    )
+    
+    // Create local weather tool for comparison
+    val localWeatherTool = WeatherTool.tool
+    
+    // Create MCP registry combining local and MCP tools
+    val mcpRegistry = new MCPToolRegistry(
+      mcpServers = Seq(serverConfig),
+      localTools = Seq(localWeatherTool),
+      cacheTTL = 5.minutes
+    )
+    
+    // Show all available tools
+    val allTools = mcpRegistry.getAllTools
+    logger.info(s"📦 Available tools (${allTools.size} total):")
+    allTools.zipWithIndex.foreach { case (tool, index) =>
+      val source = if (tool.description.contains("local")) "local" else "MCP"
+      logger.info(s"   ${index + 1}. ${tool.name} ($source): ${tool.description}")
+    }
+    logger.info("ℹ️  Note: Local tools take precedence over MCP tools with same name")
+    
+    // Test the tools
+    runToolTests(mcpRegistry)
+    
+    // Clean up
+    mcpRegistry.closeMCPClients()
+    logger.info("✨ Example completed!")
+  }
+  
+  private def runToolTests(registry: MCPToolRegistry): Unit = {
+    logger.info("🧪 Testing MCP tools:")
+    
+    // Test 1: Weather tool (local version)
+    logger.info("1️⃣ Testing local weather tool:")
+    val localWeatherRequest = ToolCallRequest(
+      functionName = "get_weather",
+      arguments = ujson.Obj(
+        "location" -> ujson.Str("London, UK"),
+        "units" -> ujson.Str("celsius")
+      )
+    )
+    
+    executeAndLog(registry, localWeatherRequest, "   ")
+    
+    // Test 2: Currency conversion (MCP tool)
+    logger.info("2️⃣ Testing MCP currency conversion:")
+    val currencyRequest = ToolCallRequest(
+      functionName = "currency_convert",
+      arguments = ujson.Obj(
+        "amount" -> ujson.Num(100),
+        "from_currency" -> ujson.Str("USD"),
+        "to_currency" -> ujson.Str("EUR")
+      )
+    )
+    
+    executeAndLog(registry, currencyRequest, "   ")
+    
+    // Test 3: Weather tool (local tool will be used due to name conflict)
+    logger.info("3️⃣ Testing weather tool (local tool takes precedence):")
+    val mcpWeatherRequest = ToolCallRequest(
+      functionName = "get_weather",
+      arguments = ujson.Obj(
+        "location" -> ujson.Str("Tokyo, Japan"),
+        "units" -> ujson.Str("celsius")
+      )
+    )
+    
+    executeAndLog(registry, mcpWeatherRequest, "   ")
+  }
+  
+  private def executeAndLog(registry: MCPToolRegistry, request: ToolCallRequest, indent: String): Unit = {
+    registry.execute(request) match {
+      case Right(result) =>
+        logger.info(s"${indent}✅ Success: ${result.render()}")
+      case Left(error) =>
+        logger.error(s"${indent}❌ Failed: $error")
+    }
+  }
+}

--- a/src/main/scala/org/llm4s/mcp/MCPClientImpl.scala
+++ b/src/main/scala/org/llm4s/mcp/MCPClientImpl.scala
@@ -10,25 +10,83 @@ import scala.util.{ Failure, Success, Try }
 /**
  * Implementation of MCP client that connects to and communicates with MCP servers.
  * Handles JSON-RPC communication, tool discovery, and execution delegation.
+ * Supports both 2025-03-26 (Streamable HTTP) and 2024-11-05 (HTTP+SSE) transports.
  */
 class MCPClientImpl(config: MCPServerConfig) extends MCPClient {
   private val logger      = LoggerFactory.getLogger(getClass)
-  private val transport   = MCPTransport.create(config)
+  private var transport: Option[MCPTransportImpl] = None
   private val requestId   = new AtomicLong(0)
   private var initialized = false
+  private var protocolVersion = "2025-03-26" // Start with latest version
 
   logger.info(s"MCPClientImpl created for server: ${config.name}")
 
-  // Performs MCP protocol handshake with the server
-  override def initialize(): Either[String, Unit] = {
-    if (initialized) return Right(())
+  // Initialize transport with backward compatibility detection
+  private def initializeTransport(): Either[String, MCPTransportImpl] = {
+    transport match {
+      case Some(t) => Right(t)
+      case None =>
+        config.transport match {
+          case StreamableHTTPTransport(url, name) =>
+            tryHttpTransportWithFallback(url, name)
+          case SSETransport(url, name) =>
+            tryHttpTransportWithFallback(url, name)
+          case StdioTransport(command, name) =>
+            // Stdio transport remains unchanged
+            val stdioTransport = new StdioTransportImpl(command, name)
+            transport = Some(stdioTransport)
+            Right(stdioTransport)
+        }
+    }
+  }
 
-    val initRequest = JsonRpcRequest(
+  // Unified HTTP transport logic: try Streamable HTTP first, fallback to SSE
+  private def tryHttpTransportWithFallback(url: String, name: String): Either[String, MCPTransportImpl] = {
+    // Try new 2025-03-26 Streamable HTTP transport first
+    logger.info(s"Attempting to connect using Streamable HTTP transport (2025-03-26) to $url")
+    val newTransport = new StreamableHTTPTransportImpl(url, name)
+    
+    // Test with a simple initialize request
+    val testRequest = createInitializeRequest("2025-03-26")
+    newTransport.sendRequest(testRequest) match {
+      case Right(_) =>
+        logger.info(s"Successfully connected using Streamable HTTP transport (2025-03-26)")
+        transport = Some(newTransport)
+        protocolVersion = "2025-03-26"
+        Right(newTransport)
+      case Left(error) if error.contains("405") || error.contains("404") =>
+        // Server doesn't support new transport, try fallback
+        logger.info(s"Server doesn't support Streamable HTTP, attempting fallback to HTTP+SSE (2024-11-05)")
+        newTransport.close()
+        
+        // Try old transport
+        val oldTransport = new SSETransportImpl(url, name)
+        val oldTestRequest = createInitializeRequest("2024-11-05")
+        oldTransport.sendRequest(oldTestRequest) match {
+          case Right(_) =>
+            logger.info(s"Successfully connected using HTTP+SSE transport (2024-11-05)")
+            transport = Some(oldTransport)
+            protocolVersion = "2024-11-05"
+            Right(oldTransport)
+          case Left(fallbackError) =>
+            logger.error(s"Both transport methods failed. New: $error, Old: $fallbackError")
+            oldTransport.close()
+            Left(s"Failed to connect with both transports. Latest error: $fallbackError")
+        }
+      case Left(error) =>
+        logger.error(s"Failed to connect using Streamable HTTP transport: $error")
+        newTransport.close()
+        Left(error)
+    }
+  }
+
+  private def createInitializeRequest(version: String): JsonRpcRequest = {
+    JsonRpcRequest(
       id = generateId(),
-      method = "initialize", // method value for handshake/setup
+      method = "initialize",
       params = Some(
         ujson.Obj(
-          "protocolVersion" -> ujson.Str("2024-11-05"), // consider switching to 2025-03-26 (without sse)
+          "protocolVersion" -> ujson.Str(version),
           "capabilities" -> ujson.Obj(
             "tools" -> ujson.Obj()
           ),
@@ -39,26 +97,40 @@ class MCPClientImpl(config: MCPServerConfig) extends MCPClient {
         )
       )
     )
+  }
 
-    transport.sendRequest(initRequest) match {
-      case Right(response) =>
-        response.result match {
-          case Some(result) =>
-            Try {
-              val protocolVersion = result("protocolVersion").str
-              // Validate protocol version compatibility
-              if (protocolVersion.startsWith("2024-") || protocolVersion.startsWith("2025-")) {
-                initialized = true
-                Right(())
-              } else {
-                Left(s"Unsupported protocol version: $protocolVersion")
-              }
-            }.getOrElse(Left("Invalid initialization response format"))
-          case None =>
-            Left("Initialize request failed: no result in response")
+  // Performs MCP protocol handshake with the server
+  override def initialize(): Either[String, Unit] = {
+    if (initialized) {
+      Right(())
+    } else {
+      initializeTransport().flatMap { transportImpl =>
+        val initRequest = createInitializeRequest(protocolVersion)
+
+        transportImpl.sendRequest(initRequest) match {
+          case Right(response) =>
+            response.result match {
+              case Some(result) =>
+                Try {
+                  val serverProtocolVersion = result("protocolVersion").str
+                  logger.info(s"Server supports protocol version: $serverProtocolVersion")
+                  
+                  // Validate protocol version compatibility
+                  if (serverProtocolVersion.startsWith("2024-") || serverProtocolVersion.startsWith("2025-")) {
+                    initialized = true
+                    logger.info(s"Successfully initialized MCP client for ${config.name} with protocol $serverProtocolVersion")
+                    Right(())
+                  } else {
+                    Left(s"Unsupported protocol version: $serverProtocolVersion")
+                  }
+                }.getOrElse(Left("Invalid initialization response format"))
+              case None =>
+                Left("Initialize request failed: no result in response")
+            }
+          case Left(errorMsg) =>
+            Left(s"Initialize request failed: $errorMsg")
         }
-      case Left(errorMsg) =>
-        Left(s"Initialize request failed: $errorMsg")
+      }
     }
   }
 
@@ -68,44 +140,50 @@ class MCPClientImpl(config: MCPServerConfig) extends MCPClient {
     initialize() match {
       case Left(errorMsg) =>
         logger.error(s"Failed to initialize MCP client for ${config.name}: $errorMsg")
-        return Seq.empty
-      case Right(_) => // Continue
-    }
+        Seq.empty
+      case Right(_) => 
+        transport match {
+          case Some(transportImpl) =>
+            val listRequest = JsonRpcRequest(
+              id = generateId(),
+              method = "tools/list", // method value for getting available tools
+              params = None
+            )
 
-    val listRequest = JsonRpcRequest(
-      id = generateId(),
-      method = "tools/list", // method value for getting available tools
-      params = None
-    )
-
-    transport.sendRequest(listRequest) match {
-      case Right(response) =>
-        response.result match {
-          case Some(result) =>
-            Try {
-              val toolsData = result("tools").arr
-              toolsData.map(convertMCPToolToToolFunction).toSeq
-            } match {
-              case Success(tools) =>
-                logger.info(s"Successfully retrieved ${tools.size} tools from ${config.name}")
-                tools
-              case Failure(exception) =>
-                logger.error(s"Failed to parse tools from ${config.name}: ${exception.getMessage}", exception)
+            transportImpl.sendRequest(listRequest) match {
+              case Right(response) =>
+                response.result match {
+                  case Some(result) =>
+                    Try {
+                      val toolsData = result("tools").arr
+                      toolsData.map(convertMCPToolToToolFunction).toSeq
+                    } match {
+                      case Success(tools) =>
+                        logger.info(s"Successfully retrieved ${tools.size} tools from ${config.name}")
+                        tools
+                      case Failure(exception) =>
+                        logger.error(s"Failed to parse tools from ${config.name}: ${exception.getMessage}", exception)
+                        Seq.empty
+                    }
+                  case None =>
+                    logger.warn(s"No tools result from ${config.name}")
+                    Seq.empty
+                }
+              case Left(errorMsg) =>
+                logger.error(s"Failed to fetch tools from ${config.name}: $errorMsg")
                 Seq.empty
             }
           case None =>
-            logger.warn(s"No tools result from ${config.name}")
+            logger.error(s"No transport available for ${config.name}")
             Seq.empty
         }
-      case Left(errorMsg) =>
-        logger.error(s"Failed to fetch tools from ${config.name}: $errorMsg")
-        Seq.empty
     }
   }
 
   // Closes the transport connection and resets initialization state
   override def close(): Unit = {
-    transport.close()
+    transport.foreach(_.close())
+    transport = None
     initialized = false
   }
 
@@ -190,42 +268,47 @@ class MCPClientImpl(config: MCPServerConfig) extends MCPClient {
 
   // Creates tool execution handler that delegates to MCP server
   private def createMCPToolHandler(toolName: String): SafeParameterExtractor => Either[String, Value] = { params =>
-    val callRequest = JsonRpcRequest(
-      id = generateId(),
-      method = "tools/call", // method value for executing a specific tool
-      params = Some(
-        ujson.Obj(
-          "name"      -> ujson.Str(toolName),
-          "arguments" -> params.params
+    transport match {
+      case Some(transportImpl) =>
+        val callRequest = JsonRpcRequest(
+          id = generateId(),
+          method = "tools/call", // method value for executing a specific tool
+          params = Some(
+            ujson.Obj(
+              "name"      -> ujson.Str(toolName),
+              "arguments" -> params.params
+            )
+          )
         )
-      )
-    )
 
-    transport.sendRequest(callRequest) match {
-      case Right(response) =>
-        response.result match {
-          case Some(result) =>
-            Try {
-              // MCP returns content array with text results
-              val content = result("content").arr
-              if (content.nonEmpty) {
-                val firstContent = content(0)
-                val text         = firstContent("text").str
+        transportImpl.sendRequest(callRequest) match {
+          case Right(response) =>
+            response.result match {
+              case Some(result) =>
+                Try {
+                  // MCP returns content array with text results
+                  val content = result("content").arr
+                  if (content.nonEmpty) {
+                    val firstContent = content(0)
+                    val text         = firstContent("text").str
 
-                // Try to parse as JSON, fallback to string result
-                Try(ujsonRead(text)).getOrElse(ujson.Str(text))
-              } else {
-                ujson.Obj("result" -> ujson.Str("No content returned"))
-              }
-            } match {
-              case Success(parsed) => Right(parsed)
-              case Failure(e)      => Left(s"Failed to parse tool result: ${e.getMessage}")
+                    // Try to parse as JSON, fallback to string result
+                    Try(ujsonRead(text)).getOrElse(ujson.Str(text))
+                  } else {
+                    ujson.Obj("result" -> ujson.Str("No content returned"))
+                  }
+                } match {
+                  case Success(parsed) => Right(parsed)
+                  case Failure(e)      => Left(s"Failed to parse tool result: ${e.getMessage}")
+                }
+              case None =>
+                Left("Tool call failed: no result")
             }
-          case None =>
-            Left("Tool call failed: no result")
+          case Left(errorMsg) =>
+            Left(s"Tool call failed: $errorMsg")
         }
-      case Left(errorMsg) =>
-        Left(s"Tool call failed: $errorMsg")
+      case None =>
+        Left("No transport available")
     }
   }
 }

--- a/src/main/scala/org/llm4s/mcp/MCPClientImpl.scala
+++ b/src/main/scala/org/llm4s/mcp/MCPClientImpl.scala
@@ -10,14 +10,14 @@ import scala.util.{ Failure, Success, Try }
 /**
  * Implementation of MCP client that connects to and communicates with MCP servers.
  * Handles JSON-RPC communication, tool discovery, and execution delegation.
- * Supports both 2025-03-26 (Streamable HTTP) and 2024-11-05 (HTTP+SSE) transports.
+ * Supports both 2025-06-18 (Streamable HTTP) and 2024-11-05 (HTTP+SSE) transports.
  */
 class MCPClientImpl(config: MCPServerConfig) extends MCPClient {
   private val logger      = LoggerFactory.getLogger(getClass)
   private var transport: Option[MCPTransportImpl] = None
   private val requestId   = new AtomicLong(0)
   private var initialized = false
-  private var protocolVersion = "2025-03-26" // Start with latest version
+  private var protocolVersion = "2025-06-18" // Updated to latest version
 
   logger.info(s"MCPClientImpl created for server: ${config.name}")
 
@@ -42,17 +42,17 @@ class MCPClientImpl(config: MCPServerConfig) extends MCPClient {
 
   // Unified HTTP transport logic: try Streamable HTTP first, fallback to SSE
   private def tryHttpTransportWithFallback(url: String, name: String): Either[String, MCPTransportImpl] = {
-    // Try new 2025-03-26 Streamable HTTP transport first
-    logger.info(s"Attempting to connect using Streamable HTTP transport (2025-03-26) to $url")
+    // Try new 2025-06-18 Streamable HTTP transport first
+    logger.info(s"Attempting to connect using Streamable HTTP transport (2025-06-18) to $url")
     val newTransport = new StreamableHTTPTransportImpl(url, name)
     
     // Test with a simple initialize request
-    val testRequest = createInitializeRequest("2025-03-26")
+    val testRequest = createInitializeRequest("2025-06-18")
     newTransport.sendRequest(testRequest) match {
       case Right(_) =>
-        logger.info(s"Successfully connected using Streamable HTTP transport (2025-03-26)")
+        logger.info(s"Successfully connected using Streamable HTTP transport (2025-06-18)")
         transport = Some(newTransport)
-        protocolVersion = "2025-03-26"
+        protocolVersion = "2025-06-18"
         Right(newTransport)
       case Left(error) if error.contains("405") || error.contains("404") =>
         // Server doesn't support new transport, try fallback

--- a/src/main/scala/org/llm4s/mcp/MCPServerConfig.scala
+++ b/src/main/scala/org/llm4s/mcp/MCPServerConfig.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
  * Defines how to connect to and communicate with an MCP server.
  *
  * @param name Unique identifier for this server configuration
- * @param transport Transport mechanism (stdio or SSE) for communication
+ * @param transport Transport mechanism (stdio, SSE, or Streamable HTTP) for communication
  * @param timeout Maximum time to wait for server responses
  */
 case class MCPServerConfig(
@@ -32,13 +32,27 @@ object MCPServerConfig {
     MCPServerConfig(name, StdioTransport(command, name), timeout)
 
   /**
-   * Creates configuration for SSE-based MCP server.
+   * Creates configuration for Streamable HTTP-based MCP server (2025-03-26 spec).
+   * Connects to server via HTTP with support for SSE streaming.
+   * The client will automatically try this transport first, then fallback to SSE if not supported.
+   *
+   * @param name Unique identifier for this server
+   * @param url HTTP URL of the MCP endpoint (single endpoint for both POST and GET)
+   * @param timeout Maximum response timeout
+   * @return MCPServerConfig configured for Streamable HTTP transport with automatic fallback
+   */
+  def streamableHTTP(name: String, url: String, timeout: Duration = 30.seconds): MCPServerConfig =
+    MCPServerConfig(name, StreamableHTTPTransport(url, name), timeout)
+
+  /**
+   * Creates configuration for SSE-based MCP server (legacy 2024-11-05 spec).
    * Connects to server via HTTP Server-Sent Events.
+   * The client will still try the latest transport first, then fallback to this if needed.
    *
    * @param name Unique identifier for this server
    * @param url HTTP URL of the SSE endpoint
    * @param timeout Maximum response timeout
-   * @return MCPServerConfig configured for SSE transport
+   * @return MCPServerConfig configured for SSE transport with automatic upgrade attempt
    */
   def sse(name: String, url: String, timeout: Duration = 30.seconds): MCPServerConfig =
     MCPServerConfig(name, SSETransport(url, name), timeout)

--- a/src/main/scala/org/llm4s/mcp/MCPTypes.scala
+++ b/src/main/scala/org/llm4s/mcp/MCPTypes.scala
@@ -161,15 +161,68 @@ case class ToolsCallResponse(
 )
 
 /**
- * Individual content item within a tool response.
+ * Enhanced content item within a tool response (PR #371 - Structured Tool Output).
+ * Supports text, resource links, and structured annotations.
  *
- * @param `type` Content type, typically "text"
- * @param text The actual content text
+ * @param `type` Content type: "text", "resource", "image", etc.
+ * @param text The actual content text (for text type)
+ * @param resource Resource reference (for resource type)
+ * @param annotations Optional structured metadata
  */
 case class MCPContent(
   `type`: String,
-  text: String
+  text: Option[String] = None,
+  resource: Option[ResourceReference] = None,
+  annotations: Option[ujson.Value] = None
 )
+
+/**
+ * Reference to an MCP resource (PR #603 - Resource links in tool results).
+ *
+ * @param uri URI of the referenced resource
+ * @param `type` Optional MIME type or resource type
+ */
+case class ResourceReference(
+  uri: String,
+  `type`: Option[String] = None
+)
+
+/**
+ * Standard JSON-RPC and MCP-specific error codes.
+ */
+object MCPErrorCodes {
+  // Standard JSON-RPC 2.0 error codes
+  val PARSE_ERROR = -32700
+  val INVALID_REQUEST = -32600
+  val METHOD_NOT_FOUND = -32601
+  val INVALID_PARAMS = -32602
+  val INTERNAL_ERROR = -32603
+  
+  // MCP-specific error codes (range -32000 to -32099)
+  val INVALID_PROTOCOL_VERSION = -32000
+  val TOOL_NOT_FOUND = -32001
+  val TOOL_EXECUTION_ERROR = -32002
+  val SESSION_EXPIRED = -32003
+  val UNAUTHORIZED = -32004
+  val RESOURCE_NOT_FOUND = -32005
+  
+  def getErrorMessage(code: Int): String = code match {
+    case PARSE_ERROR => "Parse error"
+    case INVALID_REQUEST => "Invalid Request"
+    case METHOD_NOT_FOUND => "Method not found"
+    case INVALID_PARAMS => "Invalid params"
+    case INTERNAL_ERROR => "Internal error"
+    case INVALID_PROTOCOL_VERSION => "Invalid protocol version"
+    case TOOL_NOT_FOUND => "Tool not found"
+    case TOOL_EXECUTION_ERROR => "Tool execution error"
+    case SESSION_EXPIRED => "Session expired"
+    case UNAUTHORIZED => "Unauthorized"
+    case RESOURCE_NOT_FOUND => "Resource not found"
+    case _ => s"Unknown error ($code)"
+  }
+}
+
+
 
 // Serialization support for JSON marshalling/unmarshalling
 object JsonRpcRequest {
@@ -222,4 +275,8 @@ object ToolsCallResponse {
 
 object MCPContent {
   implicit val rw: ReadWriter[MCPContent] = macroRW
+}
+
+object ResourceReference {
+  implicit val rw: ReadWriter[ResourceReference] = macroRW
 }


### PR DESCRIPTION
This PR aims to update the MCP connector with the latest spec (2025-06-18) with Streamable HTTP Transport Protocol:

**Summary**

Adds complete MCP (Model Context Protocol) server and client implementation supporting the latest 2025-06-18 Streamable HTTP specification with automatic fallback to legacy protocols.

**Key Changes**

-New Transport Protocol: Implements Streamable HTTP (2025-06-18) with single endpoint, session management, and protocol headers

-Automatic Fallback: Seamless fallback from 2025-06-18 to 2024-11-05 HTTP+SSE when servers don't support newer protocol

-Session Management: Server-generated sessions with mcp-session-id headers for stateful operations

-Protocol Compliance: Supports 2025-06-18, 2025-03-26, and 2024-11-05 specifications with proper JSON-RPC 2.0 handling

The examples have also been adapted to the new spec.


