### PR TITLE
Add notification communication in mcp

### DIFF
--- a/src/main/scala/org/llm4s/mcp/MCPClientImpl.scala
+++ b/src/main/scala/org/llm4s/mcp/MCPClientImpl.scala
@@ -116,15 +116,14 @@ class MCPClientImpl(config: MCPServerConfig) extends MCPClient {
       initializeTransport().flatMap { transportImpl =>
         // Check if we already did initialization during transport testing
         if (isTransportInitialized) {
-          // Just send the initialized notification to complete handshake
-          val initializedNotification = JsonRpcRequest(
+          // Send initialized notification to complete handshake (notifications have no ID)
+          val initializedNotification = JsonRpcNotification(
             jsonrpc = "2.0",
-            id = generateId(),
-            method = "initialized",
+            method = "notifications/initialized",
             params = Some(ujson.Obj())
           )
 
-          transportImpl.sendRequest(initializedNotification) match {
+          transportImpl.sendNotification(initializedNotification) match {
             case Right(_) =>
               initialized = true
               logger.info(s"Completed MCP client initialization for ${config.name} with existing connection")
@@ -149,15 +148,14 @@ class MCPClientImpl(config: MCPServerConfig) extends MCPClient {
 
                     // Validate protocol version compatibility
                     if (serverProtocolVersion.startsWith("2024-") || serverProtocolVersion.startsWith("2025-")) {
-                      // Send initialized notification to complete the handshake
-                      val initializedNotification = JsonRpcRequest(
+                      // Send initialized notification to complete the handshake (notifications have no ID)
+                      val initializedNotification = JsonRpcNotification(
                         jsonrpc = "2.0",
-                        id = generateId(),
-                        method = "initialized",
+                        method = "notifications/initialized",
                         params = Some(ujson.Obj())
                       )
 
-                      transportImpl.sendRequest(initializedNotification) match {
+                      transportImpl.sendNotification(initializedNotification) match {
                         case Right(_) =>
                           initialized = true
                           logger.info(
@@ -365,6 +363,6 @@ object MCPClientImpl {
     jsonrpc = "2.0",
     id = "",
     method = "tools/list", // method value for getting available tools
-    params = None
+    params = None          // Optional params omitted per JSON-RPC 2.0 spec
   )
 }

--- a/src/main/scala/org/llm4s/mcp/MCPTypes.scala
+++ b/src/main/scala/org/llm4s/mcp/MCPTypes.scala
@@ -19,6 +19,21 @@ case class JsonRpcRequest(
 )
 
 /**
+ * JSON-RPC 2.0 notification structure for MCP protocol communication.
+ * Notifications are requests without an ID - the client doesn't expect a response.
+ * Used for fire-and-forget messages like the "initialized" notification.
+ *
+ * @param jsonrpc Protocol version, always "2.0"
+ * @param method The method name to invoke on the server
+ * @param params Optional parameters for the method
+ */
+case class JsonRpcNotification(
+  jsonrpc: String, // No default value to force explicit setting
+  method: String,
+  params: Option[ujson.Value] = None
+)
+
+/**
  * JSON-RPC 2.0 response structure returned by MCP servers.
  * Contains either a result or error, never both.
  *
@@ -250,6 +265,10 @@ object MCPErrorCodes {
 // Serialization support for JSON marshalling/unmarshalling
 object JsonRpcRequest {
   implicit val rw: ReadWriter[JsonRpcRequest] = macroRW
+}
+
+object JsonRpcNotification {
+  implicit val rw: ReadWriter[JsonRpcNotification] = macroRW
 }
 
 object JsonRpcResponse {

--- a/src/test/scala/org/llm4s/mcp/MCPClientImplSpec.scala
+++ b/src/test/scala/org/llm4s/mcp/MCPClientImplSpec.scala
@@ -54,11 +54,11 @@ class MCPClientImplSpec extends AnyFlatSpec with Matchers with MockFactory with 
       .expects(where((req: JsonRpcRequest) => req.method == "initialize"))
       .returning(Right(initResponse))
 
-    (mockTransport.sendRequest _)
-      .expects(where((req: JsonRpcRequest) => req.method == "initialized"))
-      .returning(Right(JsonRpcResponse("2.0", "3", None)))
+    (mockTransport.sendNotification _)
+      .expects(where((notif: JsonRpcNotification) => notif.method == "notifications/initialized"))
+      .returning(Right(()))
 
-    val request = JsonRpcRequest("2.0", "3", "tools/list", None)
+    val request = JsonRpcRequest("2.0", "2", "tools/list", None)
     (mockTransport.sendRequest _)
       .expects(request)
       .returning(Right(toolsResponse))


### PR DESCRIPTION
This work on MCP files was mistakenly deleted from the PR: #169 .

This PR gives our MCP connector notification support, for compatibility with some mcp servers. The issue was noticed when using an email mcp server that requires notifications in the protocol.

closes https://github.com/elvankonukseven/GSoC-Progress-Tracker/issues/21