### PR TITLE
Async support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ CLAUDE.md
 .metals
 .vscode
 **/.claude/settings.local.json
+**/*.iml

--- a/build.sbt
+++ b/build.sbt
@@ -120,6 +120,7 @@ lazy val root = (project in file("."))
       "com.knuddels"       % "jtokkit"         % "1.1.0",
       "com.lihaoyi"       %% "requests"        % "0.9.0",
       "org.java-websocket" % "Java-WebSocket"  % "1.5.3",
+      "org.typelevel"     %% "cats-core"       % "2.13.0",
       "org.scalatest"     %% "scalatest"       % "3.2.19" % Test,
       "org.scalamock"     %% "scalamock"       % "7.3.3"  % Test,
       "com.softwaremill.sttp.client4" %% "core"  % "4.0.0-M7",

--- a/samples/src/main/scala/org/llm4s/samples/actions/SummarizationExample.scala
+++ b/samples/src/main/scala/org/llm4s/samples/actions/SummarizationExample.scala
@@ -3,7 +3,6 @@ package org.llm4s.samples.actions
 import org.llm4s.llmconnect.LLM
 import org.llm4s.llmconnect.model._
 import org.llm4s.tokens.Tokenizer
-import org.llm4s.identity.TokenizerId
 import org.llm4s.identity.TokenizerId.O200K_BASE
 
 /**

--- a/samples/src/main/scala/org/llm4s/samples/tokens/TokenSample.scala
+++ b/samples/src/main/scala/org/llm4s/samples/tokens/TokenSample.scala
@@ -1,6 +1,5 @@
 package org.llm4s.samples.tokens
 
-import org.llm4s.identity.TokenizerId
 import org.llm4s.identity.TokenizerId.{ CL100K_BASE, O200K_BASE, R50K_BASE }
 import org.llm4s.tokens.Tokenizer
 

--- a/samples/src/main/scala/org/llm4s/samples/toolapi/WeatherToolExample.scala
+++ b/samples/src/main/scala/org/llm4s/samples/toolapi/WeatherToolExample.scala
@@ -2,7 +2,6 @@ package org.llm4s.samples.toolapi
 
 import org.llm4s.toolapi._
 import org.llm4s.toolapi.tools.WeatherTool
-import upickle.default._
 
 /**
  * Example demonstrating how to use the weather tool

--- a/samples/src/main/scala/org/llm4s/samples/toolapi/WorkspaceToolExample.scala
+++ b/samples/src/main/scala/org/llm4s/samples/toolapi/WorkspaceToolExample.scala
@@ -4,14 +4,12 @@ import org.llm4s.llmconnect.{ LLM, LLMClient }
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.config.{ AnthropicConfig, OpenAIConfig }
 import org.llm4s.llmconnect.provider.LLMProvider
-import org.llm4s.shared._
 import org.llm4s.toolapi._
 import org.llm4s.workspace.ContainerisedWorkspace
 import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 import upickle.default._
-import ujson._
 
 /**
  * Example demonstrating how to use workspace tools with different LLM models

--- a/samples/src/main/scala/org/llm4s/samples/workspace/ContainerisedWorkspaceDemo.scala
+++ b/samples/src/main/scala/org/llm4s/samples/workspace/ContainerisedWorkspaceDemo.scala
@@ -1,6 +1,6 @@
 package org.llm4s.samples.workspace
 
-import org.llm4s.shared.{ FileOperation, ReplaceOperation }
+import org.llm4s.shared.ReplaceOperation
 import org.llm4s.workspace.ContainerisedWorkspace
 import org.slf4j.LoggerFactory
 

--- a/src/main/scala/org/llm4s/imagegeneration/ImageGeneration.scala
+++ b/src/main/scala/org/llm4s/imagegeneration/ImageGeneration.scala
@@ -4,6 +4,8 @@ import java.time.Instant
 import java.nio.file.Path
 import org.llm4s.imagegeneration.provider.{ HttpClient, HuggingFaceClient, StableDiffusionClient }
 
+import scala.concurrent.Future
+
 // ===== ERROR HANDLING =====
 
 sealed trait ImageGenerationError {
@@ -184,14 +186,14 @@ trait ImageGenerationClient {
   def generateImage(
     prompt: String,
     options: ImageGenerationOptions = ImageGenerationOptions()
-  ): Either[ImageGenerationError, GeneratedImage]
+  ): Future[Either[ImageGenerationError, GeneratedImage]]
 
   /** Generate multiple images from a text prompt */
   def generateImages(
     prompt: String,
     count: Int,
     options: ImageGenerationOptions = ImageGenerationOptions()
-  ): Either[ImageGenerationError, Seq[GeneratedImage]]
+  ): Future[Either[ImageGenerationError, Seq[GeneratedImage]]]
 
   /** Check the health/status of the image generation service */
   def health(): Either[ImageGenerationError, ServiceStatus]
@@ -216,7 +218,7 @@ object ImageGeneration {
     prompt: String,
     config: ImageGenerationConfig,
     options: ImageGenerationOptions = ImageGenerationOptions()
-  ): Either[ImageGenerationError, GeneratedImage] =
+  ): Future[Either[ImageGenerationError, GeneratedImage]] =
     client(config).generateImage(prompt, options)
 
   /** Convenience method for generating multiple images */
@@ -225,7 +227,7 @@ object ImageGeneration {
     count: Int,
     config: ImageGenerationConfig,
     options: ImageGenerationOptions = ImageGenerationOptions()
-  ): Either[ImageGenerationError, Seq[GeneratedImage]] =
+  ): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
     client(config).generateImages(prompt, count, options)
 
   /** Get a Stable Diffusion client with default local configuration */
@@ -260,7 +262,7 @@ object ImageGeneration {
     prompt: String,
     options: ImageGenerationOptions = ImageGenerationOptions(),
     baseUrl: String = "http://localhost:7860"
-  ): Either[ImageGenerationError, GeneratedImage] = {
+  ): Future[Either[ImageGenerationError, GeneratedImage]] = {
     val config = StableDiffusionConfig(baseUrl = baseUrl)
     generateImage(prompt, config, options)
   }


### PR DESCRIPTION
The idea is to make the ```makeHttpRequest``` call run in parallel...

The earlier pipelining of error handling using the Either pipeline helped to wrap it further inside Scala Futures. 
        1. Introduced the cats library so all this async layer and the error handling stands out of the way
        2. Makes it easier to focus on the business logic 
        3. The monadic flow is very appealing - and helps reason with the code very easy 
        4. The Monad transformer helps cut the indirection boilerplate 
        
 ```
                        ...  
                        response   <- EitherT(makeHttpRequest(payload)) // this code executes in the future
                        ...  
```