### PR TITLE
Add test to document precedence when multiple HTTP status codes are present in exception messages

### DIFF
--- a/modules/core/src/test/scala/org/llm4s/error/ThrowableOpsSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/error/ThrowableOpsSpec.scala
@@ -57,6 +57,14 @@ class ThrowableOpsSpec extends AnyFlatSpec with Matchers {
     rateLimitError.provider shouldBe "unknown"
   }
 
+  it should "prioritize authentication error when both 401 and 429 are present in message" in {
+    val throwable = new RuntimeException("HTTP 401 Unauthorized, then HTTP 429 Too Many Requests")
+
+    val error = throwable.toLLMError
+
+    error shouldBe a[AuthenticationError]
+  }
+
   it should "convert unknown exception to UnknownError" in {
     val throwable = new IllegalStateException("Something unexpected happened")
 


### PR DESCRIPTION
### Summary

This PR adds a small, focused test to cover an edge case in `ThrowableOps.toLLMError` where
multiple HTTP status codes (401 and 429) appear in the same exception message.

The intent is to explicitly document and lock the current precedence behavior without
changing any production logic.

---

### Motivation

The existing test suite already verifies how individual HTTP status codes (401 and 429)
are mapped to `AuthenticationError` and `RateLimitError` respectively.

However, in real-world scenarios, exception messages can sometimes contain multiple
status codes due to retries, wrapped errors, or upstream error aggregation.

This test ensures that when both 401 and 429 are present, authentication errors
take precedence, making the behavior explicit and protected against future regressions.

---

### Changes

- Added a single test case to `ThrowableOpsSpec` to validate error precedence
  when both HTTP 401 and 429 appear in the same exception message
- No production code changes
- No behavior changes — this test documents the existing behavior

---

### Scope & Risk

- Test-only change
- Very low risk
- Improves clarity and confidence around error-mapping logic

---

### Notes

This PR intentionally avoids expanding the logic or refactoring existing code.
Its sole purpose is to improve coverage and make precedence rules explicit.
