### PR TITLE
Add dotenv-java integration for environment variable management

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,7 +134,8 @@ lazy val root = (project in file("."))
       "org.apache.tika" % "tika-core" % "3.2.1",
       "org.apache.poi" % "poi-ooxml" % "5.4.1",
       "com.lihaoyi" %% "requests" % "0.9.0",
-      "org.jsoup" % "jsoup" % "1.21.1"
+      "org.jsoup" % "jsoup" % "1.21.1",
+      "io.github.cdimascio" % "dotenv-java" % "3.0.0"
     )
 
   )

--- a/src/main/scala/org/llm4s/config/EnvLoader.scala
+++ b/src/main/scala/org/llm4s/config/EnvLoader.scala
@@ -1,0 +1,14 @@
+package org.llm4s.config
+
+import io.github.cdimascio.dotenv.Dotenv
+
+object EnvLoader {
+  private lazy val dotenv = Dotenv
+    .configure()
+    .ignoreIfMissing()
+    .load()
+
+  def get(key: String): Option[String] = Option(dotenv.get(key))
+
+  def getOrElse(key: String, default: String): String = get(key).getOrElse(default)
+}

--- a/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -2,6 +2,7 @@ package org.llm4s.llmconnect
 
 import com.azure.ai.openai.{ OpenAIClientBuilder, OpenAIServiceVersion, OpenAIClient => AzureOpenAIClient }
 import com.azure.core.credential.AzureKeyCredential
+import org.llm4s.config.EnvLoader
 import org.llm4s.llmconnect.config.{ AnthropicConfig, AzureConfig, OpenAIConfig, ProviderConfig }
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.provider.{
@@ -14,7 +15,7 @@ import org.llm4s.llmconnect.provider.{
 
 object LLMConnect {
   private def readEnv(key: String): Option[String] =
-    sys.env.get(key)
+    EnvLoader.get(key)
 
   /**
    * Get an LLMClient based on environment variables

--- a/src/main/scala/org/llm4s/llmconnect/config/EmbeddingConfig.scala
+++ b/src/main/scala/org/llm4s/llmconnect/config/EmbeddingConfig.scala
@@ -1,5 +1,7 @@
 package org.llm4s.llmconnect.config
 
+import org.llm4s.config.EnvLoader
+
 case class EmbeddingProviderConfig(
   baseUrl: String,
   model: String,
@@ -9,10 +11,10 @@ case class EmbeddingProviderConfig(
 object EmbeddingConfig {
 
   def loadEnv(name: String): String =
-    sys.env.getOrElse(name, throw new RuntimeException(s"\nMissing env variable: $name"))
+    EnvLoader.get(name).getOrElse(throw new RuntimeException(s"Missing env variable: $name"))
 
   def loadOptionalEnv(name: String, default: String): String =
-    sys.env.getOrElse(name, default)
+    EnvLoader.get(name).getOrElse(default)
 
   val openAI: EmbeddingProviderConfig = EmbeddingProviderConfig(
     baseUrl = loadEnv("OPENAI_EMBEDDING_BASE_URL"),

--- a/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -1,12 +1,14 @@
 package org.llm4s.llmconnect.config
 
+import org.llm4s.config.EnvLoader
+
 sealed trait ProviderConfig {
   def model: String
 }
 
 object ProviderConfig {
   def readEnv(key: String): Option[String] =
-    sys.env.get(key)
+    EnvLoader.get(key)
 }
 
 case class OpenAIConfig(

--- a/src/main/scala/org/llm4s/trace/LangfuseTracing.scala
+++ b/src/main/scala/org/llm4s/trace/LangfuseTracing.scala
@@ -1,6 +1,7 @@
 package org.llm4s.trace
 
 import org.llm4s.agent.AgentState
+import org.llm4s.config.EnvLoader
 import org.llm4s.llmconnect.model.{ AssistantMessage, SystemMessage, ToolMessage, UserMessage }
 import org.slf4j.LoggerFactory
 
@@ -10,12 +11,12 @@ import java.util.UUID
 import scala.util.{ Failure, Success, Try }
 
 class LangfuseTracing(
-  langfuseUrl: String = sys.env.getOrElse("LANGFUSE_URL", "https://cloud.langfuse.com/api/public/ingestion"),
-  publicKey: String = sys.env.getOrElse("LANGFUSE_PUBLIC_KEY", ""),
-  secretKey: String = sys.env.getOrElse("LANGFUSE_SECRET_KEY", ""),
-  environment: String = sys.env.getOrElse("LANGFUSE_ENV", "production"),
-  release: String = sys.env.getOrElse("LANGFUSE_RELEASE", "1.0.0"),
-  version: String = sys.env.getOrElse("LANGFUSE_VERSION", "1.0.0")
+  langfuseUrl: String = EnvLoader.getOrElse("LANGFUSE_URL", "https://cloud.langfuse.com/api/public/ingestion"),
+  publicKey: String = EnvLoader.getOrElse("LANGFUSE_PUBLIC_KEY", ""),
+  secretKey: String = EnvLoader.getOrElse("LANGFUSE_SECRET_KEY", ""),
+  environment: String = EnvLoader.getOrElse("LANGFUSE_ENV", "production"),
+  release: String = EnvLoader.getOrElse("LANGFUSE_RELEASE", "1.0.0"),
+  version: String = EnvLoader.getOrElse("LANGFUSE_VERSION", "1.0.0")
 ) extends Tracing {
   private val logger         = LoggerFactory.getLogger(getClass)
   private def nowIso: String = DateTimeFormatter.ISO_INSTANT.format(Instant.now())

--- a/src/main/scala/org/llm4s/trace/Tracing.scala
+++ b/src/main/scala/org/llm4s/trace/Tracing.scala
@@ -1,6 +1,7 @@
 package org.llm4s.trace
 
 import org.llm4s.agent.AgentState
+import org.llm4s.config.EnvLoader
 import org.llm4s.llmconnect.model.{ TokenUsage, Completion }
 
 trait Tracing {
@@ -23,7 +24,7 @@ object Tracing {
    * - "none": Uses NoOpTracing (no tracing)
    */
   def create(): Tracing = {
-    val mode = sys.env.getOrElse("TRACING_MODE", "langfuse").toLowerCase
+    val mode = EnvLoader.getOrElse("TRACING_MODE", "langfuse").toLowerCase
 
     mode match {
       case "langfuse" => new LangfuseTracing()

--- a/src/test/scala/org/llm4s/config/EnvLoaderTest.scala
+++ b/src/test/scala/org/llm4s/config/EnvLoaderTest.scala
@@ -1,0 +1,27 @@
+package org.llm4s.config
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class EnvLoaderTest extends AnyFlatSpec with Matchers {
+
+  "EnvLoader" should "load values from .env file" in {
+    // Test loading LLM_MODEL which should exist in .env
+    val llmModel = EnvLoader.get("LLM_MODEL")
+    llmModel should be(defined)
+    llmModel.get should not be empty
+  }
+
+  it should "return None for non-existent variables" in {
+    val nonExistent = EnvLoader.get("NON_EXISTENT_VAR_12345")
+    nonExistent should be(None)
+  }
+
+  it should "provide getOrElse functionality" in {
+    val llmModel = EnvLoader.getOrElse("LLM_MODEL", "default-model")
+    (llmModel should not).equal("default-model")
+
+    val nonExistent = EnvLoader.getOrElse("NON_EXISTENT_VAR_12345", "default-value")
+    nonExistent should equal("default-value")
+  }
+}


### PR DESCRIPTION
## Summary
This PR extracts the dotenv-java integration from the `bloop_metals_integration` branch to enable `.env` file support in llm4s.

## Changes
- Added `dotenv-java` dependency (version 3.0.0) to `build.sbt`
- Created `EnvLoader` utility object that uses dotenv-java to load environment variables
- Added tests for `EnvLoader` functionality
- Updated all environment variable access to use `EnvLoader` instead of `sys.env`

## Files Modified
- `build.sbt` - Added dotenv-java dependency
- `src/main/scala/org/llm4s/config/EnvLoader.scala` - New utility for loading env vars
- `src/test/scala/org/llm4s/config/EnvLoaderTest.scala` - Tests for EnvLoader
- `src/main/scala/org/llm4s/llmconnect/LLMConnect.scala` - Use EnvLoader
- `src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala` - Use EnvLoader
- `src/main/scala/org/llm4s/llmconnect/config/EmbeddingConfig.scala` - Use EnvLoader
- `src/main/scala/org/llm4s/trace/Tracing.scala` - Use EnvLoader
- `src/main/scala/org/llm4s/trace/LangfuseTracing.scala` - Use EnvLoader

## Benefits
- Supports `.env` files for easier local development
- No need to set system environment variables
- Maintains backward compatibility (still reads from system env if .env file is missing)
- All existing tests pass

## Test Results
✅ All tests pass
✅ Code compiles for both Scala 2.13 and 3.x
✅ EnvLoader tests verify functionality

🤖 Generated with [Claude Code](https://claude.ai/code)