### PR TITLE
Improve streaming tool calls and timeouts

### DIFF
--- a/codex.txt
+++ b/codex.txt
@@ -1,1 +1,0 @@
-codex resume 0199eb03-9dd6-7c92-8a49-5c331e15686d

--- a/modules/core/src/main/scala/org/llm4s/agent/memory/InMemoryStore.scala
+++ b/modules/core/src/main/scala/org/llm4s/agent/memory/InMemoryStore.scala
@@ -65,6 +65,9 @@ final case class InMemoryStore private (
     topK: Int,
     filter: MemoryFilter
   ): Result[Seq[ScoredMemory]] = {
+    if (query.trim.isEmpty) {
+      return Right(Seq.empty)
+    }
     // First filter by criteria
     val filtered = memories.values.filter(filter.matches).toSeq
 

--- a/modules/core/src/test/scala/org/llm4s/agent/memory/InMemoryStoreSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/memory/InMemoryStoreSpec.scala
@@ -140,6 +140,18 @@ class InMemoryStoreSpec extends AnyFlatSpec with Matchers {
     scored.head.memory.content should include("JVM")
   }
 
+  it should "return empty results for blank search queries" in {
+    val memory1 = createMemory("Scala is a programming language")
+    val memory2 = createMemory("Java runs on the JVM")
+
+    val result = for {
+      store  <- InMemoryStore.withMemories(Seq(memory1, memory2))
+      scored <- store.search("   ", topK = 10)
+    } yield scored
+
+    result shouldBe Right(Seq.empty)
+  }
+
   it should "return recent memories in descending order" in {
     val old    = Memory(MemoryId.generate(), "Old", MemoryType.Conversation, Map.empty, dayAgo)
     val medium = Memory(MemoryId.generate(), "Medium", MemoryType.Conversation, Map.empty, hourAgo)

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/streaming/StreamingAccumulatorTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/streaming/StreamingAccumulatorTest.scala
@@ -139,6 +139,20 @@ class StreamingAccumulatorTest extends AnyFunSuite with Matchers {
     toolCalls.head.name shouldBe "get_weather"
   }
 
+  test("should assemble tool call arguments from raw JSON fragments") {
+    val accumulator = StreamingAccumulator.create()
+
+    val partialCall1 = ToolCall("tool-1", "get_weather", ujson.Str("{\"location\":"))
+    val partialCall2 = ToolCall("tool-1", "", ujson.Str("\"SF\"}"))
+
+    accumulator.addChunk(StreamedChunk("msg-1", None, Some(partialCall1), None))
+    accumulator.addChunk(StreamedChunk("msg-1", None, Some(partialCall2), None))
+
+    val toolCalls = accumulator.getCurrentToolCalls
+    (toolCalls should have).length(1)
+    toolCalls.head.arguments("location").str shouldBe "SF"
+  }
+
   // ===========================================
   // Thinking content tests (Phase 4.1)
   // ===========================================

--- a/modules/workspace/workspaceClient/src/test/scala/org/llm4s/workspace/ContainerisedWorkspaceTest.scala
+++ b/modules/workspace/workspaceClient/src/test/scala/org/llm4s/workspace/ContainerisedWorkspaceTest.scala
@@ -61,12 +61,14 @@ class ContainerisedWorkspaceTest extends AnyFunSuite with Matchers with BeforeAn
     }
   }
 
+  private val EnableDockerEnvVar = "LLM4S_DOCKER_TESTS"
+
   private def isDockerAvailable: Boolean =
-    false // temporarily disable this test
-//    Try {
-//      val process = Runtime.getRuntime.exec(Array("docker", "--version"))
-//      process.waitFor() == 0
-//    }.getOrElse(false)
+    sys.env.get(EnableDockerEnvVar).exists(_.equalsIgnoreCase("true")) &&
+      Try {
+        val process = Runtime.getRuntime.exec(Array("docker", "--version"))
+        process.waitFor() == 0
+      }.getOrElse(false)
 
   test("WebSocket workspace can handle basic file operations") {
     assume(isDockerAvailable, "Docker not available - skipping WebSocket tests")


### PR DESCRIPTION
- Accumulate multi-tool streaming deltas and raw argument fragments across OpenAI/OpenRouter handlers

- Emit tool-call chunks for fake streaming and parse partial JSON safely

- Treat blank memory searches as empty results and cover it with a unit test

- Align workspace WebSocket response timeout with command timeout + buffer

- Gate Docker workspace tests via env flag and add streaming accumulator coverage

- Remove codex.txt