### PR TITLE
refactor(llmconnect): improve Conversation API documentation and consistency

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/model/Conversation.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/model/Conversation.scala
@@ -15,13 +15,21 @@ import upickle.default.{ macroRW, ReadWriter => RW }
 case class Conversation(messages: Seq[Message]) {
 
   /**
-   * Add a message and return a new Conversation
+   * Add a message and return a new Conversation.
+   * This operation is immutable - the original conversation is unchanged.
+   *
+   * @param message The message to add
+   * @return A new Conversation containing all previous messages plus the new one
    */
   def addMessage(message: Message): Conversation =
     Conversation(messages :+ message)
 
   /**
-   * Add multiple messages and return a new Conversation
+   * Add multiple messages and return a new Conversation.
+   * This operation is immutable - the original conversation is unchanged.
+   *
+   * @param newMessages The messages to add
+   * @return A new Conversation containing all previous messages plus the new ones
    */
   def addMessages(newMessages: Seq[Message]): Conversation =
     Conversation(messages ++ newMessages)
@@ -38,7 +46,7 @@ case class Conversation(messages: Seq[Message]) {
    *
    * @return Number of messages in the conversation
    */
-  def messageCount: Int = messages.length
+  def messageCount: Int = messages.size
 
   /**
    * Filter messages by role.
@@ -75,7 +83,16 @@ object Conversation {
 
   /**
    * Create a conversation from system and user prompts (most common pattern).
-   * Validates both messages.
+   * Validates both messages (rejects empty or whitespace-only content).
+   *
+   * @example
+   * {{{
+   * val result = Conversation.fromPrompts(
+   *   "You are a helpful assistant",
+   *   "What is 2+2?"
+   * )
+   * // Returns Right(Conversation(...)) on success
+   * }}}
    *
    * @param systemPrompt The system message content
    * @param userPrompt The user message content
@@ -86,7 +103,13 @@ object Conversation {
 
   /**
    * Create a single-user-message conversation (for simple queries).
-   * Validates the message.
+   * Validates the message (rejects empty or whitespace-only content).
+   *
+   * @example
+   * {{{
+   * val result = Conversation.userOnly("What is the capital of France?")
+   * // Returns Right(Conversation(List(UserMessage(...)))) on success
+   * }}}
    *
    * @param prompt The user message content
    * @return Result containing the validated conversation or validation error
@@ -96,7 +119,15 @@ object Conversation {
 
   /**
    * Create a system-only conversation (for system prompts).
-   * Validates the message.
+   * Validates the message (rejects empty or whitespace-only content).
+   * Useful for creating an initial conversation to build from with addMessage/addMessages.
+   *
+   * @example
+   * {{{
+   * val result = Conversation.systemOnly("You are a helpful assistant")
+   *   .map(_.addMessage(UserMessage("Hello")))
+   * // Returns Right(Conversation(List(SystemMessage(...), UserMessage(...)))) on success
+   * }}}
    *
    * @param prompt The system message content
    * @return Result containing the validated conversation or validation error

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/model/ConversationConvenienceMethodsSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/model/ConversationConvenienceMethodsSpec.scala
@@ -46,6 +46,17 @@ class ConversationConvenienceMethodsSpec extends AnyFlatSpec with Matchers {
     result.isLeft shouldBe true
   }
 
+  it should "preserve leading/trailing whitespace in valid prompts" in {
+    val result = Conversation.fromPrompts("  System prompt  ", "  User prompt  ")
+
+    result.isRight shouldBe true
+    result.foreach { conv =>
+      conv.messageCount should be(2)
+      conv.messages(0).content should be("  System prompt  ")
+      conv.messages(1).content should be("  User prompt  ")
+    }
+  }
+
   // --- Conversation.userOnly tests ---
 
   "Conversation.userOnly" should "create a valid conversation with single user message" in {
@@ -70,6 +81,16 @@ class ConversationConvenienceMethodsSpec extends AnyFlatSpec with Matchers {
     result.isLeft shouldBe true
   }
 
+  it should "preserve leading/trailing whitespace in valid prompts" in {
+    val result = Conversation.userOnly("  User prompt  ")
+
+    result.isRight shouldBe true
+    result.foreach { conv =>
+      conv.messageCount should be(1)
+      conv.messages(0).content should be("  User prompt  ")
+    }
+  }
+
   // --- Conversation.systemOnly tests ---
 
   "Conversation.systemOnly" should "create a valid conversation with single system message" in {
@@ -92,6 +113,16 @@ class ConversationConvenienceMethodsSpec extends AnyFlatSpec with Matchers {
     val result = Conversation.systemOnly("   ")
 
     result.isLeft shouldBe true
+  }
+
+  it should "preserve leading/trailing whitespace in valid prompts" in {
+    val result = Conversation.systemOnly("  System prompt  ")
+
+    result.isRight shouldBe true
+    result.foreach { conv =>
+      conv.messageCount should be(1)
+      conv.messages(0).content should be("  System prompt  ")
+    }
   }
 
   // --- Conversation.lastMessage tests ---


### PR DESCRIPTION


Enhancements:
- Change messageCount to use .size instead of .length (more idiomatic Scala)
- Add comprehensive ScalaDoc with @example blocks for all convenience methods
- Document immutability behavior in addMessage/addMessages
- Clarify validation behavior (rejects empty/whitespace-only content)
- Add usage guidance for systemOnly (creating initial conversations)

Testing:
- Add tests documenting whitespace preservation behavior
- Verify that valid prompts with leading/trailing whitespace are preserved
- Confirm whitespace-only prompts are rejected as expected

These improvements enhance developer experience by making the API behavior more explicit and providing clear usage examples in the documentation.