### PR TITLE
Add typed PgConfig to config loader

### DIFF
--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -159,4 +159,33 @@ llm4s {
       model   = ${?COHERE_RERANK_MODEL}
     }
   }
+
+  # PostgreSQL settings used by permission-aware RAG (loaded at the app edge).
+  # Env var overrides supported for convenience:
+  #   PGVECTOR_HOST, PGVECTOR_PORT, PGVECTOR_DATABASE,
+  #   PGVECTOR_USER, PGVECTOR_PASSWORD,
+  #   PGVECTOR_TABLE, PGVECTOR_MAX_POOL_SIZE
+  rag {
+    permissions {
+      pg {
+        host = "localhost"
+        host = ${?PGVECTOR_HOST}
+        port = 5432
+        port = ${?PGVECTOR_PORT}
+        database = "postgres"
+        database = ${?PGVECTOR_DATABASE}
+
+        user = "postgres"
+        user = ${?PGVECTOR_USER}
+        password = ""
+        password = ${?PGVECTOR_PASSWORD}
+
+        vectorTableName = "vectors"
+        vectorTableName = ${?PGVECTOR_TABLE}
+
+        maxPoolSize = 10
+        maxPoolSize = ${?PGVECTOR_MAX_POOL_SIZE}
+      }
+    }
+  }
 }

--- a/modules/core/src/main/scala/org/llm4s/config/Llm4sConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/Llm4sConfig.scala
@@ -1,4 +1,3 @@
-// scalafix:off DisableSyntax.NoPureConfigDefault
 package org.llm4s.config
 
 import org.llm4s.llmconnect.config._
@@ -7,11 +6,11 @@ import pureconfig.ConfigSource
 
 object Llm4sConfig {
 
-  def stringOrElse(path: String, default: String): String =
-    ConfigSource.default.at(path).load[String].toOption.getOrElse(default)
-
   def provider(): Result[ProviderConfig] =
     org.llm4s.config.ProviderConfigLoader.load(ConfigSource.default)
+
+  def pgSearchIndex(): Result[org.llm4s.rag.permissions.SearchIndex.PgConfig] =
+    org.llm4s.config.PgSearchIndexConfigLoader.load(ConfigSource.default)
 
   final private case class LangfuseSection(
     url: Option[String],
@@ -145,4 +144,3 @@ object Llm4sConfig {
     fromConf
   }
 }
-// scalafix:on DisableSyntax.NoPureConfigDefault

--- a/modules/core/src/main/scala/org/llm4s/config/PgSearchIndexConfigLoader.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/PgSearchIndexConfigLoader.scala
@@ -1,0 +1,27 @@
+package org.llm4s.config
+
+import org.llm4s.error.ProcessingError
+import org.llm4s.rag.permissions.SearchIndex
+import org.llm4s.types.Result
+import pureconfig.{ ConfigReader => PureConfigReader, ConfigSource }
+
+object PgSearchIndexConfigLoader {
+
+  implicit private val pgConfigReader: PureConfigReader[SearchIndex.PgConfig] =
+    PureConfigReader.forProduct7(
+      "host",
+      "port",
+      "database",
+      "user",
+      "password",
+      "vectorTableName",
+      "maxPoolSize"
+    )(SearchIndex.PgConfig.apply)
+
+  def load(source: ConfigSource): Result[SearchIndex.PgConfig] =
+    source
+      .at("llm4s.rag.permissions.pg")
+      .load[SearchIndex.PgConfig]
+      .left
+      .map(e => ProcessingError("pg-search-index-config", e.prettyPrint()))
+}

--- a/modules/samples/src/main/resources/application.conf
+++ b/modules/samples/src/main/resources/application.conf
@@ -41,10 +41,6 @@ llm4s {
   }
 }
 
-PGVECTOR_TEST_URL = ${?PGVECTOR_TEST_URL}
-PGVECTOR_USER = ${?PGVECTOR_USER}
-PGVECTOR_PASSWORD = ${?PGVECTOR_PASSWORD}
-
 # Optional per-developer overlay; if present, its values override the above.
 # Example (in application.local.conf):
 # llm4s {


### PR DESCRIPTION
 This PR removes the temporary Llm4sConfig.stringOrElse escape hatch and switches PgSearchIndex wiring to fully typed PureConfig settings (loaded from reference.conf with env overrides). stringOrElse was a stopgap to get main compiling/tests passing, but it breaks the “no config
  reads in core” boundary and encourages untyped config usage. With this change, samples load a typed SearchIndex.PgConfig and inject it into core, keeping configuration at the app edge and making Scala 2.13/3 builds consistent.
