### PR TITLE
Refactored claude code review: OIDC + GITHUB_TOKEN fallback on forked/external PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -97,10 +97,10 @@ jobs:
             echo "🔒 Trusted PR detected - will run full Claude review"
           else
             echo "trusted=false" >> $GITHUB_OUTPUT
-            echo "⚠️ External PR detected - will post notification only"
+            echo "⚠️ External PR detected - will post notification comment"
           fi
 
-      # For trusted PRs: checkout the PR branch and run Claude review
+      # For trusted PRs: checkout PR branch and run full Claude review
       - name: Checkout PR (Trusted)
         if: steps.pr-type.outputs.trusted == 'true'
         uses: actions/checkout@v4
@@ -114,6 +114,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Optional: Specify model (defaults to Claude Sonnet 4)
+          # model: "claude-opus-4-20250514"
+
           direct_prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
@@ -126,8 +129,8 @@ jobs:
 
           use_sticky_comment: true
 
-      # For external PRs: checkout main branch only (security) and post comment
-      - name: Checkout Main Branch (External)
+      # For external PRs: checkout main branch only (security) and post notification
+      - name: Checkout Main Branch (External - Security)
         if: steps.pr-type.outputs.trusted == 'false'
         uses: actions/checkout@v4
         with:
@@ -136,38 +139,29 @@ jobs:
 
       - name: Comment on External PR
         if: steps.pr-type.outputs.trusted == 'false'
-        uses: actions/github-script@v7
+        uses: thollander/actions-comment-pull-request@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const comment = `## 🔒 Claude Code Review Status
+          message: |
+            ## 🔒 Claude Code Review Status
             
-            Thank you for your contribution! This PR is from an external repository (\`${{ github.event.pull_request.head.repo.full_name }}\`), so automated Claude review is disabled for security reasons.
+            Thank you for your contribution! This PR is from an external repository (`${{ github.event.pull_request.head.repo.full_name }}`), so automated Claude review is disabled for security reasons.
             
             **For maintainers:** To get Claude review for this PR, run:
-            \`\`\`bash
+            ```bash
             gh workflow run "Claude Code Review" -f pr_number=${{ github.event.pull_request.number }}
-            \`\`\`
+            ```
             
-            Or comment \`@claude\` to trigger manual review via the regular workflow.
+            Or comment `@claude` to trigger manual review via the regular workflow.
             
             **PR Summary:**
             - Files changed: ${{ github.event.pull_request.changed_files }}
             - Additions: +${{ github.event.pull_request.additions }}
             - Deletions: -${{ github.event.pull_request.deletions }}
             - Author: @${{ github.event.pull_request.user.login }}
-            - Source: \`${{ github.event.pull_request.head.repo.full_name }}:${{ github.event.pull_request.head.ref }}\`
+            - Source: `${{ github.event.pull_request.head.repo.full_name }}:${{ github.event.pull_request.head.ref }}`
             
             ---
-            *This comment was posted automatically to inform about the review status.*
-            `;
-            
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
+            *This comment was posted automatically.*
 
   # Manual trigger job for maintainers to review external PRs
   claude-review-manual:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Log External PR Info
         run: |
           echo "::notice::External PR detected - Claude review skipped for security"
-          echo "## 🔒 External PR - Claude Review Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "## 🔒 External PR - Claude review skipped for security reasons" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "This PR is from an external repository (\`${{ github.event.pull_request.head.repo.full_name }}\`)." >> $GITHUB_STEP_SUMMARY
           echo "Automated Claude review is disabled for security reasons." >> $GITHUB_STEP_SUMMARY
@@ -173,12 +173,12 @@ jobs:
             
               Thank you for your contribution! This PR is from an external repository, so automated Claude review is disabled for security reasons.
             
-              **For maintainers:** To get Claude review for this PR, run:
+              **For maintainers:** To get Claude review for this PR:
+              Comment \`@claude\` in the regular workflow to trigger manual review.
+              Or run:
               \`\`\`bash
               gh workflow run claude-code-review.yml -f pr_number=${{ github.event.pull_request.number }}
               \`\`\`
-            
-              Or comment \`@claude\` in the regular workflow to trigger manual review.
             
               **PR Summary:**
               - Files changed: ${{ github.event.pull_request.changed_files }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,7 +17,7 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    if: false # Just temporary to skip this job as we want to test the below jobs
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -75,4 +75,132 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
+
+  # Job for trusted PRs (from same repo or collaborators)
+  claude-code-review-trusted-oidc:
+    if: |
+      github.event_name == 'pull_request' && (
+        github.event.pull_request.head.repo.full_name == github.repository ||
+        github.event.pull_request.author_association == 'COLLABORATOR' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'OWNER'
+      )
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run claude code review (OIDC)
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
+          # model: "claude-opus-4-20250514"
+
+          direct_prompt: |
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+            
+            Be constructive and helpful in your feedback.
+
+          use_sticky_comment: true
+
+  # Job for external/forked PRs (no OIDC available)
+  claude-review-external:
+    if: |
+      github.event_name == 'pull_request' && (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        github.event.pull_request.author_association != 'COLLABORATOR' &&
+        github.event.pull_request.author_association != 'MEMBER' &&
+        github.event.pull_request.author_association != 'OWNER'
+      )
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Comment on External PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const comment = `## 🤖 Claude code review status
+            
+            Thank you for your contribution! This PR is from an external repository, so automated claude review is disabled for security reasons.
+            
+            **For maintainers:** To get Claude review for this PR, run:
+            comment \`@claude\` in the regular workflow to trigger manual review.
+            Or use the manual trigger workflow:
+            \`\`\`
+            gh workflow run claude-code-review.yml -f pr_number=${{ github.event.pull_request.number }}
+            \`\`\`
+            
+            
+            **PR Summary:**
+            - Files changed: ${{ github.event.pull_request.changed_files }}
+            - Additions: +${{ github.event.pull_request.additions }}
+            - Deletions: -${{ github.event.pull_request.deletions }}
+            `;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+
+  # Manual trigger job for maintainers to review external PRs
+  claude-review-manual:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: refs/pull/${{ github.event.inputs.pr_number }}/merge
+
+      - name: Run Claude Code Review (Manual)
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          direct_prompt: |
+            Please review this external contributor's pull request with extra attention to:
+            - Security implications of the changes
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Test coverage
+            
+            This is from an external contributor, so be thorough but welcoming in your feedback.
+
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -149,13 +149,13 @@ jobs:
           echo "Automated Claude review is disabled for security reasons." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### For Maintainers:" >> $GITHUB_STEP_SUMMARY
-          echo "To get Claude review for this PR, run:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "To get Claude review for this PR, comment \`@claude\` to trigger manual review via the regular workflow." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Or, run:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
           echo "gh workflow run claude-code-review.yml -f pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Or comment \`@claude\` to trigger manual review via the regular workflow." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
           echo "### PR Summary:" >> $GITHUB_STEP_SUMMARY
           echo "- **Files changed:** ${{ github.event.pull_request.changed_files }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Additions:** +${{ github.event.pull_request.additions }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -162,6 +162,44 @@ jobs:
           echo "- **Deletions:** -${{ github.event.pull_request.deletions }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Author:** @${{ github.event.pull_request.user.login }}" >> $GITHUB_STEP_SUMMARY
 
+      - name: Comment on External PR
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              const comment = `## 🔒 Claude Code Review Status
+            
+              Thank you for your contribution! This PR is from an external repository, so automated Claude review is disabled for security reasons.
+            
+              **For maintainers:** To get Claude review for this PR, run:
+              \`\`\`bash
+              gh workflow run claude-code-review.yml -f pr_number=${{ github.event.pull_request.number }}
+              \`\`\`
+            
+              Or comment \`@claude\` in the regular workflow to trigger manual review.
+            
+              **PR Summary:**
+              - Files changed: ${{ github.event.pull_request.changed_files }}
+              - Additions: +${{ github.event.pull_request.additions }}
+              - Deletions: -${{ github.event.pull_request.deletions }}
+              - Author: @${{ github.event.pull_request.user.login }}
+              `;
+            
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              });
+            
+              console.log('✅ Successfully commented on external PR');
+            } catch (error) {
+              console.log('⚠️ Could not comment on PR (expected for external PRs):', error.message);
+              console.log('📝 External contributors can still see the workflow status and maintainers have the workflow summary');
+            }
+
   # Manual trigger job for maintainers to review external PRs
   claude-review-manual:
     if: github.event_name == 'workflow_dispatch'
@@ -193,5 +231,3 @@ jobs:
             - Test coverage
             
             This is from an external contributor, so be thorough but welcoming in your feedback.
-
-

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -76,45 +76,35 @@ jobs:
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
 
-  # Single job that handles both trusted and external PRs
-  claude-review-enhanced:
+  # Job for trusted PRs (from same repo or collaborators)
+  claude-review-trusted:
+    if: |
+      github.event_name == 'pull_request' && (
+        github.event.pull_request.head.repo.full_name == github.repository ||
+        github.event.pull_request.author_association == 'COLLABORATOR' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'OWNER'
+      )
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-      issues: write
+      issues: read
       id-token: write
 
     steps:
-      - name: Determine PR type
-        id: pr-type
-        run: |
-          if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]] || \
-             [[ "${{ github.event.pull_request.author_association }}" == "COLLABORATOR" ]] || \
-             [[ "${{ github.event.pull_request.author_association }}" == "MEMBER" ]] || \
-             [[ "${{ github.event.pull_request.author_association }}" == "OWNER" ]]; then
-            echo "trusted=true" >> $GITHUB_OUTPUT
-            echo "🔒 Trusted PR detected - will run full Claude review"
-          else
-            echo "trusted=false" >> $GITHUB_OUTPUT
-            echo "⚠️ External PR detected - will post notification comment"
-          fi
-
-      # For trusted PRs: checkout PR branch and run full Claude review
-      - name: Checkout PR (Trusted)
-        if: steps.pr-type.outputs.trusted == 'true'
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Run Claude Code Review (Trusted)
-        if: steps.pr-type.outputs.trusted == 'true'
+      - name: Run Claude Code Review (OIDC)
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4)
+          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
 
           direct_prompt: |
@@ -129,39 +119,86 @@ jobs:
 
           use_sticky_comment: true
 
-      # For external PRs: checkout main branch only (security) and post notification
-      - name: Checkout Main Branch (External - Security)
-        if: steps.pr-type.outputs.trusted == 'false'
+  # Job for external/forked PRs (no OIDC available, limited permissions)
+  claude-review-external:
+    if: |
+      github.event_name == 'pull_request' && (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        github.event.pull_request.author_association != 'COLLABORATOR' &&
+        github.event.pull_request.author_association != 'MEMBER' &&
+        github.event.pull_request.author_association != 'OWNER'
+      )
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Log External PR Info
+        run: |
+          echo "::notice::External PR detected - Claude review skipped for security"
+          echo "## 🔒 External PR - Claude Review Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "This PR is from an external repository (\`${{ github.event.pull_request.head.repo.full_name }}\`)." >> $GITHUB_STEP_SUMMARY
+          echo "Automated Claude review is disabled for security reasons." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### For Maintainers:" >> $GITHUB_STEP_SUMMARY
+          echo "To get Claude review for this PR, run:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "gh workflow run claude-code-review.yml -f pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Or comment \`@claude\` to trigger manual review via the regular workflow." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### PR Summary:" >> $GITHUB_STEP_SUMMARY
+          echo "- **Files changed:** ${{ github.event.pull_request.changed_files }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Additions:** +${{ github.event.pull_request.additions }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Deletions:** -${{ github.event.pull_request.deletions }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Author:** @${{ github.event.pull_request.user.login }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Comment on External PR
-        if: steps.pr-type.outputs.trusted == 'false'
-        uses: thollander/actions-comment-pull-request@v2
+        uses: actions/github-script@v7
+        continue-on-error: true
         with:
-          message: |
-            ## 🔒 Claude Code Review Status
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              const comment = `## 🔒 Claude Code Review Status
             
-            Thank you for your contribution! This PR is from an external repository (`${{ github.event.pull_request.head.repo.full_name }}`), so automated Claude review is disabled for security reasons.
+              Thank you for your contribution! This PR is from an external repository, so automated Claude review is disabled for security reasons.
             
-            **For maintainers:** To get Claude review for this PR, run:
-            ```bash
-            gh workflow run "Claude Code Review" -f pr_number=${{ github.event.pull_request.number }}
-            ```
+              **For maintainers:** To get Claude review for this PR, run:
+              \`\`\`bash
+              gh workflow run claude-code-review.yml -f pr_number=${{ github.event.pull_request.number }}
+              \`\`\`
             
-            Or comment `@claude` to trigger manual review via the regular workflow.
+              Or comment \`@claude\` in the regular workflow to trigger manual review.
             
-            **PR Summary:**
-            - Files changed: ${{ github.event.pull_request.changed_files }}
-            - Additions: +${{ github.event.pull_request.additions }}
-            - Deletions: -${{ github.event.pull_request.deletions }}
-            - Author: @${{ github.event.pull_request.user.login }}
-            - Source: `${{ github.event.pull_request.head.repo.full_name }}:${{ github.event.pull_request.head.ref }}`
+              **PR Summary:**
+              - Files changed: ${{ github.event.pull_request.changed_files }}
+              - Additions: +${{ github.event.pull_request.additions }}
+              - Deletions: -${{ github.event.pull_request.deletions }}
+              - Author: @${{ github.event.pull_request.user.login }}
+              `;
             
-            ---
-            *This comment was posted automatically.*
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              });
+            
+              console.log('✅ Successfully commented on external PR');
+            } catch (error) {
+              console.log('⚠️ Could not comment on PR (expected for external PRs):', error.message);
+              console.log('📝 External contributors can still see the workflow status and maintainers have the workflow summary');
+            }
 
   # Manual trigger job for maintainers to review external PRs
   claude-review-manual:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -122,7 +122,7 @@ jobs:
   # Job for external/forked PRs (no OIDC available, limited permissions)
   claude-review-external:
     if: |
-      github.event_name == 'pull_request' && (
+      github.event_name == 'pull_request_target' && (
         github.event.pull_request.head.repo.full_name != github.repository &&
         github.event.pull_request.author_association != 'COLLABORATOR' &&
         github.event.pull_request.author_association != 'MEMBER' &&
@@ -132,73 +132,50 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
+      issues: write
 
     steps:
-      - name: Checkout repository
+      # SECURITY: Only checkout the target branch, not the PR code
+      # This prevents malicious code execution while still allowing comments
+      - name: Checkout target branch (security)
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
-      - name: Log External PR Info
-        run: |
-          echo "::notice::External PR detected - Claude review skipped for security"
-          echo "## 🔒 External PR - Claude Review Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "This PR is from an external repository (\`${{ github.event.pull_request.head.repo.full_name }}\`)." >> $GITHUB_STEP_SUMMARY
-          echo "Automated Claude review is disabled for security reasons." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### For Maintainers:" >> $GITHUB_STEP_SUMMARY
-          echo "To get Claude review for this PR, run:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "gh workflow run claude-code-review.yml -f pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Or comment \`@claude\` to trigger manual review via the regular workflow." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### PR Summary:" >> $GITHUB_STEP_SUMMARY
-          echo "- **Files changed:** ${{ github.event.pull_request.changed_files }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Additions:** +${{ github.event.pull_request.additions }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Deletions:** -${{ github.event.pull_request.deletions }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Author:** @${{ github.event.pull_request.user.login }}" >> $GITHUB_STEP_SUMMARY
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Comment on External PR
         uses: actions/github-script@v7
-        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            try {
-              const comment = `## 🔒 Claude Code Review Status
+            const comment = `## 🔒 Claude Code Review Status
             
-              Thank you for your contribution! This PR is from an external repository, so automated Claude review is disabled for security reasons.
+            Thank you for your contribution! This PR is from an external repository (\`${{ github.event.pull_request.head.repo.full_name }}\`), so automated Claude review is disabled for security reasons.
             
-              **For maintainers:** To get Claude review for this PR, run:
-              \`\`\`bash
-              gh workflow run claude-code-review.yml -f pr_number=${{ github.event.pull_request.number }}
-              \`\`\`
+            **For maintainers:** To get Claude review for this PR, run:
+            \`\`\`bash
+            gh workflow run claude-code-review.yml -f pr_number=${{ github.event.pull_request.number }}
+            \`\`\`
             
-              Or comment \`@claude\` in the regular workflow to trigger manual review.
+            Or comment \`@claude\` to trigger manual review via the regular workflow.
             
-              **PR Summary:**
-              - Files changed: ${{ github.event.pull_request.changed_files }}
-              - Additions: +${{ github.event.pull_request.additions }}
-              - Deletions: -${{ github.event.pull_request.deletions }}
-              - Author: @${{ github.event.pull_request.user.login }}
-              `;
+            **PR Summary:**
+            - Files changed: ${{ github.event.pull_request.changed_files }}
+            - Additions: +${{ github.event.pull_request.additions }}
+            - Deletions: -${{ github.event.pull_request.deletions }}
+            - Author: @${{ github.event.pull_request.user.login }}
             
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: comment
-              });
+            ---
+            *This comment was posted automatically to inform about the review status.*
+            `;
             
-              console.log('✅ Successfully commented on external PR');
-            } catch (error) {
-              console.log('⚠️ Could not comment on PR (expected for external PRs):', error.message);
-              console.log('📝 External contributors can still see the workflow status and maintainers have the workflow summary');
-            }
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
 
   # Manual trigger job for maintainers to review external PRs
   claude-review-manual:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -76,36 +76,43 @@ jobs:
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
 
-  # Job for trusted PRs (from same repo or collaborators)
-  claude-code-review-trusted-oidc:
-    if: |
-      github.event_name == 'pull_request' && (
-        github.event.pull_request.head.repo.full_name == github.repository ||
-        github.event.pull_request.author_association == 'COLLABORATOR' ||
-        github.event.pull_request.author_association == 'MEMBER' ||
-        github.event.pull_request.author_association == 'OWNER'
-      )
-
+  # Single job that handles both trusted and external PRs
+  claude-review-enhanced:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-      issues: read
+      issues: write
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: Determine PR type
+        id: pr-type
+        run: |
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]] || \
+             [[ "${{ github.event.pull_request.author_association }}" == "COLLABORATOR" ]] || \
+             [[ "${{ github.event.pull_request.author_association }}" == "MEMBER" ]] || \
+             [[ "${{ github.event.pull_request.author_association }}" == "OWNER" ]]; then
+            echo "trusted=true" >> $GITHUB_OUTPUT
+            echo "🔒 Trusted PR detected - will run full Claude review"
+          else
+            echo "trusted=false" >> $GITHUB_OUTPUT
+            echo "⚠️ External PR detected - will post notification only"
+          fi
+
+      # For trusted PRs: checkout the PR branch and run Claude review
+      - name: Checkout PR (Trusted)
+        if: steps.pr-type.outputs.trusted == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Run claude code review (OIDC)
+      - name: Run Claude Code Review (Trusted)
+        if: steps.pr-type.outputs.trusted == 'true'
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
 
           direct_prompt: |
             Please review this pull request and provide feedback on:
@@ -119,32 +126,16 @@ jobs:
 
           use_sticky_comment: true
 
-  # Job for external/forked PRs (no OIDC available, limited permissions)
-  claude-review-external:
-    if: |
-      github.event_name == 'pull_request_target' && (
-        github.event.pull_request.head.repo.full_name != github.repository &&
-        github.event.pull_request.author_association != 'COLLABORATOR' &&
-        github.event.pull_request.author_association != 'MEMBER' &&
-        github.event.pull_request.author_association != 'OWNER'
-      )
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-
-    steps:
-      # SECURITY: Only checkout the target branch, not the PR code
-      # This prevents malicious code execution while still allowing comments
-      - name: Checkout target branch (security)
+      # For external PRs: checkout main branch only (security) and post comment
+      - name: Checkout Main Branch (External)
+        if: steps.pr-type.outputs.trusted == 'false'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Comment on External PR
+        if: steps.pr-type.outputs.trusted == 'false'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -155,7 +146,7 @@ jobs:
             
             **For maintainers:** To get Claude review for this PR, run:
             \`\`\`bash
-            gh workflow run claude-code-review.yml -f pr_number=${{ github.event.pull_request.number }}
+            gh workflow run "Claude Code Review" -f pr_number=${{ github.event.pull_request.number }}
             \`\`\`
             
             Or comment \`@claude\` to trigger manual review via the regular workflow.
@@ -165,6 +156,7 @@ jobs:
             - Additions: +${{ github.event.pull_request.additions }}
             - Deletions: -${{ github.event.pull_request.deletions }}
             - Author: @${{ github.event.pull_request.user.login }}
+            - Source: \`${{ github.event.pull_request.head.repo.full_name }}:${{ github.event.pull_request.head.ref }}\`
             
             ---
             *This comment was posted automatically to inform about the review status.*

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -119,7 +119,7 @@ jobs:
 
           use_sticky_comment: true
 
-  # Job for external/forked PRs (no OIDC available)
+  # Job for external/forked PRs (no OIDC available, limited permissions)
   claude-review-external:
     if: |
       github.event_name == 'pull_request' && (
@@ -132,8 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-      issues: read
+      pull-requests: read
 
     steps:
       - name: Checkout repository
@@ -141,35 +140,27 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Comment on External PR
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const comment = `## 🤖 Claude code review status
-            
-            Thank you for your contribution! This PR is from an external repository, so automated claude review is disabled for security reasons.
-            
-            **For maintainers:** To get Claude review for this PR, run:
-            comment \`@claude\` in the regular workflow to trigger manual review.
-            Or use the manual trigger workflow:
-            \`\`\`
-            gh workflow run claude-code-review.yml -f pr_number=${{ github.event.pull_request.number }}
-            \`\`\`
-            
-            
-            **PR Summary:**
-            - Files changed: ${{ github.event.pull_request.changed_files }}
-            - Additions: +${{ github.event.pull_request.additions }}
-            - Deletions: -${{ github.event.pull_request.deletions }}
-            `;
-            
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
+      - name: Log External PR Info
+        run: |
+          echo "::notice::External PR detected - Claude review skipped for security"
+          echo "## 🔒 External PR - Claude Review Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "This PR is from an external repository (\`${{ github.event.pull_request.head.repo.full_name }}\`)." >> $GITHUB_STEP_SUMMARY
+          echo "Automated Claude review is disabled for security reasons." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### For Maintainers:" >> $GITHUB_STEP_SUMMARY
+          echo "To get Claude review for this PR, run:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "gh workflow run claude-code-review.yml -f pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Or comment \`@claude\` to trigger manual review via the regular workflow." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### PR Summary:" >> $GITHUB_STEP_SUMMARY
+          echo "- **Files changed:** ${{ github.event.pull_request.changed_files }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Additions:** +${{ github.event.pull_request.additions }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Deletions:** -${{ github.event.pull_request.deletions }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Author:** @${{ github.event.pull_request.user.login }}" >> $GITHUB_STEP_SUMMARY
 
   # Manual trigger job for maintainers to review external PRs
   claude-review-manual:


### PR DESCRIPTION
Use an OIDC-based reusable workflow for secure ops, and fallback to GITHUB_TOKEN for general CI by default. This balances security, ease of contribution & best practices.

Claude code review fails on external PRs due to security reasons & write permissions.
- External PRs meaning PRs created from branches of forked repos
- **Solution:** We adapt to OIDC + GITHUB_TOKEN approach.
     - OIDC: This run claude code reviews on Trusted PRs that are created directly in llm4s/llm4s repo
     - GITHUB_TOKEN: This skips automated `claude` code review and wait for maintainer to comment claude on the PR to run claude code review.

Example CI Run for external PRs - https://github.com/llm4s/llm4s/actions/runs/16491775065 