### PR TITLE
Refactor all LLM clients to use apply() instead of create() or new

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -20,14 +20,14 @@ object LLMConnect {
     config match {
       case cfg: OpenAIConfig =>
         if (cfg.baseUrl.contains("openrouter.ai"))
-          Right(new OpenRouterClient(cfg))
+          OpenRouterClient(cfg)
         else OpenAIClient(cfg)
       case cfg: AzureConfig =>
         OpenAIClient(cfg)
       case cfg: AnthropicConfig =>
-        Right(new AnthropicClient(cfg))
+        AnthropicClient(cfg)
       case cfg: OllamaConfig =>
-        Right(new OllamaClient(cfg))
+        OllamaClient(cfg)
     }
 
   // Typed-config entry: build client directly from ProviderConfig
@@ -37,10 +37,10 @@ object LLMConnect {
   def getClient(provider: LLMProvider, config: ProviderConfig): Result[LLMClient] =
     (provider, config) match {
       case (LLMProvider.OpenAI, cfg: OpenAIConfig)       => OpenAIClient(cfg)
-      case (LLMProvider.OpenRouter, cfg: OpenAIConfig)   => Right(new OpenRouterClient(cfg))
+      case (LLMProvider.OpenRouter, cfg: OpenAIConfig)   => OpenRouterClient(cfg)
       case (LLMProvider.Azure, cfg: AzureConfig)         => OpenAIClient(cfg)
-      case (LLMProvider.Anthropic, cfg: AnthropicConfig) => Right(new AnthropicClient(cfg))
-      case (LLMProvider.Ollama, cfg: OllamaConfig)       => Right(new OllamaClient(cfg))
+      case (LLMProvider.Anthropic, cfg: AnthropicConfig) => AnthropicClient(cfg)
+      case (LLMProvider.Ollama, cfg: OllamaConfig)       => OllamaClient(cfg)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
@@ -330,3 +330,10 @@ curl https://api.anthropic.com/v1/messages \
     toolCalls
   }
 }
+
+object AnthropicClient {
+  import org.llm4s.types.TryOps
+
+  def apply(config: AnthropicConfig): Result[AnthropicClient] =
+    Try(new AnthropicClient(config)).toResult
+}

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OllamaClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OllamaClient.scala
@@ -167,3 +167,10 @@ class OllamaClient(config: OllamaConfig) extends LLMClient {
 
   override def getReserveCompletion(): Int = config.reserveCompletion
 }
+
+object OllamaClient {
+  import org.llm4s.types.TryOps
+
+  def apply(config: OllamaConfig): Result[OllamaClient] =
+    Try(new OllamaClient(config)).toResult
+}

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenRouterClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenRouterClient.scala
@@ -251,3 +251,10 @@ class OpenRouterClient(config: OpenAIConfig) extends LLMClient {
 
   override def getReserveCompletion(): Int = config.reserveCompletion
 }
+
+object OpenRouterClient {
+  import org.llm4s.types.TryOps
+
+  def apply(config: OpenAIConfig): Result[OpenRouterClient] =
+    Try(new OpenRouterClient(config)).toResult
+}


### PR DESCRIPTION
## Summary

This PR refactors all LLM client instantiation to use the idiomatic Scala `apply()` factory pattern with consistent `Result`-based error handling across all providers.

**Changes:**
- ✅ Renamed `OpenAIClient.create()` → `OpenAIClient.apply()`
- ✅ Added companion objects with `apply()` methods to:
  - `AnthropicClient`
  - `OllamaClient`
  - `OpenRouterClient`
- ✅ Updated all call sites in `LLMConnect.scala` to use the apply syntax

**Before:**
```scala
// Inconsistent patterns
OpenAIClient.create(cfg)           // Result-based ✅
Right(new AnthropicClient(cfg))    // Direct instantiation ❌
Right(new OllamaClient(cfg))       // Direct instantiation ❌
Right(new OpenRouterClient(cfg))   // Direct instantiation ❌

**After:**

// Consistent apply pattern
OpenAIClient(cfg)       // Result[OpenAIClient]
AnthropicClient(cfg)    // Result[AnthropicClient]
OllamaClient(cfg)       // Result[OllamaClient]
OpenRouterClient(cfg)   // Result[OpenRouterClient]