### PR TITLE
feat: Add a multi-tonal translation example

### DIFF
--- a/modules/samples/src/main/scala/org/llm4s/samples/actions/TranslationExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/actions/TranslationExample.scala
@@ -51,7 +51,7 @@ object TranslationExample {
 
     result.fold(
       err => println(s"Error: ${err.formatted}"),
-      (informal, formal) => {
+      { case (informal, formal) =>
         println(s"Informal ($language): $informal")
         println(s"Formal   ($language): $formal")
         println("-------------------------")


### PR DESCRIPTION
This pull request adds a new example, `TranslationExample`, demonstrating how to use the LLM4S library for multi-tonal text translation. The example shows how to create a reusable translation function with tone control, dynamically modify system prompts, and handle results in a type-safe way.

**New translation example and usage patterns:**

* Added `TranslationExample.scala` in `org.llm4s.samples.actions` to demonstrate multi-tonal (formal/informal) translation using LLM4S, including:
  - Creating a reusable translation function with tone control.
  - Dynamically adjusting the system prompt based on the selected tone.
  - Handling translation results using the `Result` type for type safety.
* Showcased how to use the `LLMClient` and configuration from `Llm4sConfig` for translation tasks.