### PR TITLE
🚀 [EmbedX] Code Cleanup (Phase 1) + PGVector Integration (Phase 2)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -240,7 +240,6 @@ lazy val samples = (project in file("samples"))
 
 lazy val crossLibDependencies = Def.setting {
   Seq(
-    "org.llm4s"     %% "llm4s"     % version.value,
     "org.scalatest" %% "scalatest" % "3.2.19" % Test,
     "com.softwaremill.sttp.client4" %% "core"  % "4.0.9",
     "com.lihaoyi"                   %% "ujson" % "4.2.1",
@@ -254,22 +253,25 @@ lazy val crossLibDependencies = Def.setting {
 
 lazy val crossTestScala2 = (project in file("crosstest/scala2"))
   .settings(
-    name               := "crosstest-scala2",
-    scalaVersion       := scala213,
-    resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.defaultLocal,
-    libraryDependencies ++= crossLibDependencies.value
+    name         := "crosstest-scala2",
+    scalaVersion := scala213,
+    libraryDependencies ++= crossLibDependencies.value ++ Seq(
+      "org.llm4s" %% "llm4s" % (ThisBuild / version).value % Test
+    )
   )
 
+
 lazy val crossTestScala3 = (project in file("crosstest/scala3"))
+  .dependsOn(root % "compile->compile;test->test") // fine: both are Scala 3
   .settings(
-    name               := "crosstest-scala3",
-    scalaVersion       := scala3,
-    resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.defaultLocal,
+    name         := "crosstest-scala3",
+    scalaVersion := scala3,
+    resolvers   += Resolver.mavenLocal,
+    resolvers   += Resolver.defaultLocal,
     libraryDependencies ++= crossLibDependencies.value,
     scalacOptions ++= scala3CompilerOptions
   )
+
 
 addCommandAlias("buildAll", ";clean;+compile;+test")
 addCommandAlias("publishAll", ";clean;+publish")


### PR DESCRIPTION
## 📌 Summary
This PR lands a two-phase update:

- **Phase 1 — Code Cleanup:** consolidate configs, remove dead code, align naming, tame warnings, and improve logs/tests.  
- **Phase 2 — PGVector Integration:** add a PostgreSQL/pgvector backing store for embeddings with similarity search, fully config-driven.

---

## 🎯 Why
- Reduce technical debt and friction in `samples` and `llmconnect` modules.  
- Provide a **first-class, SQL-native** vector store (no extra infra) to support retrieval and future RAG samples.  

---

## 🔄 Scope & Changes

### Phase 1 — Code Cleanup
- **Config hygiene**
  - Single source of truth for embedding provider + model (static, config-driven).
  - Removed legacy dynamic model switching and unused knobs.
- **API consistency**
  - Normalized names across: `EmbeddingClient`, provider request/response models, and extractors.
  - Clear, typed errors replacing ad-hoc `Either[String, …]`.
- **Warnings & formatting**
  - Removed unused imports/params; aligned with scalafmt/scalafix and CI settings.
- **Observability**
  - Consistent structured logging (correlation IDs where available).
- **Tests**
  - Stable test seeds and deterministic sample fixtures.
- **Docs**
  - Updated comments and README entries to match current behavior.

### Phase 2 — PGVector Integration
- **Storage**
  - Abstraction: `VectorStore` → `PGVectorStore` implementation.
  - Insert/upsert embeddings with metadata; query by cosine similarity (Top-K).
- **Config**
  - `.env` / HOCON entries for DB url, user, table, etc.
  - No code changes required to switch environments.
- **Examples**
  - Sample flow: extract → embed → persist → query (document + query vectors).

---
