### PR TITLE
ci: remove duplicate sbt/coursier cache from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,19 +124,6 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'sbt'
       
-      - name: Cache Coursier
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/coursier
-            ~/.ivy2/cache
-            ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ matrix.scala }}-${{ matrix.java }}-${{ hashFiles('**/build.sbt', '**/project/**.scala', '**/project/build.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-sbt-${{ matrix.scala }}-${{ matrix.java }}-
-            ${{ runner.os }}-sbt-${{ matrix.scala }}-
-            ${{ runner.os }}-sbt-
-      
       - uses: sbt/setup-sbt@v1
       
       - name: Run tests


### PR DESCRIPTION
### **This PR removes the manual actions/cache step from the test matrix job to avoid redundant dependency caching.**

All CI jobs already use actions/setup-java with cache: sbt, which automatically handles caching for:

sbt (~/.sbt)
Ivy (~/.ivy2/cache)
Coursier (~/.cache/coursier)

The test matrix job additionally restored the same directories using a separate actions/cache step. This resulted in duplicate cache restoration for the same paths, while other jobs (quick-checks, coverage, postgres-tests) relied solely on the built-in sbt cache provided by setup-java.

1. Removing the manual cache step:
2. keeps caching behavior consistent across all jobs
3. reduces CI configuration complexity
4. avoids maintaining two cache strategies for the same toolchain
5. does not change build or test behavior

All dependency caching remains fully enabled via setup-java, and CI performance and correctness are unaffected.

If there was a specific reason for keeping a custom cache strategy in the test matrix (e.g. Scala-version–specific tuning), I’m happy to adjust or revert accordingly.