### PR TITLE
Addressed TODO - Fixed test

### DIFF
--- a/samples/src/main/scala/org/llm4s/samples/SpeechSamples.scala
+++ b/samples/src/main/scala/org/llm4s/samples/SpeechSamples.scala
@@ -16,9 +16,7 @@ object SpeechSamples {
   private val logger = LoggerFactory.getLogger(getClass)
 
   implicit class RichDataOutputStream(dos: DataOutputStream) extends AnyVal {
-    def writeString(s: String): Try[Unit] = Try {
-      dos.writeBytes(s)
-    }.tap { x =>
+    def writeString(s: String): Try[Unit] = Try(dos.writeBytes(s)).tap { x =>
       x.fold(
         ex => logger.error("Failed to write string to audio file: {}", ex.getMessage),
         _ => logger.debug("Successfully wrote string data to audio file")

--- a/samples/src/test/scala/org/llm4s/samples/RichDataOutputStreamSpec.scala
+++ b/samples/src/test/scala/org/llm4s/samples/RichDataOutputStreamSpec.scala
@@ -236,7 +236,8 @@ class RichDataOutputStreamSpec extends AnyFlatSpec with Matchers with MockFactor
       _ <- richDos.writeShort(16.toShort) // This won't execute
     } yield ()
 
-    results should equal (Failure(new RuntimeException("Something Broke")))
+    results shouldBe a[Failure[_]]
+    results.failed.get.getMessage shouldBe "Something Broke"
     val bytes = getWrittenBytes(box)
     bytes.length should equal(0)
   }


### PR DESCRIPTION
One test `"stop chain execution on first failure" `in the `RichDataOutputStreamSpec` class was breaking the build. The analysis is as follows:
         The original definition of `RichDataOutputStream` was as below: 

`implicit class RichDataOutputStream(dos: DataOutputStream)`

A test created a mock for this class.  This mock was programmed to throw an exception on the first call - ensuring that the monadic pipeline using Try[...] breaks as expected & any subsequent calls in the pipeline are never called. 
       After the build passed - I changed the above exension class definition as 

`implicit class RichDataOutputStream(dos: DataOutputStream) extends AnyVal `

This broke the test - especially the mock creation. As as optimization - the Scala compiler avoids creating an instance of the `RichDataOutputStream` class at runtime. So there is no class to mock and there was a compilation error. 
         Due to other issues, this error never came to light - and the build broke and the change sneaked in...

Fixed the test to not use a mock... Instead a subclass of the `ByteArrayOutputStream` is created - and the overridden method is programmed to throw... 