### PR TITLE
Fixed codex observation

### DIFF
--- a/samples/src/main/scala/org/llm4s/samples/SpeechSamples.scala
+++ b/samples/src/main/scala/org/llm4s/samples/SpeechSamples.scala
@@ -178,7 +178,7 @@ object SpeechSamples {
     val dataSize = sampleRate * duration * channels * bytesPerSample
     val fileSize = 36 + dataSize
 
-    val writeFileTry = for {
+    for {
       path <- makePath("whisper-speech", ".wav")
       _ <- Using.Manager { use =>
         val fos = use(new FileOutputStream(path.toFile))


### PR DESCRIPTION
Not sure how it compiled earlier - but looks like codex is right...

```
-    val writeFileTry = for { // This was some wrong edit - which I forgot to remove
+    for {
       path <- makePath("whisper-speech", ".wav")
...
```
I just double checked - and indeed the error, as pointed out - should have triggered...

Ironically the earlier version compiled fine 
      I compile for both Scala versions locally - and after running the scalafmtAll task just in case - then push... We do have the Github Actions CD pipeline - which also repeats the process...
      Really this is the first time I see the Scala compiler missing something like this... 

Anyways good that the fix is going in...    