### PR TITLE
Fix tool call failures and improve error messages

### DIFF
--- a/src/main/scala/org/llm4s/mcp/MCPToolRegistry.scala
+++ b/src/main/scala/org/llm4s/mcp/MCPToolRegistry.scala
@@ -49,7 +49,7 @@ class MCPToolRegistry(
             } catch {
               case e: Exception =>
                 logger.error(s"MCP tool ${request.functionName} execution failed", e)
-                Left(ToolCallError.ExecutionError(e))
+                Left(ToolCallError.ExecutionError(request.functionName, e))
             }
           case None =>
             logger.warn(s"Tool ${request.functionName} not found in any registry (local or MCP)")

--- a/src/main/scala/org/llm4s/toolapi/EnhancedParameterExtractor.scala
+++ b/src/main/scala/org/llm4s/toolapi/EnhancedParameterExtractor.scala
@@ -1,0 +1,188 @@
+package org.llm4s.toolapi
+
+import scala.annotation.tailrec
+
+/**
+ * Enhanced parameter extraction with structured error reporting
+ */
+case class EnhancedParameterExtractor(params: ujson.Value) {
+
+  def getString(path: String): Either[ToolParameterError, String] =
+    extract(path, _.strOpt, "string")
+
+  def getInt(path: String): Either[ToolParameterError, Int] =
+    extract(path, _.numOpt.map(_.toInt), "integer")
+
+  def getDouble(path: String): Either[ToolParameterError, Double] =
+    extract(path, _.numOpt, "number")
+
+  def getBoolean(path: String): Either[ToolParameterError, Boolean] =
+    extract(path, _.boolOpt, "boolean")
+
+  def getArray(path: String): Either[ToolParameterError, ujson.Arr] =
+    extract(path, v => Option(v).collect { case arr: ujson.Arr => arr }, "array")
+
+  def getObject(path: String): Either[ToolParameterError, ujson.Obj] =
+    extract(path, v => Option(v).collect { case obj: ujson.Obj => obj }, "object")
+
+  // Get an optional parameter (returns None if missing, Left if wrong type)
+  def getOptionalString(path: String): Either[ToolParameterError, Option[String]] =
+    extractOptional(path, _.strOpt, "string")
+
+  def getOptionalInt(path: String): Either[ToolParameterError, Option[Int]] =
+    extractOptional(path, _.numOpt.map(_.toInt), "integer")
+
+  def getOptionalDouble(path: String): Either[ToolParameterError, Option[Double]] =
+    extractOptional(path, _.numOpt, "number")
+
+  def getOptionalBoolean(path: String): Either[ToolParameterError, Option[Boolean]] =
+    extractOptional(path, _.boolOpt, "boolean")
+
+  private def extract[T](
+    path: String,
+    extractor: ujson.Value => Option[T],
+    expectedType: String
+  ): Either[ToolParameterError, T] = {
+    val pathParts = if (path.contains('.')) path.split('.').toList else List(path)
+
+    navigateToValue(pathParts, params) match {
+      case Left(error) => Left(error)
+      case Right(None) =>
+        // Parameter is missing
+        val availableParams = params match {
+          case obj: ujson.Obj => obj.obj.keys.toList.sorted
+          case _              => Nil
+        }
+        Left(ToolParameterError.MissingParameter(path, expectedType, availableParams))
+      case Right(Some(ujson.Null)) =>
+        // Parameter exists but is null
+        Left(ToolParameterError.NullParameter(path, expectedType))
+      case Right(Some(value)) =>
+        // Try to extract the value with the correct type
+        extractor(value) match {
+          case Some(result) => Right(result)
+          case None =>
+            val actualType = getValueType(value)
+            Left(ToolParameterError.TypeMismatch(path, expectedType, actualType))
+        }
+    }
+  }
+
+  private def extractOptional[T](
+    path: String,
+    extractor: ujson.Value => Option[T],
+    expectedType: String
+  ): Either[ToolParameterError, Option[T]] = {
+    val pathParts = if (path.contains('.')) path.split('.').toList else List(path)
+
+    navigateToValue(pathParts, params) match {
+      case Left(error)             => Left(error)
+      case Right(None)             => Right(None) // Optional parameter missing is OK
+      case Right(Some(ujson.Null)) => Right(None) // Null for optional is OK
+      case Right(Some(value)) =>
+        extractor(value) match {
+          case Some(result) => Right(Some(result))
+          case None =>
+            val actualType = getValueType(value)
+            Left(ToolParameterError.TypeMismatch(path, expectedType, actualType))
+        }
+    }
+  }
+
+  private def navigateToValue(
+    pathParts: List[String],
+    current: ujson.Value
+  ): Either[ToolParameterError, Option[ujson.Value]] = {
+
+    @tailrec
+    def navigate(
+      parts: List[String],
+      value: ujson.Value,
+      traversedPath: List[String]
+    ): Either[ToolParameterError, Option[ujson.Value]] =
+      parts match {
+        case Nil => Right(Some(value))
+        case head :: tail =>
+          value match {
+            case ujson.Null =>
+              val parentPath = traversedPath.mkString(".")
+              Left(
+                ToolParameterError.InvalidNesting(
+                  head,
+                  if (parentPath.isEmpty) "root" else parentPath,
+                  "null"
+                )
+              )
+            case obj: ujson.Obj =>
+              obj.obj.get(head) match {
+                case Some(nextValue) =>
+                  navigate(tail, nextValue, traversedPath :+ head)
+                case None =>
+                  if (tail.isEmpty) {
+                    // This is the final parameter we're looking for
+                    Right(None)
+                  } else {
+                    // We're trying to navigate deeper but intermediate path is missing
+                    val fullPath = (traversedPath :+ head).mkString(".")
+                    Left(
+                      ToolParameterError.MissingParameter(
+                        fullPath,
+                        "object",
+                        obj.obj.keys.toList.sorted
+                      )
+                    )
+                  }
+              }
+            case other =>
+              val parentPath = traversedPath.mkString(".")
+              Left(
+                ToolParameterError.InvalidNesting(
+                  head,
+                  if (parentPath.isEmpty) "root" else parentPath,
+                  getValueType(other)
+                )
+              )
+          }
+      }
+
+    current match {
+      case ujson.Null if pathParts.nonEmpty =>
+        Left(
+          ToolParameterError.InvalidNesting(
+            pathParts.head,
+            "root",
+            "null"
+          )
+        )
+      case _ =>
+        navigate(pathParts, current, Nil)
+    }
+  }
+
+  private def getValueType(value: ujson.Value): String = value match {
+    case _: ujson.Str  => "string"
+    case _: ujson.Num  => "number"
+    case _: ujson.Bool => "boolean"
+    case _: ujson.Arr  => "array"
+    case _: ujson.Obj  => "object"
+    case ujson.Null    => "null"
+    case null          => "unknown"
+  }
+
+  /**
+   * Validate all required parameters at once and collect errors
+   */
+  def validateRequired(
+    requirements: (String, String)*
+  ): Either[List[ToolParameterError], Unit] = {
+    val errors = requirements.flatMap { case (path, expectedType) =>
+      extract(path, _ => Some(()), expectedType) match {
+        case Left(error) => Some(error)
+        case Right(_)    => None
+      }
+    }.toList
+
+    if (errors.isEmpty) Right(())
+    else Left(errors)
+  }
+}

--- a/src/main/scala/org/llm4s/toolapi/ToolFunction.scala
+++ b/src/main/scala/org/llm4s/toolapi/ToolFunction.scala
@@ -29,13 +29,37 @@ case class ToolFunction[T, R: ReadWriter](
   /**
    * Executes the tool with the given arguments
    */
-  def execute(args: ujson.Value): Either[ToolCallError, ujson.Value] = {
-    val extractor = SafeParameterExtractor(args)
-    handler(extractor) match {
-      case Right(result) => Right(writeJs(result))
-      case Left(error)   => Left(ToolCallError.InvalidArguments(List(error)))
+  def execute(args: ujson.Value): Either[ToolCallError, ujson.Value] =
+    // Check for null arguments first
+    args match {
+      case ujson.Null =>
+        Left(ToolCallError.NullArguments(name))
+      case _ =>
+        val extractor = SafeParameterExtractor(args)
+        handler(extractor) match {
+          case Right(result) => Right(writeJs(result))
+          case Left(error)   => Left(ToolCallError.HandlerError(name, error))
+        }
     }
-  }
+
+  /**
+   * Executes the tool with enhanced error reporting
+   * Uses EnhancedParameterExtractor for better error messages
+   */
+  def executeEnhanced(
+    args: ujson.Value,
+    enhancedHandler: EnhancedParameterExtractor => Either[List[ToolParameterError], R]
+  ): Either[ToolCallError, ujson.Value] =
+    args match {
+      case ujson.Null =>
+        Left(ToolCallError.NullArguments(name))
+      case _ =>
+        val extractor = EnhancedParameterExtractor(args)
+        enhancedHandler(extractor) match {
+          case Right(result) => Right(writeJs(result))
+          case Left(errors)  => Left(ToolCallError.InvalidArguments(name, errors))
+        }
+    }
 }
 
 /**

--- a/src/main/scala/org/llm4s/toolapi/ToolParameterError.scala
+++ b/src/main/scala/org/llm4s/toolapi/ToolParameterError.scala
@@ -1,0 +1,141 @@
+package org.llm4s.toolapi
+
+/**
+ * Structured error information for tool parameter validation
+ */
+sealed trait ToolParameterError {
+  def parameterName: String
+  def getMessage: String
+}
+
+object ToolParameterError {
+
+  /**
+   * A required parameter is completely missing from the arguments
+   */
+  case class MissingParameter(
+    parameterName: String,
+    expectedType: String,
+    availableParameters: List[String] = Nil
+  ) extends ToolParameterError {
+    def getMessage: String = {
+      val available = if (availableParameters.nonEmpty) {
+        s" (available: ${availableParameters.mkString(", ")})"
+      } else ""
+      s"required parameter '$parameterName' (type: $expectedType) is missing$available"
+    }
+  }
+
+  /**
+   * A required parameter is present but has a null value
+   */
+  case class NullParameter(
+    parameterName: String,
+    expectedType: String
+  ) extends ToolParameterError {
+    def getMessage: String =
+      s"parameter '$parameterName' (type: $expectedType) is required but value was null"
+  }
+
+  /**
+   * A parameter has the wrong type
+   */
+  case class TypeMismatch(
+    parameterName: String,
+    expectedType: String,
+    actualType: String
+  ) extends ToolParameterError {
+    def getMessage: String =
+      s"parameter '$parameterName' has wrong type - expected $expectedType but got $actualType"
+  }
+
+  /**
+   * Cannot access a nested property because parent is not an object
+   */
+  case class InvalidNesting(
+    parameterName: String,
+    parentPath: String,
+    parentType: String
+  ) extends ToolParameterError {
+    def getMessage: String =
+      s"cannot access parameter '$parameterName' because parent '$parentPath' is $parentType, not an object"
+  }
+
+  /**
+   * Multiple parameter errors
+   */
+  case class MultipleErrors(
+    errors: List[ToolParameterError]
+  ) extends ToolParameterError {
+    def parameterName: String = errors.map(_.parameterName).mkString(", ")
+    def getMessage: String =
+      if (errors.size == 1) {
+        errors.head.getMessage
+      } else {
+        s"multiple parameter issues:\n${errors.map(e => s"  - ${e.getMessage}").mkString("\n")}"
+      }
+  }
+}
+
+/**
+ * Enhanced tool call errors with consistent formatting
+ */
+sealed trait ToolCallError {
+  def toolName: String
+  def getMessage: String
+  def getFormattedMessage: String = s"Tool call '$toolName' ${getMessage}"
+}
+
+object ToolCallError {
+
+  /**
+   * Tool function doesn't exist
+   */
+  case class UnknownFunction(toolName: String) extends ToolCallError {
+    def getMessage: String = "is not a recognized tool"
+  }
+
+  /**
+   * Tool received null arguments when it expected an object
+   */
+  case class NullArguments(toolName: String) extends ToolCallError {
+    def getMessage: String = "received null arguments - expected an object with required parameters"
+  }
+
+  /**
+   * Tool has parameter validation errors
+   */
+  case class InvalidArguments(
+    toolName: String,
+    parameterErrors: List[ToolParameterError]
+  ) extends ToolCallError {
+    def getMessage: String = {
+      val errorMessages = parameterErrors match {
+        case single :: Nil => single.getMessage
+        case multiple =>
+          s"has parameter issues:\n${multiple.map(e => s"  - ${e.getMessage}").mkString("\n")}"
+      }
+      errorMessages
+    }
+  }
+
+  /**
+   * Tool execution failed (after parameters were validated)
+   */
+  case class ExecutionError(
+    toolName: String,
+    cause: Throwable
+  ) extends ToolCallError {
+    def getMessage: String = s"failed during execution: ${cause.getMessage}"
+  }
+
+  /**
+   * Tool handler returned an error (business logic failure)
+   */
+  case class HandlerError(
+    toolName: String,
+    error: String
+  ) extends ToolCallError {
+    def getMessage: String = s"failed with error: $error"
+  }
+}

--- a/src/main/scala/org/llm4s/toolapi/ToolRegistry.scala
+++ b/src/main/scala/org/llm4s/toolapi/ToolRegistry.scala
@@ -13,16 +13,6 @@ case class ToolCallRequest(
 )
 
 /**
- * Error types for tool calls
- */
-sealed trait ToolCallError
-object ToolCallError {
-  case class UnknownFunction(name: String)          extends ToolCallError
-  case class InvalidArguments(errors: List[String]) extends ToolCallError
-  case class ExecutionError(cause: Throwable)       extends ToolCallError
-}
-
-/**
  * Registry for tool functions with execution capabilities
  */
 class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
@@ -39,7 +29,7 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
         Result
           .fromTry(Try(tool.execute(request.arguments)))
           .left
-          .map(e => ToolCallError.ExecutionError(new Exception(e.message)))
+          .map(e => ToolCallError.ExecutionError(request.functionName, new Exception(e.message)))
           .flatten
       case None => Left(ToolCallError.UnknownFunction(request.functionName))
     }

--- a/src/test/scala/org/llm4s/agent/AgentToolFailureTest.scala
+++ b/src/test/scala/org/llm4s/agent/AgentToolFailureTest.scala
@@ -1,0 +1,239 @@
+package org.llm4s.agent
+
+import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.model._
+import org.llm4s.toolapi._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import upickle.default._
+
+class AgentToolFailureTest extends AnyFlatSpec with Matchers with MockFactory {
+
+  // Result wrapper for tool response
+  case class ToolResult(message: String)
+  implicit val toolResultRW: ReadWriter[ToolResult] = macroRW[ToolResult]
+
+  // Helper to create a failing tool
+  def createFailingTool(name: String, errorMessage: String): ToolFunction[Map[String, Any], ToolResult] = {
+
+    val schema = Schema
+      .`object`[Map[String, Any]]("Tool parameters")
+      .withProperty(Schema.property("item", Schema.string("Item name")))
+      .withProperty(Schema.property("quantity", Schema.number("Quantity")))
+
+    ToolBuilder[Map[String, Any], ToolResult](
+      name,
+      "Test tool that fails",
+      schema
+    ).withHandler { _ =>
+      // Return the specified error
+      Left(errorMessage)
+    }.build()
+  }
+
+  "Agent" should "handle tool execution failures gracefully without creating empty messages" in {
+    // Create a mock LLM client
+    val mockClient = mock[LLMClient]
+
+    // Create a tool that fails with the error from the trace
+    val failingTool = createFailingTool("add_inventory_item", "Expected object at '' but found Null$")
+
+    val toolRegistry = new ToolRegistry(Seq(failingTool))
+    val agent        = new Agent(mockClient)
+
+    // Initialize agent state
+    val initialState = agent.initialize(
+      query = "Add an apple to inventory",
+      tools = toolRegistry
+    )
+
+    // First interaction: LLM requests tool call with null arguments
+    val toolCallId = "call_123"
+    val assistantResponseWithToolCall = AssistantMessage(
+      contentOpt = None,
+      toolCalls = Seq(
+        ToolCall(
+          id = toolCallId,
+          name = "add_inventory_item",
+          arguments = ujson.Null // This is the problematic null argument
+        )
+      )
+    )
+
+    val completionWithToolCall = Completion(
+      id = "completion-123",
+      created = System.currentTimeMillis() / 1000,
+      content = assistantResponseWithToolCall.content,
+      model = "test-model",
+      message = assistantResponseWithToolCall,
+      toolCalls = assistantResponseWithToolCall.toolCalls.toList,
+      usage = Some(TokenUsage(100, 50, 150))
+    )
+
+    // Mock the first LLM call that returns a tool call request
+    (mockClient.complete _)
+      .expects(*, *)
+      .returning(Right(completionWithToolCall))
+      .once()
+
+    // Run the first step - should get tool call
+    val step1Result = agent.runStep(initialState)
+    (step1Result should be).a(Symbol("right"))
+
+    val stateAfterToolCall = step1Result.getOrElse(fail("Expected successful step"))
+    stateAfterToolCall.status shouldBe AgentStatus.WaitingForTools
+
+    // Run the next step - process the tool call (which will fail)
+    val step2Result = agent.runStep(stateAfterToolCall)
+    (step2Result should be).a(Symbol("right"))
+
+    val stateAfterToolExecution = step2Result.getOrElse(fail("Expected successful step"))
+
+    // Verify the tool message was created with error content (not empty)
+    val toolMessages = stateAfterToolExecution.conversation.messages.collect { case tm: ToolMessage => tm }
+
+    toolMessages should have size 1
+    val toolMessage = toolMessages.head
+    toolMessage.toolCallId shouldBe toolCallId
+    toolMessage.content should not be empty
+    toolMessage.content should include("isError")
+    toolMessage.content should include("Tool call 'add_inventory_item'")
+    toolMessage.content should include("received null arguments")
+
+    // Verify the message passes validation
+    (toolMessage.validate should be).a(Symbol("right"))
+
+    // The state should be ready to continue (InProgress)
+    stateAfterToolExecution.status shouldBe AgentStatus.InProgress
+
+    // Verify the conversation is valid
+    val validationResult = Message.validateConversation(stateAfterToolExecution.conversation.messages.toList)
+    (validationResult should be).a(Symbol("right"))
+  }
+
+  "Agent" should "handle tool execution with empty error messages" in {
+    val mockClient = mock[LLMClient]
+
+    // Create a tool that fails with an empty error message
+    val failingTool = createFailingTool("test_tool", "")
+
+    val toolRegistry = new ToolRegistry(Seq(failingTool))
+    val agent        = new Agent(mockClient)
+
+    val initialState = agent.initialize(
+      query = "Test query",
+      tools = toolRegistry
+    )
+
+    val toolCallId = "call_456"
+    val assistantResponseWithToolCall = AssistantMessage(
+      contentOpt = Some("I'll use the test tool"),
+      toolCalls = Seq(
+        ToolCall(
+          id = toolCallId,
+          name = "test_tool",
+          arguments = ujson.Obj()
+        )
+      )
+    )
+
+    val completionWithToolCall = Completion(
+      id = "completion-123",
+      created = System.currentTimeMillis() / 1000,
+      content = assistantResponseWithToolCall.content,
+      model = "test-model",
+      message = assistantResponseWithToolCall,
+      toolCalls = assistantResponseWithToolCall.toolCalls.toList,
+      usage = Some(TokenUsage(100, 50, 150))
+    )
+
+    (mockClient.complete _)
+      .expects(*, *)
+      .returning(Right(completionWithToolCall))
+      .once()
+
+    // Run steps
+    val step1Result = agent.runStep(initialState)
+    (step1Result should be).a(Symbol("right"))
+
+    val stateAfterToolCall = step1Result.getOrElse(fail("Expected successful step"))
+    val step2Result        = agent.runStep(stateAfterToolCall)
+    (step2Result should be).a(Symbol("right"))
+
+    val stateAfterToolExecution = step2Result.getOrElse(fail("Expected successful step"))
+
+    // Verify tool message has non-empty content even with empty error
+    val toolMessages = stateAfterToolExecution.conversation.messages.collect { case tm: ToolMessage => tm }
+
+    toolMessages should have size 1
+    val toolMessage = toolMessages.head
+    toolMessage.content should not be empty
+    toolMessage.content should include("isError")
+
+    // Verify message and conversation validation
+    (toolMessage.validate should be).a(Symbol("right"))
+    (Message.validateConversation(stateAfterToolExecution.conversation.messages.toList) should be).a(Symbol("right"))
+  }
+
+  "Agent" should "handle tool execution errors with special characters" in {
+    val mockClient = mock[LLMClient]
+
+    // Create a tool that fails with special characters in error message
+    val failingTool = createFailingTool("special_char_tool", "Error with \"quotes\" and \\ backslash")
+
+    val toolRegistry = new ToolRegistry(Seq(failingTool))
+    val agent        = new Agent(mockClient)
+
+    val initialState = agent.initialize(
+      query = "Test special characters",
+      tools = toolRegistry
+    )
+
+    val assistantResponseWithToolCall = AssistantMessage(
+      contentOpt = None,
+      toolCalls = Seq(
+        ToolCall(
+          id = "call_789",
+          name = "special_char_tool",
+          arguments = ujson.Obj()
+        )
+      )
+    )
+
+    val completionWithToolCall = Completion(
+      id = "completion-123",
+      created = System.currentTimeMillis() / 1000,
+      content = assistantResponseWithToolCall.content,
+      model = "test-model",
+      message = assistantResponseWithToolCall,
+      toolCalls = assistantResponseWithToolCall.toolCalls.toList,
+      usage = Some(TokenUsage(100, 50, 150))
+    )
+
+    (mockClient.complete _)
+      .expects(*, *)
+      .returning(Right(completionWithToolCall))
+      .once()
+
+    val step1Result        = agent.runStep(initialState)
+    val stateAfterToolCall = step1Result.getOrElse(fail("Expected successful step"))
+
+    val step2Result             = agent.runStep(stateAfterToolCall)
+    val stateAfterToolExecution = step2Result.getOrElse(fail("Expected successful step"))
+
+    // Verify tool message content is valid JSON-like structure
+    val toolMessages = stateAfterToolExecution.conversation.messages.collect { case tm: ToolMessage => tm }
+
+    toolMessages should have size 1
+    val toolMessage = toolMessages.head
+    toolMessage.content should not be empty
+
+    // The error message should be properly escaped in the JSON
+    toolMessage.content should include("isError")
+
+    // Verify validation passes
+    (toolMessage.validate should be).a(Symbol("right"))
+    (Message.validateConversation(stateAfterToolExecution.conversation.messages.toList) should be).a(Symbol("right"))
+  }
+}

--- a/src/test/scala/org/llm4s/toolapi/EnhancedErrorMessagesTest.scala
+++ b/src/test/scala/org/llm4s/toolapi/EnhancedErrorMessagesTest.scala
@@ -1,0 +1,258 @@
+package org.llm4s.toolapi
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import upickle.default._
+
+class EnhancedErrorMessagesTest extends AnyFlatSpec with Matchers {
+
+  // Result type for testing
+  case class TestResult(message: String)
+  implicit val testResultRW: ReadWriter[TestResult] = macroRW[TestResult]
+
+  def createEnhancedTool(name: String = "test_tool"): ToolFunction[Map[String, Any], TestResult] = {
+    val schema = Schema
+      .`object`[Map[String, Any]]("Test parameters")
+      .withProperty(Schema.property("item", Schema.string("Item name")))
+      .withProperty(Schema.property("quantity", Schema.number("Item quantity")))
+      .withProperty(Schema.property("location", Schema.string("Storage location")))
+
+    // Create a tool that uses the EnhancedParameterExtractor internally
+    ToolBuilder[Map[String, Any], TestResult](
+      name,
+      "Test tool for enhanced error messages",
+      schema
+    ).withHandler { params =>
+      // Convert SafeParameterExtractor errors to match new format
+      val enhancedExtractor = EnhancedParameterExtractor(params.params)
+
+      val result = for {
+        item <- enhancedExtractor.getString("item")
+        qty  <- enhancedExtractor.getDouble("quantity")
+        loc  <- enhancedExtractor.getString("location")
+      } yield TestResult(s"Success: $item, $qty, $loc")
+
+      result.left.map(_.getMessage)
+    }.build()
+  }
+
+  "Enhanced error messages" should "clearly indicate null arguments" in {
+    val tool   = createEnhancedTool("add_inventory_item")
+    val result = tool.execute(ujson.Null)
+
+    (result should be).a(Symbol("left"))
+    val error   = result.left.getOrElse(fail("Expected error"))
+    val message = error.getFormattedMessage
+
+    message shouldBe "Tool call 'add_inventory_item' received null arguments - expected an object with required parameters"
+  }
+
+  "Enhanced error messages" should "clearly indicate missing required parameters" in {
+    val tool = createEnhancedTool("add_inventory_item")
+    val result = tool.execute(
+      ujson.Obj(
+        "item" -> "Apple"
+        // Missing: quantity and location
+      )
+    )
+
+    (result should be).a(Symbol("left"))
+    val error   = result.left.getOrElse(fail("Expected error"))
+    val message = error.getFormattedMessage
+
+    // Should get the first missing parameter
+    message should include("Tool call 'add_inventory_item'")
+    message should include("required parameter")
+    message should include("'quantity'")
+    message should include("(type: number)")
+    message should include("is missing")
+  }
+
+  "Enhanced error messages" should "clearly indicate null values for required parameters" in {
+    val tool = createEnhancedTool("add_inventory_item")
+    val result = tool.execute(
+      ujson.Obj(
+        "item"     -> "Apple",
+        "quantity" -> ujson.Null,
+        "location" -> "Warehouse A"
+      )
+    )
+
+    (result should be).a(Symbol("left"))
+    val error   = result.left.getOrElse(fail("Expected error"))
+    val message = error.getFormattedMessage
+
+    message shouldBe "Tool call 'add_inventory_item' failed with error: parameter 'quantity' (type: number) is required but value was null"
+  }
+
+  "Enhanced error messages" should "clearly indicate type mismatches" in {
+    val tool = createEnhancedTool("add_inventory_item")
+    val result = tool.execute(
+      ujson.Obj(
+        "item"     -> "Apple",
+        "quantity" -> "five", // Wrong type: string instead of number
+        "location" -> "Warehouse A"
+      )
+    )
+
+    (result should be).a(Symbol("left"))
+    val error   = result.left.getOrElse(fail("Expected error"))
+    val message = error.getFormattedMessage
+
+    message shouldBe "Tool call 'add_inventory_item' failed with error: parameter 'quantity' has wrong type - expected number but got string"
+  }
+
+  "Enhanced error messages" should "handle execution errors consistently" in {
+    val schema = Schema
+      .`object`[Map[String, Any]]("Test parameters")
+      .withProperty(Schema.property("value", Schema.number("A value")))
+
+    val tool = ToolBuilder[Map[String, Any], TestResult](
+      "divide_by_value",
+      "Divides 10 by the provided value",
+      schema
+    ).withHandler { params =>
+      val extractor = EnhancedParameterExtractor(params.params)
+      extractor.getDouble("value") match {
+        case Right(0)  => Left("cannot divide by zero")
+        case Right(v)  => Right(TestResult(s"Result: ${10.0 / v}"))
+        case Left(err) => Left(err.getMessage)
+      }
+    }.build()
+
+    val result = tool.execute(ujson.Obj("value" -> 0))
+
+    (result should be).a(Symbol("left"))
+    val error   = result.left.getOrElse(fail("Expected error"))
+    val message = error.getFormattedMessage
+
+    message shouldBe "Tool call 'divide_by_value' failed with error: cannot divide by zero"
+  }
+
+  "ToolParameterError messages" should "be clear and consistent" in {
+    // Test MissingParameter
+    val missing = ToolParameterError.MissingParameter(
+      "email",
+      "string",
+      List("name", "age", "address")
+    )
+    missing.getMessage shouldBe "required parameter 'email' (type: string) is missing (available: name, age, address)"
+
+    // Test NullParameter
+    val nullParam = ToolParameterError.NullParameter("age", "number")
+    nullParam.getMessage shouldBe "parameter 'age' (type: number) is required but value was null"
+
+    // Test TypeMismatch
+    val typeMismatch = ToolParameterError.TypeMismatch("count", "integer", "string")
+    typeMismatch.getMessage shouldBe "parameter 'count' has wrong type - expected integer but got string"
+
+    // Test InvalidNesting
+    val invalidNesting = ToolParameterError.InvalidNesting("name", "user", "string")
+    invalidNesting.getMessage shouldBe "cannot access parameter 'name' because parent 'user' is string, not an object"
+  }
+
+  "ToolCallError messages" should "have consistent format" in {
+    // Test UnknownFunction
+    val unknown = ToolCallError.UnknownFunction("foo_bar")
+    unknown.getFormattedMessage shouldBe "Tool call 'foo_bar' is not a recognized tool"
+
+    // Test NullArguments
+    val nullArgs = ToolCallError.NullArguments("process_data")
+    nullArgs.getFormattedMessage shouldBe "Tool call 'process_data' received null arguments - expected an object with required parameters"
+
+    // Test InvalidArguments with single error
+    val singleError = ToolCallError.InvalidArguments(
+      "calculate",
+      List(ToolParameterError.MissingParameter("value", "number"))
+    )
+    singleError.getFormattedMessage shouldBe "Tool call 'calculate' required parameter 'value' (type: number) is missing"
+
+    // Test InvalidArguments with multiple errors
+    val multipleErrors = ToolCallError.InvalidArguments(
+      "submit_form",
+      List(
+        ToolParameterError.MissingParameter("email", "string"),
+        ToolParameterError.TypeMismatch("age", "number", "string"),
+        ToolParameterError.NullParameter("name", "string")
+      )
+    )
+    multipleErrors.getFormattedMessage should include("Tool call 'submit_form' has parameter issues:")
+    multipleErrors.getFormattedMessage should include("- required parameter 'email' (type: string) is missing")
+    multipleErrors.getFormattedMessage should include(
+      "- parameter 'age' has wrong type - expected number but got string"
+    )
+    multipleErrors.getFormattedMessage should include(
+      "- parameter 'name' (type: string) is required but value was null"
+    )
+
+    // Test ExecutionError
+    val execError = ToolCallError.ExecutionError("process", new RuntimeException("Network timeout"))
+    execError.getFormattedMessage shouldBe "Tool call 'process' failed during execution: Network timeout"
+
+    // Test HandlerError
+    val handlerError = ToolCallError.HandlerError("validate", "Invalid format")
+    handlerError.getFormattedMessage shouldBe "Tool call 'validate' failed with error: Invalid format"
+  }
+
+  "EnhancedParameterExtractor" should "provide helpful information about available properties" in {
+    val extractor = EnhancedParameterExtractor(
+      ujson.Obj(
+        "firstName" -> "John",
+        "lastName"  -> "Doe",
+        "email"     -> "john@example.com"
+      )
+    )
+
+    val result = extractor.getString("username")
+
+    (result should be).a(Symbol("left"))
+    val error = result.left.getOrElse(fail("Expected error"))
+    error.getMessage should include("required parameter 'username' (type: string) is missing")
+    error.getMessage should include("available: email, firstName, lastName")
+  }
+
+  "EnhancedParameterExtractor" should "handle nested parameters correctly" in {
+    val extractor = EnhancedParameterExtractor(
+      ujson.Obj(
+        "user" -> ujson.Obj(
+          "profile" -> ujson.Obj(
+            "name" -> "John"
+          )
+        )
+      )
+    )
+
+    // Test successful nested access
+    val nameResult = extractor.getString("user.profile.name")
+    nameResult shouldBe Right("John")
+
+    // Test missing nested property
+    val ageResult = extractor.getInt("user.profile.age")
+    (ageResult should be).a(Symbol("left"))
+    val error = ageResult.left.getOrElse(fail("Expected error"))
+    error.getMessage should include("required parameter 'user.profile.age' (type: integer) is missing")
+  }
+
+  "EnhancedParameterExtractor" should "handle optional parameters correctly" in {
+    val extractor = EnhancedParameterExtractor(
+      ujson.Obj(
+        "required" -> "value",
+        "optional" -> ujson.Null
+      )
+    )
+
+    // Optional parameter that's missing should return None
+    val missing = extractor.getOptionalString("nonexistent")
+    missing shouldBe Right(None)
+
+    // Optional parameter that's null should return None
+    val nullValue = extractor.getOptionalString("optional")
+    nullValue shouldBe Right(None)
+
+    // Optional parameter with wrong type should return error
+    val wrongType = extractor.getOptionalInt("required")
+    (wrongType should be).a(Symbol("left"))
+    val error = wrongType.left.getOrElse(fail("Expected error"))
+    error.getMessage should include("has wrong type - expected integer but got string")
+  }
+}

--- a/src/test/scala/org/llm4s/toolapi/ErrorMessageDemonstration.scala
+++ b/src/test/scala/org/llm4s/toolapi/ErrorMessageDemonstration.scala
@@ -1,0 +1,121 @@
+package org.llm4s.toolapi
+
+import upickle.default._
+
+/**
+ * Demonstration of improved error messages for tool parameter validation
+ */
+object ErrorMessageDemonstration extends App {
+
+  // Define a simple result type
+  case class Result(message: String)
+  implicit val resultRW: ReadWriter[Result] = macroRW[Result]
+
+  // Create a test tool with various parameter requirements
+  val inventoryTool = {
+    val schema = Schema
+      .`object`[Map[String, Any]]("Inventory management parameters")
+      .withProperty(Schema.property("item", Schema.string("Item name to add")))
+      .withProperty(Schema.property("quantity", Schema.number("Quantity to add")))
+      .withProperty(Schema.property("location", Schema.string("Storage location")))
+
+    ToolBuilder[Map[String, Any], Result](
+      "add_inventory_item",
+      "Adds an item to the inventory system",
+      schema
+    ).withHandler { extractor =>
+      for {
+        item <- extractor.getString("item")
+        qty  <- extractor.getDouble("quantity")
+        loc  <- extractor.getString("location")
+      } yield Result(s"Added $qty units of $item to $loc")
+    }.build()
+  }
+
+  println("=" * 60)
+  println("Tool Parameter Validation - Error Message Examples")
+  println("=" * 60)
+
+  // Example 1: Null arguments
+  println("\n1. Null arguments:")
+  val nullResult = inventoryTool.execute(ujson.Null)
+  nullResult match {
+    case Left(error) =>
+      println(s"   Error: ${error.getMessage}")
+    case Right(_) =>
+      println("   Unexpected success")
+  }
+
+  // Example 2: Missing required parameter
+  println("\n2. Missing 'quantity' parameter:")
+  val missingParamResult = inventoryTool.execute(
+    ujson.Obj(
+      "item"     -> "Apple",
+      "location" -> "Warehouse A"
+      // Missing: "quantity"
+    )
+  )
+  missingParamResult match {
+    case Left(error) =>
+      println(s"   Error: ${error.getMessage}")
+    case Right(_) =>
+      println("   Unexpected success")
+  }
+
+  // Example 3: Type mismatch
+  println("\n3. Type mismatch (string instead of number for quantity):")
+  val typeMismatchResult = inventoryTool.execute(
+    ujson.Obj(
+      "item"     -> "Apple",
+      "quantity" -> "five", // Should be a number
+      "location" -> "Warehouse A"
+    )
+  )
+  typeMismatchResult match {
+    case Left(error) =>
+      println(s"   Error: ${error.getMessage}")
+    case Right(_) =>
+      println("   Unexpected success")
+  }
+
+  // Example 4: Null value for required field
+  println("\n4. Null value for required 'location' field:")
+  val nullFieldResult = inventoryTool.execute(
+    ujson.Obj(
+      "item"     -> "Apple",
+      "quantity" -> 10,
+      "location" -> ujson.Null
+    )
+  )
+  nullFieldResult match {
+    case Left(error) =>
+      println(s"   Error: ${error.getMessage}")
+    case Right(_) =>
+      println("   Unexpected success")
+  }
+
+  // Example 5: Successful execution
+  println("\n5. Successful execution with all parameters:")
+  val successResult = inventoryTool.execute(
+    ujson.Obj(
+      "item"     -> "Apple",
+      "quantity" -> 10,
+      "location" -> "Warehouse A"
+    )
+  )
+  successResult match {
+    case Left(error) =>
+      println(s"   Error: ${error.getMessage}")
+    case Right(result) =>
+      println(s"   Success: ${result.render()}")
+  }
+
+  println("\n" + "=" * 60)
+  println("The improved error messages now clearly indicate:")
+  println("- Which tool failed")
+  println("- What parameter is problematic")
+  println("- What the actual issue is (null, missing, wrong type)")
+  println("- What was expected")
+  println("- Available alternatives when applicable")
+  println("=" * 60)
+}

--- a/src/test/scala/org/llm4s/toolapi/ImprovedErrorMessageDemo.scala
+++ b/src/test/scala/org/llm4s/toolapi/ImprovedErrorMessageDemo.scala
@@ -1,0 +1,117 @@
+package org.llm4s.toolapi
+
+/**
+ * Demonstration of the improved error messages with consistent formatting
+ */
+object ImprovedErrorMessageDemo extends App {
+
+  println("=" * 70)
+  println("IMPROVED ERROR MESSAGE DEMONSTRATION")
+  println("=" * 70)
+
+  // Example 1: Unknown tool
+  println("\n1. Unknown tool:")
+  val unknownTool = ToolCallError.UnknownFunction("calculate_tax")
+  println(s"   ${unknownTool.getFormattedMessage}")
+
+  // Example 2: Null arguments
+  println("\n2. Null arguments:")
+  val nullArgs = ToolCallError.NullArguments("add_inventory_item")
+  println(s"   ${nullArgs.getFormattedMessage}")
+
+  // Example 3: Missing required parameter
+  println("\n3. Missing required parameter:")
+  val missingParam = ToolCallError.InvalidArguments(
+    "add_inventory_item",
+    List(ToolParameterError.MissingParameter("quantity", "number", List("item", "location")))
+  )
+  println(s"   ${missingParam.getFormattedMessage}")
+
+  // Example 4: Null value for required parameter
+  println("\n4. Parameter is null:")
+  val nullParam = ToolCallError.InvalidArguments(
+    "add_inventory_item",
+    List(ToolParameterError.NullParameter("quantity", "number"))
+  )
+  println(s"   ${nullParam.getFormattedMessage}")
+
+  // Example 5: Type mismatch
+  println("\n5. Type mismatch:")
+  val typeMismatch = ToolCallError.InvalidArguments(
+    "add_inventory_item",
+    List(ToolParameterError.TypeMismatch("quantity", "number", "string"))
+  )
+  println(s"   ${typeMismatch.getFormattedMessage}")
+
+  // Example 6: Multiple parameter errors
+  println("\n6. Multiple parameter errors:")
+  val multipleErrors = ToolCallError.InvalidArguments(
+    "submit_order",
+    List(
+      ToolParameterError.MissingParameter("customer_id", "string"),
+      ToolParameterError.TypeMismatch("quantity", "number", "string"),
+      ToolParameterError.NullParameter("product_id", "string")
+    )
+  )
+  println(s"   ${multipleErrors.getFormattedMessage}")
+
+  // Example 7: Nested parameter error
+  println("\n7. Nested parameter error:")
+  val nestedError = ToolCallError.InvalidArguments(
+    "update_profile",
+    List(ToolParameterError.InvalidNesting("email", "user", "string"))
+  )
+  println(s"   ${nestedError.getFormattedMessage}")
+
+  // Example 8: Execution error
+  println("\n8. Execution error (after validation):")
+  val execError = ToolCallError.ExecutionError(
+    "process_payment",
+    new RuntimeException("Network timeout while contacting payment gateway")
+  )
+  println(s"   ${execError.getFormattedMessage}")
+
+  // Example 9: Handler error (business logic failure)
+  println("\n9. Handler error (business logic):")
+  val handlerError = ToolCallError.HandlerError(
+    "divide_numbers",
+    "cannot divide by zero"
+  )
+  println(s"   ${handlerError.getFormattedMessage}")
+
+  println("\n" + "=" * 70)
+  println("KEY IMPROVEMENTS:")
+  println("=" * 70)
+  println("✓ Consistent 'Tool call <name>' prefix for all errors")
+  println("✓ Clear distinction between missing, null, and wrong type")
+  println("✓ Parameter types included in error messages")
+  println("✓ Available parameters shown when one is missing")
+  println("✓ Execution vs validation errors clearly separated")
+  println("✓ Multi-line formatting for multiple errors")
+  println("=" * 70)
+
+  // Show JSON format as it would appear in Agent responses
+  println("\n" + "=" * 70)
+  println("JSON FORMAT (as returned to LLM):")
+  println("=" * 70)
+
+  def toJsonError(error: ToolCallError): String = {
+    val message = error.getFormattedMessage
+      .replace("\\", "\\\\")
+      .replace("\"", "\\\"")
+      .replace("\n", "\\n")
+    s"""{ "isError": true, "error": "$message" }"""
+  }
+
+  println("\nExample JSON responses:")
+  println("\n1. Missing parameter:")
+  println(toJsonError(missingParam))
+
+  println("\n2. Multiple errors:")
+  println(toJsonError(multipleErrors))
+
+  println("\n3. Execution error:")
+  println(toJsonError(execError))
+
+  println("\n" + "=" * 70)
+}

--- a/src/test/scala/org/llm4s/toolapi/ParameterValidationTest.scala
+++ b/src/test/scala/org/llm4s/toolapi/ParameterValidationTest.scala
@@ -1,0 +1,232 @@
+package org.llm4s.toolapi
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import upickle.default._
+
+class ParameterValidationTest extends AnyFlatSpec with Matchers {
+
+  // Result type for testing
+  case class TestResult(message: String)
+  implicit val testResultRW: ReadWriter[TestResult] = macroRW[TestResult]
+
+  def createTestTool(name: String = "test_tool"): ToolFunction[Map[String, Any], TestResult] = {
+    val schema = Schema
+      .`object`[Map[String, Any]]("Test parameters")
+      .withProperty(Schema.property("requiredString", Schema.string("A required string parameter")))
+      .withProperty(Schema.property("requiredNumber", Schema.number("A required number parameter")))
+      .withProperty(Schema.property("optionalBool", Schema.boolean("An optional boolean parameter")))
+
+    ToolBuilder[Map[String, Any], TestResult](
+      name,
+      "Test tool for parameter validation",
+      schema
+    ).withHandler { extractor =>
+      for {
+        str <- extractor.getString("requiredString")
+        num <- extractor.getDouble("requiredNumber")
+        bool = extractor.getBoolean("optionalBool").toOption
+      } yield TestResult(s"Got string: $str, number: $num, bool: $bool")
+    }.build()
+  }
+
+  "ToolFunction" should "provide clear error message for null arguments" in {
+    val tool   = createTestTool("inventory_tool")
+    val result = tool.execute(ujson.Null)
+
+    (result should be).a(Symbol("left"))
+    val error   = result.left.getOrElse(fail("Expected error"))
+    val message = error.getFormattedMessage
+
+    message should include("inventory_tool")
+    message should include("null arguments")
+    message should include("expected an object")
+  }
+
+  "ToolFunction" should "provide clear error message for missing required parameters" in {
+    val tool = createTestTool()
+    val result = tool.execute(
+      ujson.Obj(
+        "requiredString" -> "test"
+        // Missing requiredNumber
+      )
+    )
+
+    (result should be).a(Symbol("left"))
+    val error   = result.left.getOrElse(fail("Expected error"))
+    val message = error.getMessage
+
+    message should include("requiredNumber")
+    message should include("missing")
+    message should include("Available properties")
+    message should include("requiredString")
+  }
+
+  "ToolFunction" should "provide clear error message for type mismatches" in {
+    val tool = createTestTool()
+    val result = tool.execute(
+      ujson.Obj(
+        "requiredString" -> 123,           // Wrong type: number instead of string
+        "requiredNumber" -> "not a number" // Wrong type: string instead of number
+      )
+    )
+
+    (result should be).a(Symbol("left"))
+    val error   = result.left.getOrElse(fail("Expected error"))
+    val message = error.getMessage
+
+    // Should report the first error encountered
+    message should include("Type mismatch")
+    message should (include("expected string").or(include("expected number")))
+  }
+
+  "ToolFunction" should "provide clear error message for null values in required fields" in {
+    val tool = createTestTool()
+    val result = tool.execute(
+      ujson.Obj(
+        "requiredString" -> ujson.Null,
+        "requiredNumber" -> 42
+      )
+    )
+
+    (result should be).a(Symbol("left"))
+    val error   = result.left.getOrElse(fail("Expected error"))
+    val message = error.getMessage
+
+    message should include("requiredString")
+    message should include("null")
+    message should include("expected string")
+  }
+
+  "SafeParameterExtractor" should "provide helpful error for accessing properties on non-objects" in {
+    val extractor = SafeParameterExtractor(
+      ujson.Obj(
+        "user" -> "John", // This is a string, not an object
+        "age"  -> 30
+      )
+    )
+
+    val result = extractor.getString("user.name") // Trying to access .name on a string
+
+    (result should be).a(Symbol("left"))
+    val error = result.left.getOrElse(fail("Expected error"))
+
+    error should include("Cannot access property")
+    error should include("name")
+    error should include("string")
+    error should include("Expected an object")
+  }
+
+  "SafeParameterExtractor" should "list available properties when a required one is missing" in {
+    val extractor = SafeParameterExtractor(
+      ujson.Obj(
+        "user" -> ujson.Obj(
+          "firstName" -> "John",
+          "lastName"  -> "Doe",
+          "email"     -> "john@example.com"
+        )
+      )
+    )
+
+    val result = extractor.getString("user.username") // username doesn't exist
+
+    (result should be).a(Symbol("left"))
+    val error = result.left.getOrElse(fail("Expected error"))
+
+    error should include("username")
+    error should include("missing")
+    error should include("Available properties")
+    error should include("firstName")
+    error should include("lastName")
+    error should include("email")
+  }
+
+  "SafeParameterExtractor" should "handle nested null values gracefully" in {
+    val extractor = SafeParameterExtractor(
+      ujson.Obj(
+        "user" -> ujson.Null
+      )
+    )
+
+    val result = extractor.getString("user.name")
+
+    (result should be).a(Symbol("left"))
+    val error = result.left.getOrElse(fail("Expected error"))
+
+    error should include("Cannot access property")
+    error should include("name")
+    error should include("null value")
+  }
+
+  "ToolFunction with complex nested parameters" should "provide clear path information in errors" in {
+    val schema = Schema
+      .`object`[Map[String, Any]]("Complex parameters")
+      .withProperty(
+        Schema.property(
+          "user",
+          Schema
+            .`object`[Map[String, Any]]("User object")
+            .withProperty(
+              Schema.property(
+                "profile",
+                Schema
+                  .`object`[Map[String, Any]]("Profile object")
+                  .withProperty(
+                    Schema.property(
+                      "settings",
+                      Schema
+                        .`object`[Map[String, Any]]("Settings object")
+                        .withProperty(Schema.property("theme", Schema.string("Theme name")))
+                    )
+                  )
+              )
+            )
+        )
+      )
+
+    val tool = ToolBuilder[Map[String, Any], TestResult](
+      "complex_tool",
+      "Tool with nested parameters",
+      schema
+    ).withHandler { extractor =>
+      extractor.getString("user.profile.settings.theme").map(theme => TestResult(s"Theme: $theme"))
+    }.build()
+
+    // Test with missing nested property
+    val result = tool.execute(
+      ujson.Obj(
+        "user" -> ujson.Obj(
+          "profile" -> ujson.Obj(
+            // Missing settings object
+          )
+        )
+      )
+    )
+
+    (result should be).a(Symbol("left"))
+    val error   = result.left.getOrElse(fail("Expected error"))
+    val message = error.getMessage
+
+    message should include("settings")
+    message should include("missing")
+    message should include("user.profile.settings.theme")
+  }
+
+  "ToolCallError" should "format multiple errors nicely" in {
+    val error = ToolCallError.InvalidArguments(
+      "test_tool",
+      List(
+        ToolParameterError.MissingParameter("name", "string"),
+        ToolParameterError.TypeMismatch("age", "number", "string"),
+        ToolParameterError.NullParameter("email", "string")
+      )
+    )
+
+    val message = error.getFormattedMessage
+
+    message should include("Tool call 'test_tool' has parameter issues:")
+    message should include("- required parameter 'name' (type: string) is missing")
+    message should include("- parameter 'age' has wrong type - expected number but got string")
+    message should include("- parameter 'email' (type: string) is required but value was null")
+  }
+}


### PR DESCRIPTION
Critical bug fix:
- Fixed reversed ToolMessage constructor arguments in Agent.scala that caused empty messages
- This was breaking subsequent LLM calls when tool calls failed

Improved error messaging system:
- Created structured ToolParameterError types for clear parameter validation errors
- Added EnhancedParameterExtractor for better error reporting with context
- Consistent error format: 'Tool call [name] [specific issue]'
- Clear distinction between missing, null, and wrong type errors
- Shows available parameters when one is missing

Changes:
- Agent.scala: Fixed ToolMessage constructor argument order (line 159)
- Created ToolParameterError.scala with structured error types
- Created EnhancedParameterExtractor.scala for enhanced validation
- Updated SafeParameterExtractor with improved error messages
- Modified ToolFunction to handle null arguments properly
- Updated ToolRegistry and MCPToolRegistry for new error types
- Added comprehensive test coverage in AgentToolFailureTest.scala
- Fixed test expectations in ParameterValidationTest and EnhancedErrorMessagesTest

This ensures tool failures produce informative error messages instead of breaking the conversation with empty messages.