### PR TITLE
Fix coverage reporting for multi-module build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,13 @@ jobs:
       - uses: sbt/setup-sbt@v1
 
       - name: Run tests with coverage
-        run: sbt coverage test coverageReport
+        run: sbt coverage test coverageAggregate
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: target/scala-3.7.1/scoverage-report/scoverage.xml
+          files: target/scala-3.7.1/scoverage-report/scoverage.xml,modules/*/target/scala-3.7.1/scoverage-report/scoverage.xml
           slug: llm4s/llm4s
           fail_ci_if_error: false
           verbose: true
@@ -77,6 +77,7 @@ jobs:
           name: coverage-report
           path: |
             target/scala-3.7.1/scoverage-report/
+            modules/*/target/scala-3.7.1/scoverage-report/
           retention-days: 14
 
   # Main test matrix


### PR DESCRIPTION
- Use coverageAggregate instead of coverageReport to combine coverage from all subprojects
- Update Codecov file paths to include both aggregate and module reports
- Update artifact paths to include module-level reports