### PR TITLE
refactor: simplify JSONValidator schema validation logic

### DIFF
--- a/modules/core/src/test/scala/org/llm4s/agent/guardrails/builtin/JSONValidatorSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/guardrails/builtin/JSONValidatorSpec.scala
@@ -44,5 +44,21 @@ class JSONValidatorSpec extends AnyFunSuite with Matchers {
 
     val result = validator.validate("""["not", "an", "object"]""")
     result.isLeft shouldBe true
+
+    val message = result.left.toOption.map(_.formatted).getOrElse("")
+    message should include("Schema requires an object")
+    message should include("non-object value")
+  }
+
+  test("empty required array passes any object") {
+    val schema    = Obj("required" -> ujson.Arr())
+    val validator = JSONValidator.withSchema(schema)
+    validator.validate("""{}""").isRight shouldBe true
+  }
+
+  test("schema without required field passes any valid JSON") {
+    val schema    = Obj("type" -> "object")
+    val validator = JSONValidator.withSchema(schema)
+    validator.validate("""{"anything": "goes"}""").isRight shouldBe true
   }
 }


### PR DESCRIPTION
- Simplify extractRequiredKeys using Option chain instead of Try/toResult
- Rename validateRequiredFields to validateAgainstSchema returning Option[String]
- Improve error message for non-object JSON when schema expects object
- Remove unused TryOps import
- Add tests for empty required array and schema without required field