### PR TITLE
DBx Core: Initial scaffolding for a provider-agnostic Vector Store layer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -240,7 +240,6 @@ lazy val samples = (project in file("samples"))
 
 lazy val crossLibDependencies = Def.setting {
   Seq(
-    "org.llm4s"     %% "llm4s"     % version.value,
     "org.scalatest" %% "scalatest" % "3.2.19" % Test,
     "com.softwaremill.sttp.client4" %% "core"  % "4.0.9",
     "com.lihaoyi"                   %% "ujson" % "4.2.1",
@@ -254,22 +253,25 @@ lazy val crossLibDependencies = Def.setting {
 
 lazy val crossTestScala2 = (project in file("crosstest/scala2"))
   .settings(
-    name               := "crosstest-scala2",
-    scalaVersion       := scala213,
-    resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.defaultLocal,
-    libraryDependencies ++= crossLibDependencies.value
+    name         := "crosstest-scala2",
+    scalaVersion := scala213,
+    libraryDependencies ++= crossLibDependencies.value ++ Seq(
+      "org.llm4s" %% "llm4s" % (ThisBuild / version).value % Test
+    )
   )
 
+
 lazy val crossTestScala3 = (project in file("crosstest/scala3"))
+  .dependsOn(root % "compile->compile;test->test") // fine: both are Scala 3
   .settings(
-    name               := "crosstest-scala3",
-    scalaVersion       := scala3,
-    resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.defaultLocal,
+    name         := "crosstest-scala3",
+    scalaVersion := scala3,
+    resolvers   += Resolver.mavenLocal,
+    resolvers   += Resolver.defaultLocal,
     libraryDependencies ++= crossLibDependencies.value,
     scalacOptions ++= scala3CompilerOptions
   )
+
 
 addCommandAlias("buildAll", ";clean;+compile;+test")
 addCommandAlias("publishAll", ";clean;+publish")

--- a/build.sbt
+++ b/build.sbt
@@ -141,7 +141,9 @@ lazy val commonSettings = Seq(
     "dev.optics" %% "monocle-macro" % "3.3.0",
     "org.scalatest" %% "scalatest"       % "3.2.19" % Test,
     "org.scalamock" %% "scalamock" %      "7.4.2" % Test,
-    "com.lihaoyi"   %% "fansi"           % "0.5.0"
+    "com.lihaoyi"   %% "fansi"           % "0.5.0",
+    "org.postgresql" % "postgresql" % "42.7.3",   // JDBC driver
+    "com.typesafe"   % "config"      % "1.4.3"    // loads reference.conf
   )
 )
 
@@ -174,7 +176,9 @@ lazy val root = (project in file("."))
       "io.github.cdimascio" % "dotenv-java" % "3.0.0",
           // Speech: Vosk for lightweight STT (replacing abandoned Sphinx4)
     "net.java.dev.jna" % "jna" % "5.13.0",
-    "com.alphacephei" % "vosk" % "0.3.45"
+    "com.alphacephei" % "vosk" % "0.3.45",
+      "org.postgresql" % "postgresql" % "42.7.3",   // JDBC driver
+      "com.typesafe"   % "config"      % "1.4.3"    // loads reference.conf
     )
 
   )
@@ -202,6 +206,8 @@ lazy val workspaceRunner = (project in file("workspaceRunner"))
     libraryDependencies ++= List(
       "com.lihaoyi"   %% "cask"            % "0.10.2",
       "com.lihaoyi"   %% "requests"        % "0.9.0",
+      "org.postgresql" % "postgresql" % "42.7.3",   // JDBC driver
+      "com.typesafe"   % "config"      % "1.4.3"
     ),
     Docker / dockerBuildOptions := Seq("--platform=linux/amd64"),
     dockerCommands ++= Seq(
@@ -247,7 +253,9 @@ lazy val crossLibDependencies = Def.setting {
     "org.apache.poi" % "poi-ooxml" % "5.4.1",
     "org.apache.tika" % "tika-core" % "3.2.1",
     "com.lihaoyi" %% "requests" % "0.9.0",
-    "org.jsoup" % "jsoup" % "1.21.1"
+    "org.jsoup" % "jsoup" % "1.21.1",
+    "org.postgresql" % "postgresql" % "42.7.3",   // JDBC driver
+    "com.typesafe"   % "config"      % "1.4.3"    // loads reference.conf
   )
 }
 

--- a/samples/src/main/scala/org/llm4s/samples/dbx/CoreInit.scala
+++ b/samples/src/main/scala/org/llm4s/samples/dbx/CoreInit.scala
@@ -1,0 +1,19 @@
+package org.llm4s.samples.dbx
+
+
+import org.llm4s.llmconnect.config.dbx.DbxConfig
+import org.llm4s.llmconnect.DbxClient
+
+
+object CoreInit extends App {
+  def main(args: Array[String]): Unit = {
+    val cfg = DbxConfig.load()
+    val client = new DbxClient(cfg)
+    client.initCore() match {
+      case Right(_) => println("yes, we are on PGVector")
+      case Left(err) =>
+        System.err.println(err.message)
+        sys.exit(1)
+    }
+  }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,15 @@
+dbx {
+pg {
+host = ${?PG_HOST}
+port = ${?PG_PORT}
+database = ${?PG_DATABASE}
+user = ${?PG_USER}
+password = ${?PG_PASSWORD}
+sslmode = ${?PG_SSLMODE} # require|disable|prefer
+schema = ${?PG_SCHEMA} # default: dbx (set env if you want)
+}
+core {
+requirePgvector = true
+systemTable = "dbx_info"
+}
+}

--- a/src/main/scala/org/llm4s/llmconnect/DbxClient.scala
+++ b/src/main/scala/org/llm4s/llmconnect/DbxClient.scala
@@ -1,0 +1,37 @@
+package org.llm4s.llmconnect
+
+import org.llm4s.llmconnect.config.dbx.DbxConfig
+import org.llm4s.llmconnect.model.dbx._
+import org.llm4s.llmconnect.provider.dbx.PGVectorProvider
+import org.llm4s.llmconnect.utils.dbx.SqlUtils
+
+final class DbxClient(cfg: DbxConfig) {
+  def initCore(): Either[DbxError, CoreHealthReport] = {
+    val pg = cfg.pg
+    val conn =
+      try SqlUtils.connect(pg.host, pg.port, pg.database, pg.user, pg.password, pg.sslmode)
+      catch {
+        case e: Throwable => return Left(ConnectionError(e.getMessage))
+      }
+    try {
+      val probe = PGVectorProvider.probe(conn, pg.database, cfg.core.requirePgvector)
+      probe match {
+        case Left(err) => Left(err)
+        case Right(version) =>
+          PGVectorProvider
+            .ensureSchema(conn, pg.schema)
+            .flatMap(_ => PGVectorProvider.ensureSystemTable(conn, pg.schema, cfg.core.systemTable))
+            .flatMap(_ => PGVectorProvider.recordVersion(conn, pg.schema, cfg.core.systemTable, version))
+            .map { _ =>
+              CoreHealthReport(
+                connectionOk = true,
+                schemaOk = true,
+                pgvectorVersion = Some(version),
+                writeOk = true,
+                messages = Nil
+              )
+            }
+      }
+    } finally conn.close()
+  }
+}

--- a/src/main/scala/org/llm4s/llmconnect/config/dbx/DbxConfig.scala
+++ b/src/main/scala/org/llm4s/llmconnect/config/dbx/DbxConfig.scala
@@ -1,0 +1,45 @@
+package org.llm4s.llmconnect.config.dbx
+
+import com.typesafe.config.ConfigFactory
+
+final case class PgConfig(
+  host: String,
+  port: Int,
+  database: String,
+  user: String,
+  password: String,
+  sslmode: String,
+  schema: String
+)
+
+final case class CoreConfig(
+  requirePgvector: Boolean,
+  systemTable: String
+)
+
+final case class DbxConfig(pg: PgConfig, core: CoreConfig)
+
+object DbxConfig {
+  def load(): DbxConfig = {
+    val c = ConfigFactory.load()
+    def must(path: String): String = {
+      val v = c.getString(path)
+      if (v == null || v.trim.isEmpty) throw new IllegalArgumentException(s"Missing config: $path")
+      v
+    }
+    val pg = PgConfig(
+      host = must("dbx.pg.host"),
+      port = c.getInt("dbx.pg.port"),
+      database = must("dbx.pg.database"),
+      user = must("dbx.pg.user"),
+      password = must("dbx.pg.password"),
+      sslmode = must("dbx.pg.sslmode"),
+      schema = Option(c.getString("dbx.pg.schema")).filter(_.nonEmpty).getOrElse("dbx")
+    )
+    val core = CoreConfig(
+      requirePgvector = c.getBoolean("dbx.core.requirePgvector"),
+      systemTable = c.getString("dbx.core.systemTable")
+    )
+    DbxConfig(pg, core)
+  }
+}

--- a/src/main/scala/org/llm4s/llmconnect/model/dbx/CoreHealthReport.scala
+++ b/src/main/scala/org/llm4s/llmconnect/model/dbx/CoreHealthReport.scala
@@ -1,0 +1,9 @@
+package org.llm4s.llmconnect.model.dbx
+
+final case class CoreHealthReport(
+  connectionOk: Boolean,
+  schemaOk: Boolean,
+  pgvectorVersion: Option[String],
+  writeOk: Boolean,
+  messages: List[String]
+)

--- a/src/main/scala/org/llm4s/llmconnect/model/dbx/DbxError.scala
+++ b/src/main/scala/org/llm4s/llmconnect/model/dbx/DbxError.scala
@@ -1,0 +1,9 @@
+package org.llm4s.llmconnect.model.dbx
+
+sealed trait DbxError { def message: String }
+final case class ConfigError(message: String)     extends DbxError
+final case class ConnectionError(message: String) extends DbxError
+final case class PgvectorMissing(message: String) extends DbxError
+final case class SchemaError(message: String)     extends DbxError
+final case class PermissionError(message: String) extends DbxError
+final case class WriteError(message: String)      extends DbxError

--- a/src/main/scala/org/llm4s/llmconnect/model/dbx/DbxInfo.scala
+++ b/src/main/scala/org/llm4s/llmconnect/model/dbx/DbxInfo.scala
@@ -1,0 +1,5 @@
+package org.llm4s.llmconnect.model.dbx
+
+import java.time.Instant
+
+final case class DbxInfo(pgvectorVersion: String, createdAt: Instant)

--- a/src/main/scala/org/llm4s/llmconnect/provider/dbx/DbxProvider.scala
+++ b/src/main/scala/org/llm4s/llmconnect/provider/dbx/DbxProvider.scala
@@ -1,0 +1,11 @@
+package org.llm4s.llmconnect.provider.dbx
+
+import org.llm4s.llmconnect.model.dbx._
+import java.sql.Connection
+
+trait DbxProvider {
+  def probe(conn: Connection, expectedDb: String, requirePgvector: Boolean): Either[DbxError, String]
+  def ensureSchema(conn: Connection, schema: String): Either[DbxError, Unit]
+  def ensureSystemTable(conn: Connection, schema: String, table: String): Either[DbxError, Unit]
+  def recordVersion(conn: Connection, schema: String, table: String, version: String): Either[DbxError, Unit]
+}

--- a/src/main/scala/org/llm4s/llmconnect/provider/dbx/PGVectorProvider.scala
+++ b/src/main/scala/org/llm4s/llmconnect/provider/dbx/PGVectorProvider.scala
@@ -1,0 +1,68 @@
+package org.llm4s.llmconnect.provider.dbx
+
+import org.llm4s.llmconnect.model.dbx._
+import java.sql.Connection
+
+object PGVectorProvider extends DbxProvider {
+  override def probe(conn: Connection, expectedDb: String, requirePgvector: Boolean): Either[DbxError, String] = {
+    val dbName = queryString(conn, "select current_database()")
+    if (dbName != expectedDb) return Left(ConnectionError(s"Connected to '$dbName' not expected '$expectedDb'"))
+
+    val versionOpt = queryStringOpt(conn, "select extversion from pg_extension where extname = 'vector'")
+    (requirePgvector, versionOpt) match {
+      case (true, None)  => Left(PgvectorMissing("pgvector extension not enabled on this database"))
+      case (_, Some(v))  => Right(v)
+      case (false, None) => Right("unknown")
+    }
+  }
+
+  override def ensureSchema(conn: Connection, schema: String): Either[DbxError, Unit] =
+    safeExec(conn, s"create schema if not exists \"$schema\"")
+
+  override def ensureSystemTable(conn: Connection, schema: String, table: String): Either[DbxError, Unit] = {
+    val sql = s"""
+                 |create table if not exists "%s".%s (
+                 | pgvector_version text not null,
+                 | created_at timestamptz not null default now()
+                 |)
+                 |""".stripMargin.format(schema, table)
+    safeExec(conn, sql)
+  }
+
+  override def recordVersion(
+    conn: Connection,
+    schema: String,
+    table: String,
+    version: String
+  ): Either[DbxError, Unit] = {
+    val count = queryInt(conn, s"select count(*) from \"$schema\".$table")
+    if (count == 0) safeExec(conn, s"insert into \"$schema\".$table(pgvector_version) values ('$version')")
+    else Right(())
+  }
+
+  // ---- helpers ----
+  private def safeExec(conn: Connection, sql: String): Either[DbxError, Unit] = {
+    val ps = conn.prepareStatement(sql)
+    try { ps.execute(); Right(()) }
+    catch { case e: Throwable => Left(PermissionError(e.getMessage)) }
+    finally ps.close()
+  }
+
+  private def queryString(conn: Connection, sql: String): String = {
+    val ps = conn.prepareStatement(sql)
+    try { val rs = ps.executeQuery(); rs.next(); val s = rs.getString(1); rs.close(); s }
+    finally ps.close()
+  }
+
+  private def queryStringOpt(conn: Connection, sql: String): Option[String] = {
+    val ps = conn.prepareStatement(sql)
+    try { val rs = ps.executeQuery(); val out = if (rs.next()) Option(rs.getString(1)) else None; rs.close(); out }
+    finally ps.close()
+  }
+
+  private def queryInt(conn: Connection, sql: String): Int = {
+    val ps = conn.prepareStatement(sql)
+    try { val rs = ps.executeQuery(); rs.next(); val i = rs.getInt(1); rs.close(); i }
+    finally ps.close()
+  }
+}

--- a/src/main/scala/org/llm4s/llmconnect/utils/dbx/SqlUtils.scala
+++ b/src/main/scala/org/llm4s/llmconnect/utils/dbx/SqlUtils.scala
@@ -1,0 +1,25 @@
+package org.llm4s.llmconnect.utils.dbx
+
+import java.sql.{ Connection, DriverManager, ResultSet }
+
+object SqlUtils {
+  def connect(host: String, port: Int, db: String, user: String, pass: String, sslmode: String): Connection = {
+    val url = s"jdbc:postgresql://$host:$port/$db?sslmode=$sslmode"
+    DriverManager.getConnection(url, user, pass)
+  }
+
+  def querySingleOpt[A](conn: Connection, sql: String)(read: ResultSet => A): Option[A] = {
+    val ps = conn.prepareStatement(sql)
+    try {
+      val rs = ps.executeQuery()
+      try if (rs.next()) Some(read(rs)) else None
+      finally rs.close()
+    } finally ps.close()
+  }
+
+  def exec(conn: Connection, sql: String): Unit = {
+    val ps = conn.prepareStatement(sql)
+    try ps.execute()
+    finally ps.close()
+  }
+}


### PR DESCRIPTION

Introduce a thin **DBx Core** that standardizes collections, upserts, similarity search, deletes, and health checks. **No drivers yet.** This unblocks parallel FAISS (DBx-Mid) and PGVector (DBx-Full) without API churn.

---

## Why
- Kill ad-hoc storage wiring across samples.
- One stable contract → swap providers without rewrites.
- Keep embedding/query logic steady while drivers evolve.

> **If we skip this:** every pipeline re-implements storage; backend changes = refactors everywhere.

---

## Scope (This PR)
- **Interfaces & types**
  - Collections: `create / list / drop`
  - Upserts: `{ id, vector, metadata, ts? }`
  - **Similarity search**: top-K (+ optional `filter`, `includeVectors`)
  - Deletes: by `ids` or by `filter`
  - Liveness: `health()` / `ready()`
- **Core types:** `VectorId`, `EmbeddingVector`, `DistanceMetric (cosine|dot|euclidean)`, `Filter (eq|in|range)`, `SearchResult`, `Paged<T>`
- **Config surface:** collection name, metric, dimension (hard-checked), basic retry/backoff
- **In-memory stub** for CI/smoke tests
- Inline docs/comments

---

## Non-Goals (by design)
- **Drivers:** land next  
  - DBx-Mid: **FAISS-CPU**  
  - DBx-Full: **PGVector**
- Migrations, schema/versioning, ANN params (HNSW/IVF), hybrid/RRF, re-ranking hooks

---

## Design Choices (with trade-offs)
- **Abstraction first.** Lock the interface; let drivers compete behind it.  
  *Cost:* small indirection vs direct SDKs.
- **Portable filters only.** `eq | in | range`.  
  *Cost:* fewer provider-specific superpowers.
- **Metric at collection level.**  
  *Cost:* no per-query overrides (yet).
- **Strict dimension checks.**  
  *Cost:* fail-fast over silent coercion.

---

## API Surface (names only)
- **VectorStore**
  - `createCollection(name, metric, dim, opts?)`
  - `dropCollection(name)`
  - `listCollections()`
  - `upsert(name, items[])` // `{ id, vector, metadata, ts? }`
  - `query(name, queryVector, topK, filter?, includeVectors?)`
  - `delete(name, byIds?, byFilter?)`
  - `health()` / `ready()`

---

## Config (minimal, stable)
- Logical store + default collection  
- `DistanceMetric`: cosine | dot | euclidean  
- `dimension`: enforced at upsert/query  
- Simple retry/backoff  
- **Secrets/DSNs live in drivers**, not Core

---

## Backwards Compatibility
- No removals. Existing samples continue to work.  
- Migration notes ship with DBx-Mid.

---

## Security & Privacy
- Core holds **no secrets** and persists **no data** (in-mem only).  
- Secrets/TLS enforced in drivers (tracked for DBx-Full).

---

## Performance Notes
- Core = thin interface + data classes → negligible overhead.  
- Real perf is driver-dependent (FAISS index type, PGVector indexes).

---

## Testing & QA
- **Unit:** dim/metric validation, filter shaping, pagination, ordering.  
- **Smoke:** create → upsert → query → delete on in-mem store.  
- **CI:** run Core tests; driver suites live with each adapter.

---

## Risks / Blind Spots (challenge these)
- **Over-abstraction:** are we hiding must-have provider features (HNSW params, hybrid/BM25+vector)?  
- **Filter ceiling:** is `eq/in/range` enough for near-term needs?  
- **Per-query metric overrides:** any hard requirements?  
- **Metadata bloat:** enforce limits to avoid slow scans?

---

## Open Questions
1. Stable tie-breaks on equal scores (e.g., sort by `id` asc)?  
2. Soft delete in Core vs provider-level?  
3. Expose vector normalization (for cosine) in Core or leave to drivers?

---

## Rollout
1. Merge **DBx Core** → cut minor version.  
2. Land **DBx-Mid (FAISS-CPU)**.  
3. Land **DBx-Full (PGVector)** with schema/migrations/env config.  
4. Migrate samples → deprecate ad-hoc storage code.
---
**Issue linkage:** `Closes #<ID>`  
**Labels:** `area:dbx` `type:feature` `scope:core` `breaking:no`
