### PR TITLE
Rename `reader` parameter to `config` in provider configurations for …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -244,10 +244,15 @@ addCommandAlias(
   "testAll",
   ";project root; +test; project shared; +test; project workspaceRunner; +test; project samples; +test; project root; +publishLocal; project crossTestScala2; test; project crossTestScala3; test"
 )
-// Clean all modules and then run all tests
+
 addCommandAlias(
   "cleanTestAll",
   ";project root; clean; project shared; clean; project workspaceRunner; clean; project samples; clean; project crossTestScala2; clean; project crossTestScala3; clean; project root; +publishLocal; testAll"
+)
+
+addCommandAlias(
+  "cleanTestAllAndFormat",
+  ";scalafmtAll;project root; clean; project shared; clean; project workspaceRunner; clean; project samples; clean; project crossTestScala2; clean; project crossTestScala3; clean; project root; +publishLocal; testAll"
 )
 addCommandAlias("compileAll", ";+compile")
 addCommandAlias("testCross", ";crossTestScala2/test;crossTestScala3/test")

--- a/crossTest/scala3/src/test/scala/org/llm4s/sc3/SafeParameterExtractorTest.scala
+++ b/crossTest/scala3/src/test/scala/org/llm4s/sc3/SafeParameterExtractorTest.scala
@@ -1,6 +1,5 @@
 package org.llm4s.sc3
 
-
 import org.llm4s.toolapi.SafeParameterExtractor
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -11,18 +10,18 @@ import scala.language.strictEquality // Enable strict equality checking
 class SafeParameterExtractorTest extends AnyFlatSpec with Matchers {
 
   // Add implicit CanEqual instances for ujson types
-  given CanEqual[ujson.Arr, ujson.Arr] = CanEqual.derived
-  given CanEqual[ujson.Obj, ujson.Obj] = CanEqual.derived
+  given CanEqual[ujson.Arr, ujson.Arr]                                               = CanEqual.derived
+  given CanEqual[ujson.Obj, ujson.Obj]                                               = CanEqual.derived
   given [T, U](using CanEqual[T, U]): CanEqual[Either[String, T], Either[String, U]] = CanEqual.derived
-  given [T, U](using CanEqual[T, U]): CanEqual[Right[String, T], Right[String, U]] = CanEqual.derived
+  given [T, U](using CanEqual[T, U]): CanEqual[Right[String, T], Right[String, U]]   = CanEqual.derived
 
   // Test fixtures
   val simpleJson = ujson.Obj(
     "stringValue" -> "test",
-    "intValue" -> 42,
+    "intValue"    -> 42,
     "doubleValue" -> 42.5,
-    "boolValue" -> true,
-    "arrayValue" -> ujson.Arr(1, 2, 3),
+    "boolValue"   -> true,
+    "arrayValue"  -> ujson.Arr(1, 2, 3),
     "objectValue" -> ujson.Obj("key" -> "value")
   )
 
@@ -31,7 +30,7 @@ class SafeParameterExtractorTest extends AnyFlatSpec with Matchers {
       "string" -> "nested",
       "number" -> 100,
       "level2" -> ujson.Obj(
-        "array" -> ujson.Arr("a", "b", "c"),
+        "array"   -> ujson.Arr("a", "b", "c"),
         "boolean" -> false
       )
     )
@@ -123,8 +122,12 @@ class SafeParameterExtractorTest extends AnyFlatSpec with Matchers {
     extractor.getBoolean("level1.level2.boolean") shouldBe Right(false)
 
     // Failure cases
-    extractor.getString("level1.nonexistent") shouldBe Left("Path 'level1.nonexistent' not found: missing 'nonexistent' segment")
-    extractor.getString("level1.string.invalid") shouldBe Left("Path 'level1.string.invalid': Expected object at 'level1.string' but found Str")
+    extractor.getString("level1.nonexistent") shouldBe Left(
+      "Path 'level1.nonexistent' not found: missing 'nonexistent' segment"
+    )
+    extractor.getString("level1.string.invalid") shouldBe Left(
+      "Path 'level1.string.invalid': Expected object at 'level1.string' but found Str"
+    )
   }
 
   it should "handle empty paths correctly" in {
@@ -150,6 +153,8 @@ class SafeParameterExtractorTest extends AnyFlatSpec with Matchers {
     val extractor = SafeParameterExtractor(jsonWithSpecialChars)
 
     extractor.getString("special.key") shouldBe Left("Path 'special.key' not found: missing 'special' segment")
-    extractor.getString("normal.special.nested") shouldBe Left("Path 'normal.special.nested' not found: missing 'special' segment")
+    extractor.getString("normal.special.nested") shouldBe Left(
+      "Path 'normal.special.nested' not found: missing 'special' segment"
+    )
   }
 }

--- a/samples/src/main/scala/org/llm4s/samples/toolapi/WorkspaceToolExample.scala
+++ b/samples/src/main/scala/org/llm4s/samples/toolapi/WorkspaceToolExample.scala
@@ -66,7 +66,9 @@ object WorkspaceToolExample {
         logger.info(s"Testing with OpenAI's $gpt4oModelName...")
         val openaiConfig = OpenAIConfig(
           apiKey = sys.env.getOrElse("OPENAI_API_KEY", ""),
-          model = gpt4oModelName
+          model = gpt4oModelName,
+          organization = None,
+          baseUrl = "https://api.openai.com/v1"
         )
         
         val openaiClient = LLM.client(LLMProvider.OpenAI, openaiConfig)
@@ -76,7 +78,8 @@ object WorkspaceToolExample {
         logger.info(s"Testing with Anthropic's $sonnetModelName...")
         val anthropicConfig = AnthropicConfig(
           apiKey = sys.env.getOrElse("ANTHROPIC_API_KEY", ""),
-          model = sonnetModelName
+          model = sonnetModelName,
+          baseUrl = "https://api.anthropic.com"
         )
         
         val anthropicClient = LLM.client(LLMProvider.Anthropic, anthropicConfig)

--- a/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -10,7 +10,7 @@ sealed trait ProviderConfig {
 case class OpenAIConfig(
   apiKey: String,
   model: String,
-  organization: Option[String] ,
+  organization: Option[String],
   baseUrl: String
 ) extends ProviderConfig
 
@@ -62,7 +62,7 @@ object AzureConfig {
 
 case class AnthropicConfig(
   apiKey: String,
-  model: String ,
+  model: String,
   baseUrl: String
 ) extends ProviderConfig
 

--- a/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -9,23 +9,23 @@ sealed trait ProviderConfig {
 
 case class OpenAIConfig(
   apiKey: String,
-  model: String = "gpt-4o",
-  organization: Option[String] = None,
-  baseUrl: String = "https://api.openai.com/v1"
+  model: String,
+  organization: Option[String] ,
+  baseUrl: String
 ) extends ProviderConfig
 
 object OpenAIConfig {
 
-  def from(modelName: String, reader: ConfigReader): OpenAIConfig =
+  def from(modelName: String, config: ConfigReader): OpenAIConfig =
     OpenAIConfig(
-      apiKey = reader
+      apiKey = config
         .get(OPENAI_API_KEY)
         .getOrElse(
           throw new IllegalArgumentException("OPENAI_API_KEY not set, required when using openai/ model.")
         ),
       model = modelName,
-      organization = reader.get(OPENAI_ORG),
-      baseUrl = reader.getOrElse(OPENAI_BASE_URL, DEFAULT_OPENAI_BASE_URL)
+      organization = config.get(OPENAI_ORG),
+      baseUrl = config.getOrElse(OPENAI_BASE_URL, DEFAULT_OPENAI_BASE_URL)
     )
 }
 
@@ -33,23 +33,23 @@ case class AzureConfig(
   endpoint: String,
   apiKey: String,
   model: String,
-  apiVersion: String = "V2025_01_01_PREVIEW"
+  apiVersion: String
 ) extends ProviderConfig
 
 object AzureConfig {
 
-  def from(modelName: String, reader: ConfigReader): AzureConfig = {
-    val endpoint = reader
+  def from(modelName: String, config: ConfigReader): AzureConfig = {
+    val endpoint = config
       .get(AZURE_API_BASE)
       .getOrElse(
         throw new IllegalArgumentException("AZURE_API_BASE not set, required when using azure/ model.")
       )
-    val apiKey = reader
+    val apiKey = config
       .get(AZURE_API_KEY)
       .getOrElse(
         throw new IllegalArgumentException("AZURE_API_KEY not set, required when using azure/ model.")
       )
-    val apiVersion = reader.get(AZURE_API_VERSION).getOrElse(DEFAULT_AZURE_V2025_01_01_PREVIEW)
+    val apiVersion = config.get(AZURE_API_VERSION).getOrElse(DEFAULT_AZURE_V2025_01_01_PREVIEW)
 
     AzureConfig(
       endpoint = endpoint,
@@ -62,21 +62,21 @@ object AzureConfig {
 
 case class AnthropicConfig(
   apiKey: String,
-  model: String = "claude-3-opus-20240229",
-  baseUrl: String = "https://api.anthropic.com"
+  model: String ,
+  baseUrl: String
 ) extends ProviderConfig
 
 object AnthropicConfig {
 
-  def from(modelName: String, reader: ConfigReader): AnthropicConfig =
+  def from(modelName: String, config: ConfigReader): AnthropicConfig =
     AnthropicConfig(
-      apiKey = reader
+      apiKey = config
         .get(ANTHROPIC_API_KEY)
         .getOrElse(
           throw new IllegalArgumentException("ANTHROPIC_API_KEY not set, required when using anthropic/ model.")
         ),
       model = modelName,
-      baseUrl = reader.getOrElse(ANTHROPIC_BASE_URL, DEFAULT_ANTHROPIC_BASE_URL)
+      baseUrl = config.getOrElse(ANTHROPIC_BASE_URL, DEFAULT_ANTHROPIC_BASE_URL)
     )
 }
 
@@ -86,8 +86,8 @@ case class OllamaConfig(
 ) extends ProviderConfig
 
 object OllamaConfig {
-  def from(modelName: String, reader: ConfigReader): OllamaConfig = {
-    val baseUrl = reader
+  def from(modelName: String, config: ConfigReader): OllamaConfig = {
+    val baseUrl = config
       .get(OLLAMA_BASE_URL)
       .getOrElse(throw new IllegalArgumentException("OLLAMA_BASE_URL must be set for ollama provider"))
     OllamaConfig(model = modelName, baseUrl = baseUrl)

--- a/src/test/scala/org/llm4s/llmconnect/LLMConnectProviderTypeSafetyTest.scala
+++ b/src/test/scala/org/llm4s/llmconnect/LLMConnectProviderTypeSafetyTest.scala
@@ -33,7 +33,8 @@ class LLMConnectProviderTypeSafetyTest extends AnyFunSuite with Matchers {
     val cfg: ProviderConfig = AzureConfig(
       endpoint = "https://example.azure.com",
       apiKey = "key",
-      model = "gpt-4o"
+      model = "gpt-4o",
+      apiVersion = "V2025_01_01_PREVIEW"
     )
     val client = LLMConnect.getClient(LLMProvider.Azure, cfg)
     client.getClass.getSimpleName shouldBe "OpenAIClient"
@@ -74,7 +75,8 @@ class LLMConnectProviderTypeSafetyTest extends AnyFunSuite with Matchers {
     val wrongCfg: ProviderConfig = AzureConfig(
       endpoint = "https://example.azure.com",
       apiKey = "key",
-      model = "gpt-4o"
+      model = "gpt-4o",
+      apiVersion = "V2025_01_01_PREVIEW"
     )
 
     assertThrows[IllegalArgumentException] {


### PR DESCRIPTION
…clarity and consistency.

Make `baseUrl` mandatory in `AnthropicConfig` and update example usage. Make `model`, `organization`, and `baseUrl` mandatory in `OpenAIConfig` and update usage in examples. Make `apiVersion` a mandatory field in `ProviderConfig` and update tests accordingly.