### PR TITLE
Fix Scaladex indexing for llm4s

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,10 +124,13 @@ lazy val commonSettings = Seq(
 // ---- projects ----
 lazy val llm4s = (project in file("."))
   .aggregate(core, samples, workspaceShared, workspaceRunner, workspaceClient, workspaceSamples)
+  .settings(
+    publish / skip := true
+  )
 
 lazy val core = (project in file("modules/core"))
   .settings(
-    name := "core",
+    name := "llm4s-core",
     commonSettings,
     Test / fork := true,
     Compile / mainClass := None,
@@ -170,7 +173,7 @@ lazy val workspaceShared = (project in file("modules/workspace/workspaceShared")
 lazy val workspaceClient = (project in file("modules/workspace/workspaceClient"))
   .dependsOn(workspaceShared, core)
   .settings(
-    name := "workspaceShared",
+    name := "workspaceClient",
     commonSettings,
     Compile / discoveredMainClasses := Seq.empty,
     coverageEnabled := false,


### PR DESCRIPTION
This PR addresses the Scaladex indexing issue for llm4s by fixing
the published sbt project layout and artifact naming.

No functional changes.
