### PR TITLE
Refactored the healthCheck() method to use foldMap

### DIFF
--- a/modules/core/src/test/scala/org/llm4s/mcp/MCPToolRegistryHealthCheckSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/mcp/MCPToolRegistryHealthCheckSpec.scala
@@ -1,0 +1,61 @@
+package org.llm4s.mcp
+
+import cats.data.ValidatedNel
+import cats.syntax.validated._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+class MCPToolRegistryHealthCheckSpec extends AnyFlatSpec with Matchers {
+
+  private def mkConfig(name: String): MCPServerConfig =
+    MCPServerConfig.stdio(name, Seq("echo", "noop"))
+
+  final private class TestRegistry(
+    servers: Seq[MCPServerConfig],
+    responses: Map[String, ValidatedNel[String, MCPServerConfig]]
+  ) extends MCPToolRegistry(servers, Seq.empty, 1.minute, initializeOnStartup = false) {
+
+    override private[mcp] def createAndInitializeClient(
+      server: MCPServerConfig
+    ): ValidatedNel[String, MCPServerConfig] =
+      responses.getOrElse(server.name, fail(s"Unexpected server ${server.name}"))
+  }
+
+  "healthCheck" should "mark all servers healthy when initialization succeeds" in {
+    val serverA = mkConfig("alpha")
+    val serverB = mkConfig("beta")
+
+    val registry = new TestRegistry(
+      servers = Seq(serverA, serverB),
+      responses = Map(
+        "alpha" -> serverA.validNel[String],
+        "beta"  -> serverB.validNel[String]
+      )
+    )
+
+    registry.healthCheck() shouldBe Map(
+      "alpha" -> true,
+      "beta"  -> true
+    )
+  }
+
+  it should "flag servers as unhealthy when initialization fails" in {
+    val serverA = mkConfig("alpha")
+    val serverB = mkConfig("beta")
+
+    val registry = new TestRegistry(
+      servers = Seq(serverA, serverB),
+      responses = Map(
+        "alpha" -> serverA.validNel[String],
+        "beta"  -> "boom".invalidNel[MCPServerConfig]
+      )
+    )
+
+    registry.healthCheck() shouldBe Map(
+      "alpha" -> true,
+      "beta"  -> false
+    )
+  }
+}


### PR DESCRIPTION
## MCP Tool Registry Improvements

### Key Changes
- Added `initializeOnStartup` parameter to control MCP tool registry initialization
- Introduced a more robust health check mechanism with error handling
- Improved initialization and error logging for MCP servers

### Features
- Optional startup initialization (default: true)
- Detailed health check with server status tracking
- Granular error reporting using Cats `ValidatedNel`

### Benefits
- Enhanced testability
- More flexible server initialization
- Better error visibility and logging

### Testing
- Added `MCPToolRegistryHealthCheckSpec` to validate new health check functionality