### PR TITLE
Remove unused imports and redundant case bindings across multiple files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,9 @@ lazy val root = (project in file("."))
   .settings(
     name := "llm4s",
     commonSettings,
+    // Library project: do not expose or auto-discover mains
+    Compile / mainClass := None,
+    Compile / discoveredMainClasses := Seq.empty,
     libraryDependencies ++= List(
       "com.azure"          % "azure-ai-openai" % "1.0.0-beta.16",
       "com.anthropic"      % "anthropic-java"  % "2.2.0",
@@ -151,7 +154,9 @@ lazy val root = (project in file("."))
 lazy val shared = (project in file("shared"))
   .settings(
     name := "shared",
-    commonSettings
+    commonSettings,
+    // Pure library: avoid main discovery noise
+    Compile / discoveredMainClasses := Seq.empty
   )
 
 lazy val workspaceRunner = (project in file("workspaceRunner"))

--- a/samples/src/main/scala/org/llm4s/samples/basic/AgentLLMCallingExample.scala
+++ b/samples/src/main/scala/org/llm4s/samples/basic/AgentLLMCallingExample.scala
@@ -2,7 +2,6 @@ package org.llm4s.samples.basic
 
 import org.llm4s.agent.{Agent, AgentState, AgentStatus}
 import org.llm4s.config.ConfigReader
-import org.llm4s.config.ConfigReader.LLMConfig
 import org.llm4s.llmconnect.LLM
 import org.llm4s.samples.util.{BenchmarkUtil, TracingUtil}
 import org.llm4s.toolapi.ToolRegistry

--- a/samples/src/main/scala/org/llm4s/samples/embeddingsupport/EmbeddingExample.scala
+++ b/samples/src/main/scala/org/llm4s/samples/embeddingsupport/EmbeddingExample.scala
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory
 
 import java.nio.file.{Files, Path, Paths}
 import java.time.{ZoneId, ZonedDateTime}
-import scala.jdk.CollectionConverters.*
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 object EmbeddingExample {

--- a/samples/src/main/scala/org/llm4s/samples/streaming/BasicStreamingExample.scala
+++ b/samples/src/main/scala/org/llm4s/samples/streaming/BasicStreamingExample.scala
@@ -94,9 +94,9 @@ object BasicStreamingExample {
       case Left(error) =>
         println(s"\n❌ Streaming failed: ${error.message}")
         error match {
-          case e: org.llm4s.error.AuthenticationError =>
+          case _: org.llm4s.error.AuthenticationError =>
             println("Please check your API key configuration.")
-          case e: org.llm4s.error.RateLimitError =>
+          case _: org.llm4s.error.RateLimitError =>
             println("You've hit the rate limit. Please wait and try again.")
           case _ =>
             println(s"Error details: $error")

--- a/samples/src/main/scala/org/llm4s/samples/util/TracingUtil.scala
+++ b/samples/src/main/scala/org/llm4s/samples/util/TracingUtil.scala
@@ -3,10 +3,7 @@ package org.llm4s.samples.util
 import org.llm4s.agent.AgentState
 import org.llm4s.toolapi.ToolFunction
 import org.llm4s.trace.{ EnhancedTracing, TraceEvent }
-import ujson._
 
-import scala.language.reflectiveCalls
-import scala.reflect.Selectable.reflectiveSelectable
 import scala.util.Try
 
 /**
@@ -132,4 +129,3 @@ object TracingUtil {
     }.toOption
   }
 }
-

--- a/samples/src/test/scala/org/llm4s/samples/basic/EnhancedTracingExampleTest.scala
+++ b/samples/src/test/scala/org/llm4s/samples/basic/EnhancedTracingExampleTest.scala
@@ -4,8 +4,6 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.llm4s.trace.{EnhancedTracing, TracingComposer, TraceEvent, TracingMode}
 import org.llm4s.llmconnect.model.TokenUsage
-import org.llm4s.error.LLMError
-import ujson._
 import org.llm4s.config.ConfigReader.LLMConfig
 
 class EnhancedTracingExampleTest extends AnyFunSuite with Matchers {

--- a/src/main/scala/org/llm4s/agent/Agent.scala
+++ b/src/main/scala/org/llm4s/agent/Agent.scala
@@ -239,11 +239,6 @@ class Agent(client: LLMClient) {
               sb.append("\n```\n\n")
           }
 
-        case _ =>
-          sb.append(s"### Step $step: ${message.role} Message\n\n")
-          sb.append("```\n")
-          sb.append(message.content)
-          sb.append("\n```\n\n")
       }
     }
 

--- a/src/main/scala/org/llm4s/agent/AgentState.scala
+++ b/src/main/scala/org/llm4s/agent/AgentState.scala
@@ -63,7 +63,6 @@ case class AgentState(
         case MessageRole.Assistant => "🤖 ASSISTANT"
         case MessageRole.System    => "⚙️ SYSTEM"
         case MessageRole.Tool      => "🛠️ TOOL"
-        case _                     => s"[${message.role.name.toUpperCase}]"
       }
 
       println(s"STEP $step: $roleMarker")

--- a/src/main/scala/org/llm4s/error/ServiceError.scala
+++ b/src/main/scala/org/llm4s/error/ServiceError.scala
@@ -7,7 +7,7 @@ final case class ServiceError private (
   override val message: String,
   httpStatus: Int,
   provider: String,
-  requestId: Option[String] = None
+  requestId: Option[String]
 ) extends LLMError
     with RecoverableError {
 

--- a/src/main/scala/org/llm4s/imagegeneration/provider/OpenAIImageClient.scala
+++ b/src/main/scala/org/llm4s/imagegeneration/provider/OpenAIImageClient.scala
@@ -28,8 +28,8 @@ import java.time.Instant
  * )
  *
  * client.generateImage("a beautiful landscape", options) match {
- *   case Right(image) => println(s"Generated image: ${image.size}")
- *   case Left(error) => println(s"Error: ${error.message}")
+ *   case Right(image) => println(s"Generated image: $${image.size}")
+ *   case Left(error) => println(s"Error: $${error.message}")
  * }
  * }}}
  */
@@ -165,7 +165,6 @@ class OpenAIImageClient(config: OpenAIConfig) extends ImageGenerationClient {
       case ImageSize.Square1024       => "1024x1024"
       case ImageSize.Landscape768x512 => if (config.model == "dall-e-3") "1792x1024" else "512x512"
       case ImageSize.Portrait512x768  => if (config.model == "dall-e-3") "1024x1792" else "512x512"
-      case _                          => "1024x1024" // Default fallback
     }
 
   /**

--- a/src/main/scala/org/llm4s/llmconnect/provider/OpenAIClient.scala
+++ b/src/main/scala/org/llm4s/llmconnect/provider/OpenAIClient.scala
@@ -21,8 +21,7 @@ import scala.jdk.CollectionConverters._
  */
 class OpenAIClient private (
   private val model: String,
-  private val client: AzureOpenAIClient,
-  private val config: Either[OpenAIConfig, AzureConfig]
+  private val client: AzureOpenAIClient
 ) extends LLMClient {
 
   /* * Constructor for OpenAI (non-Azure) */
@@ -31,8 +30,7 @@ class OpenAIClient private (
     new OpenAIClientBuilder()
       .credential(new KeyCredential(config.apiKey))
       .endpoint(config.baseUrl)
-      .buildClient(),
-    Left(config)
+      .buildClient()
   )
 
   /** Constructor for Azure OpenAI */
@@ -42,8 +40,7 @@ class OpenAIClient private (
       .credential(new AzureKeyCredential(config.apiKey))
       .endpoint(config.endpoint)
       .serviceVersion(OpenAIServiceVersion.valueOf(config.apiVersion))
-      .buildClient(),
-    Right(config)
+      .buildClient()
   )
 
   override def complete(

--- a/src/main/scala/org/llm4s/llmconnect/serialization/ToolCallDeserializer.scala
+++ b/src/main/scala/org/llm4s/llmconnect/serialization/ToolCallDeserializer.scala
@@ -12,7 +12,8 @@ trait ToolCallDeserializer {
 
 /**
  * OpenRouter-specific tool call deserializer
- * Handles OpenRouter's double-nested array structure: [[{...}]] instead of [{...}]
+ * Handles OpenRouter's double-nested array structure (array of arrays of tool calls)
+ * rather than a single-level array of tool calls.
  */
 object OpenRouterToolCallDeserializer extends ToolCallDeserializer {
 

--- a/src/main/scala/org/llm4s/trace/LangfuseTracing.scala
+++ b/src/main/scala/org/llm4s/trace/LangfuseTracing.scala
@@ -278,23 +278,6 @@ class LangfuseTracing(
             )
           )
           batchEvents += eventEvent
-        case _ =>
-          val eventEvent = ujson.Obj(
-            "id"        -> uuid,
-            "timestamp" -> now,
-            "type"      -> "event-create",
-            "body" -> ujson.Obj(
-              "id"        -> s"${traceId}-event-$idx",
-              "traceId"   -> traceId,
-              "name"      -> s"Message $idx: ${msg.role}",
-              "startTime" -> now,
-              "input"     -> ujson.Obj("content" -> msg.content),
-              "metadata" -> ujson.Obj(
-                "role" -> msg.role.name
-              )
-            )
-          )
-          batchEvents += eventEvent
       }
     }
     sendBatch(batchEvents.toSeq)

--- a/src/main/scala/org/llm4s/trace/PrintTracing.scala
+++ b/src/main/scala/org/llm4s/trace/PrintTracing.scala
@@ -68,7 +68,6 @@ class PrintTracing extends Tracing {
         case Assistant => GREEN
         case System    => YELLOW
         case Tool      => CYAN
-        case _         => GRAY
       }
 
       println(s"${BOLD}Message ${idx + 1} (${roleColor}${msg.role}${RESET}${BOLD}):$RESET")

--- a/src/main/scala/org/llm4s/types/typeclass/LLMFunctor.scala
+++ b/src/main/scala/org/llm4s/types/typeclass/LLMFunctor.scala
@@ -1,6 +1,6 @@
 package org.llm4s.types.typeclass
 
-import cats.Functor
+import cats.{ Functor => CatsFunctor }
 import org.llm4s.types.Result
 
 /**
@@ -12,15 +12,15 @@ trait LLMFunctor[F[_]] {
 }
 
 object Functor {
-  def apply[F[_]](implicit ev: Functor[F]): Functor[F] = ev
+  def apply[F[_]](implicit ev: CatsFunctor[F]): CatsFunctor[F] = ev
 
   // Extension methods
-  implicit class FunctorOps[F[_]: Functor, A](fa: F[A]) {
-    def map[B](f: A => B): F[B] = Functor[F].map(fa)(f)
+  implicit class FunctorOps[F[_]: CatsFunctor, A](fa: F[A]) {
+    def map[B](f: A => B): F[B] = CatsFunctor[F].map(fa)(f)
   }
 
   // Result instance
-  implicit val resultFunctor: Functor[Result] = new Functor[Result] {
+  implicit val resultFunctor: CatsFunctor[Result] = new CatsFunctor[Result] {
     def map[A, B](fa: Result[A])(f: A => B): Result[B] = fa.map(f)
   }
 }

--- a/src/test/scala/org/llm4s/embeddingsupport/EmbedxV2Spec.scala
+++ b/src/test/scala/org/llm4s/embeddingsupport/EmbedxV2Spec.scala
@@ -1,22 +1,19 @@
 package embeddingsupport
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-
+import org.llm4s.config.ConfigReader.LLMConfig
+import org.llm4s.llmconnect.EmbeddingClient
+import org.llm4s.llmconnect.config.{ EmbeddingConfig, ModelDimensionRegistry }
 import org.llm4s.llmconnect.encoding.UniversalEncoder
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.provider.EmbeddingProvider
-import org.llm4s.llmconnect.EmbeddingClient
 import org.llm4s.llmconnect.utils.ModelSelector
-import org.llm4s.llmconnect.config.{ EmbeddingConfig, ModelDimensionRegistry }
-import org.llm4s.config.ConfigReader
-import org.llm4s.config.ConfigReader.LLMConfig
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-import java.nio.file.{ Files, Path }
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
-import javax.imageio.ImageIO
 import java.awt.image.BufferedImage
+import java.nio.{ ByteBuffer, ByteOrder }
+import java.nio.file.{ Files, Path }
+import javax.imageio.ImageIO
 
 /**
  * Lean, high-signal tests for Embedx-v2.


### PR DESCRIPTION
Prevent main class discovery in library projects.
Remove redundant default cases and unused parameters. Clarify comment on OpenRouter's double-nested array structure in `ToolCallDeserializer.scala`
- Escape string interpolation in `OpenAIImageClient.scala` example
- Rename `Functor` to `CatsFunctor` for clarity in `LLMFunctor.scala`
- Fix formatting of code comment in `ToolCallDeserializer.scala`
- Fix wildcard import syntax in `EmbeddingExample.scala`
- Remove unused import in `TracingUtil.scala`