### PR TITLE
Fix OpenAI client parameter order and improve agent examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ CLAUDE.md
 .vscode
 **/.claude/settings.local.json
 .DS_Store
+.log
+.scala-build

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/model/Message.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/model/Message.scala
@@ -322,8 +322,8 @@ object AssistantMessage {
 /**
  * Represents a message from a tool, typically containing the result of a tool call.
  *
- * @param toolCallId Unique identifier for the tool call (as provided by the ToolCall).
  * @param content    Content of the tool message, usually the result of the tool execution, e.g. a json response.
+ * @param toolCallId Unique identifier for the tool call (as provided by the ToolCall).
  */
 final case class ToolMessage(
   content: String,

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenAIClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenAIClient.scala
@@ -191,7 +191,7 @@ class OpenAIClient private (
           msg.setToolCalls(openAIToolCools)
         }
         messages.add(msg)
-      case ToolMessage(toolCallId, content) =>
+      case ToolMessage(content, toolCallId) =>
         messages.add(new ChatRequestToolMessage(content, toolCallId))
     }
 
@@ -202,12 +202,13 @@ class OpenAIClient private (
     val choice           = completions.getChoices.get(0)
     val message          = choice.getMessage
     val toolCalls        = extractToolCalls(message)
-    val assistantMessage = AssistantMessage(content = message.getContent, toolCalls = toolCalls)
+    val content          = Option(message.getContent).getOrElse("")
+    val assistantMessage = AssistantMessage(contentOpt = if (content.isEmpty) None else Some(content), toolCalls = toolCalls)
 
     Completion(
       id = completions.getId,
       created = completions.getCreatedAt.toEpochSecond,
-      content = message.getContent,
+      content = content,
       model = completions.getModel,
       message = assistantMessage,
       toolCalls = toolCalls.toList,

--- a/modules/samples/src/main/scala/org/llm4s/samples/agent/MCPAgentExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/agent/MCPAgentExample.scala
@@ -48,7 +48,7 @@ object MCPAgentExample {
             val source = if (tool.description == "Retrieves current weather for the given location.") "local" else "MCP"
             logger.info(s"   ${index + 1}. ${tool.name} ($source): ${tool.description}")
           }
-          agent.run(query, mcpRegistry, Some(5), Some("mcp-agent-example.md"), None)
+          agent.run(query, mcpRegistry, Some(5), Some(".log/mcp-agent-example.md"), None)
       }
     } yield agentState
 

--- a/modules/samples/src/main/scala/org/llm4s/samples/agent/MultiStepAgentExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/agent/MultiStepAgentExample.scala
@@ -20,7 +20,7 @@ object MultiStepAgentExample {
       agent               = new Agent(client)
       query               = "What's the weather like in London, and is it different from New York?"
       _                   = println(s"User Query: $query\n")
-      traceLogPath        = "/Users/rory.graves/workspace/home/llm4s/log/agent-trace.md"
+      traceLogPath        = ".log/agent-trace.md"
       _                   = println(s"Trace log will be written to: $traceLogPath\n")
       _                   = println("=== Running Multi-Step Agent to Completion ===\n")
       _                   = println("Example 1: Running without a step limit, with trace logging")
@@ -59,7 +59,7 @@ object MultiStepAgentExample {
       // Example 3: Manual step execution to show the two-phase flow
       _                  = println("\n\n=== Manual Step Execution to Demonstrate Two-Phase Flow ===\n")
       _                  = println("Example 3: Running with manual step execution")
-      manualTraceLogPath = "/Users/rory.graves/workspace/home/llm4s/log/agent-trace-manual.md"
+      manualTraceLogPath = ".log/agent-trace-manual.md"
       initialState       = agent.initialize(query, toolRegistry)
       _                  = println(s"Initial state: ${initialState.status}")
       _                  = agent.writeTraceLog(initialState, manualTraceLogPath)


### PR DESCRIPTION
- Fix ToolMessage parameter order in OpenAIClient to match model definition
- Handle null content in OpenAI responses by defaulting to empty string
- Update AssistantMessage to use contentOpt for optional content
- Fix agent state variable usage in SingleStepAgentExample
- Add WaitingForTools status to agent loop condition
- Update hardcoded log paths to use relative .log directory
- Add .log and .scala-build to .gitignore