### PR TITLE
extend structured logging across all sample modules

### DIFF
--- a/modules/samples/src/main/scala/org/llm4s/samples/SpeechSamples.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/SpeechSamples.scala
@@ -222,46 +222,46 @@ object SpeechSamples {
   }
 
   def demoWhisper(filePath: String): Unit = {
-    println(s"Testing Whisper STT on ${PlatformCommands.platformName}")
+    logger.info("Testing Whisper STT on {}", PlatformCommands.platformName)
     val stt = new WhisperSpeechToText(PlatformCommands.cat) // Cross-platform file content
     val res = stt.transcribe(AudioInput.FileAudio(Paths.get(filePath)), STTOptions(language = Some("en")))
-    println(res.fold(err => s"STT error: ${err.formatted}", t => s"Transcript: ${t.text}"))
+    logger.info("{}", res.fold(err => s"STT error: ${err.formatted}", t => s"Transcript: ${t.text}"))
   }
 
   def demoWhisperReal(filePath: String): Unit = {
-    println(s"Testing REAL Whisper STT on ${PlatformCommands.platformName}")
+    logger.info("Testing REAL Whisper STT on {}", PlatformCommands.platformName)
     // Use actual Whisper CLI if available
     val stt = new WhisperSpeechToText(Seq("whisper"), model = "base")
     val res = stt.transcribe(AudioInput.FileAudio(Paths.get(filePath)), STTOptions(language = Some("en")))
-    println(res.fold(err => s"STT error: ${err.formatted}", t => s"Transcript: ${t.text}"))
+    logger.info("{}", res.fold(err => s"STT error: ${err.formatted}", t => s"Transcript: ${t.text}"))
   }
 
   def demoVosk(filePath: String): Unit = {
-    println(s"Testing Vosk STT on ${PlatformCommands.platformName}")
+    logger.info("Testing Vosk STT on {}", PlatformCommands.platformName)
     val stt = new VoskSpeechToText()
     val res = stt.transcribe(AudioInput.FileAudio(Paths.get(filePath)), STTOptions(language = Some("en")))
-    println(res.fold(err => s"STT error: ${err.formatted}", t => s"Transcript: ${t.text}"))
+    logger.info("{}", res.fold(err => s"STT error: ${err.formatted}", t => s"Transcript: ${t.text}"))
   }
 
   def demoTacotron2(text: String): Unit = {
-    println(s"Testing Tacotron2 TTS on ${PlatformCommands.platformName}")
+    logger.info("Testing Tacotron2 TTS on {}", PlatformCommands.platformName)
     val tts = new Tacotron2TextToSpeech(PlatformCommands.echo) // Cross-platform echo
     val res = tts.synthesize(text, TTSOptions(voice = Some("default")))
-    println(res.fold(err => s"TTS error: ${err.formatted}", _ => s"TTS synthesis completed."))
+    logger.info("{}", res.fold(err => s"TTS error: ${err.formatted}", _ => s"TTS synthesis completed."))
   }
 
   def main(args: Array[String]): Unit = {
-    println("=== LLM4S Speech Demo ===")
-    println(s"Platform: ${PlatformCommands.platformName}")
+    logger.info("=== LLM4S Speech Demo ===")
+    logger.info("Platform: {}", PlatformCommands.platformName)
 
-    println("\n--- Creating Test Audio Files ---")
+    logger.info("--- Creating Test Audio Files ---")
     // Create all test files
     val result: Try[Unit] = for {
       silenceWavFile    <- createTestWavFile()
       toneWavFile       <- createToneWavFile()
       speechLikeWavFile <- createSpeechLikeWavFile()
     } yield {
-      println(
+      logger.info(
         s"""
            |Created test audio files:
            |  Silence WAV: ${silenceWavFile} (${Files.size(silenceWavFile)} bytes)
@@ -270,31 +270,31 @@ object SpeechSamples {
            |""".stripMargin
       )
 
-      println("\n--- Testing STT (Mock) ---")
+      logger.info("--- Testing STT (Mock) ---")
       demoWhisper(silenceWavFile.toString)
       demoVosk(silenceWavFile.toString)
 
-      println("\n--- Testing STT (Real Whisper - Silence) ---")
-      println("Note: This requires 'whisper' CLI to be installed (pip install openai-whisper)")
+      logger.info("--- Testing STT (Real Whisper - Silence) ---")
+      logger.info("Note: This requires 'whisper' CLI to be installed (pip install openai-whisper)")
       demoWhisperReal(silenceWavFile.toString)
 
-      println("\n--- Testing STT (Real Whisper - Tone) ---")
-      println("Testing with a 440Hz tone (A note) - should be more interesting for Whisper")
+      logger.info("--- Testing STT (Real Whisper - Tone) ---")
+      logger.info("Testing with a 440Hz tone (A note) - should be more interesting for Whisper")
       demoWhisperReal(toneWavFile.toString)
 
-      println("\n--- Testing STT (Real Whisper - Speech-like) ---")
-      println(
+      logger.info("--- Testing STT (Real Whisper - Speech-like) ---")
+      logger.info(
         "Testing with a speech-like modulated tone (200Hz base + 50Hz mod) - should be more interesting for Whisper"
       )
       demoWhisperReal(speechLikeWavFile.toString)
 
-      println("\n--- Testing TTS ---")
+      logger.info("--- Testing TTS ---")
       demoTacotron2("Hello from LLM4S")
       // Cleanup
       Files.deleteIfExists(silenceWavFile)
       Files.deleteIfExists(toneWavFile)
       Files.deleteIfExists(speechLikeWavFile)
-      println("\n=== Demo Complete ===")
+      logger.info("=== Demo Complete ===")
     }
     result.tap(x => x.fold(ex => logger.error("Error '{}'", ex.getMessage), _ => logger.trace("Ran successfully")))
   }

--- a/modules/samples/src/main/scala/org/llm4s/samples/actions/TranslationExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/actions/TranslationExample.scala
@@ -5,6 +5,7 @@ import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.llmconnect.model.{ Conversation, SystemMessage, UserMessage }
 import org.llm4s.llmconnect.LLMClient
 import org.llm4s.types.Result
+import org.slf4j.LoggerFactory
 
 /**
  * Example demonstrating how to use LLM4S for multi-tonal text translation.
@@ -17,6 +18,8 @@ import org.llm4s.types.Result
  * // Run: sbt "samples/runMain org.llm4s.samples.actions.TranslationExample"
  */
 object TranslationExample {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   val textToTranslate = "Hello, how are you?"
   val language        = "French"
   private val systemPrompt =
@@ -34,11 +37,11 @@ object TranslationExample {
     case object Formal   extends Tone
   }
   def main(args: Array[String]): Unit = {
-    println("Translation Example")
-    println("-------------------------")
-    println(s"Text to translate: $textToTranslate")
-    println(s"Target Language: $language")
-    println("-------------------------")
+    logger.info("Translation Example")
+    logger.info("-------------------------")
+    logger.info("Text to translate: {}", textToTranslate)
+    logger.info("Target Language: {}", language)
+    logger.info("-------------------------")
 
     val result = for {
       providerCfg <- Llm4sConfig.provider()
@@ -50,11 +53,11 @@ object TranslationExample {
     } yield (informal, formal)
 
     result.fold(
-      err => println(s"Error: ${err.formatted}"),
+      err => logger.error("Error: {}", err.formatted),
       { case (informal, formal) =>
-        println(s"Informal ($language): $informal")
-        println(s"Formal   ($language): $formal")
-        println("-------------------------")
+        logger.info("Informal ({}): {}", language, informal)
+        logger.info("Formal   ({}): {}", language, formal)
+        logger.info("-------------------------")
       }
     )
   }

--- a/modules/samples/src/main/scala/org/llm4s/samples/agent/LongConversationExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/agent/LongConversationExample.scala
@@ -6,6 +6,7 @@ import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.llmconnect.model.MessageRole
 import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.toolapi.tools.WeatherTool
+import org.slf4j.LoggerFactory
 
 /**
  * Example demonstrating long multi-turn conversations with automatic context pruning.
@@ -15,8 +16,10 @@ import org.llm4s.toolapi.tools.WeatherTool
  */
 object LongConversationExample {
 
+  private val logger = LoggerFactory.getLogger(getClass)
+
   def main(args: Array[String]): Unit = {
-    println("=== Long Conversation with Context Pruning Example ===\n")
+    logger.info("=== Long Conversation with Context Pruning Example ===")
 
     // Configure context window management
     val contextConfig = ContextWindowConfig(
@@ -49,23 +52,23 @@ object LongConversationExample {
         contextWindowConfig = Some(contextConfig) // Enable automatic pruning
       )
 
-      _ = println("\n=== Conversation Statistics ===")
-      _ = println(s"Total messages: ${finalState.conversation.messageCount}")
-      _ = println(s"User messages: ${finalState.conversation.filterByRole(MessageRole.User).length}")
-      _ = println(s"Assistant messages: ${finalState.conversation.filterByRole(MessageRole.Assistant).length}")
-      _ = println(s"Tool messages: ${finalState.conversation.filterByRole(MessageRole.Tool).length}")
+      _ = logger.info("=== Conversation Statistics ===")
+      _ = logger.info("Total messages: {}", finalState.conversation.messageCount)
+      _ = logger.info("User messages: {}", finalState.conversation.filterByRole(MessageRole.User).length)
+      _ = logger.info("Assistant messages: {}", finalState.conversation.filterByRole(MessageRole.Assistant).length)
+      _ = logger.info("Tool messages: {}", finalState.conversation.filterByRole(MessageRole.Tool).length)
 
-      _ = println("\n=== Final Assistant Response ===")
+      _ = logger.info("=== Final Assistant Response ===")
       _ = finalState.conversation.messages
         .filter(_.role == MessageRole.Assistant)
         .lastOption
-        .foreach(msg => println(msg.content))
+        .foreach(msg => logger.info("{}", msg.content))
 
     } yield finalState
 
     result.fold(
-      error => println(s"\nError: ${error.formatted}"),
-      state => println(s"\nSuccess! Conversation completed with status: ${state.status}")
+      error => logger.error("Error: {}", error.formatted),
+      state => logger.info("Success! Conversation completed with status: {}", state.status)
     )
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/agent/MultiTurnConversationExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/agent/MultiTurnConversationExample.scala
@@ -6,6 +6,7 @@ import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.llmconnect.model.MessageRole
 import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.toolapi.tools.WeatherTool
+import org.slf4j.LoggerFactory
 
 /**
  * Example demonstrating multi-turn conversations using the functional API.
@@ -15,8 +16,10 @@ import org.llm4s.toolapi.tools.WeatherTool
  */
 object MultiTurnConversationExample {
 
+  private val logger = LoggerFactory.getLogger(getClass)
+
   def main(args: Array[String]): Unit = {
-    println("=== Multi-Turn Conversation Example ===\n")
+    logger.info("=== Multi-Turn Conversation Example ===")
 
     // Functional style - no var, no mutation!
     val result = for {
@@ -25,28 +28,28 @@ object MultiTurnConversationExample {
       tools = new ToolRegistry(Seq(WeatherTool.tool))
       agent = new Agent(client)
 
-      _ = println("Turn 1: Asking about Paris weather")
+      _ = logger.info("Turn 1: Asking about Paris weather")
       state1 <- agent.run("What's the weather in Paris?", tools)
       _ = printLastAssistantMessage(state1)
 
-      _ = println("\nTurn 2: Asking about London weather")
+      _ = logger.info("Turn 2: Asking about London weather")
       state2 <- agent.continueConversation(state1, "And what about London?")
       _ = printLastAssistantMessage(state2)
 
-      _ = println("\nTurn 3: Comparing the two")
+      _ = logger.info("Turn 3: Comparing the two")
       state3 <- agent.continueConversation(state2, "Which city is warmer?")
       _ = printLastAssistantMessage(state3)
 
-      _ = println(s"\n=== Conversation Complete ===")
-      _ = println(s"Total messages: ${state3.conversation.messageCount}")
-      _ = println(s"User messages: ${state3.conversation.filterByRole(MessageRole.User).length}")
-      _ = println(s"Assistant messages: ${state3.conversation.filterByRole(MessageRole.Assistant).length}")
+      _ = logger.info("=== Conversation Complete ===")
+      _ = logger.info("Total messages: {}", state3.conversation.messageCount)
+      _ = logger.info("User messages: {}", state3.conversation.filterByRole(MessageRole.User).length)
+      _ = logger.info("Assistant messages: {}", state3.conversation.filterByRole(MessageRole.Assistant).length)
 
     } yield state3
 
     result.fold(
-      error => println(s"\nError: ${error.formatted}"),
-      _ => println("\nSuccess!")
+      error => logger.error("Error: {}", error.formatted),
+      _ => logger.info("Success!")
     )
   }
 
@@ -54,5 +57,5 @@ object MultiTurnConversationExample {
     state.conversation.messages
       .filter(_.role == MessageRole.Assistant)
       .lastOption
-      .foreach(msg => println(s"Assistant: ${msg.content}"))
+      .foreach(msg => logger.info("Assistant: {}", msg.content))
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/agent/SingleStepAgentExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/agent/SingleStepAgentExample.scala
@@ -5,60 +5,83 @@ import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.toolapi.tools.WeatherTool
+import org.slf4j.LoggerFactory
+import scala.util.chaining._
 
 /**
  * Example demonstrating step-by-step agent execution for debugging
  */
 object SingleStepAgentExample {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
   def main(args: Array[String]): Unit = {
-    // Get a client using environment variables (Result-first)
     val result = for {
       providerCfg <- Llm4sConfig.provider()
       client      <- LLMConnect.getClient(providerCfg)
       toolRegistry = new ToolRegistry(Seq(WeatherTool.tool))
       agent        = new Agent(client)
+
       traceLogPath = ".log/single-step-trace.md"
-      query        = "I'm planning a trip to Paris. What's the weather like there now?"
-      _            = println(s"Trace log will be written to: $traceLogPath\n")
-      _            = println(s"User Query: $query\n")
-      _            = println("=== Running Step-by-Step ===\n")
-      state        = agent.initialize(query, toolRegistry)
-      _            = println(s"Initial state initialized with ${state.conversation.messages.length} messages")
-      _            = agent.writeTraceLog(state, traceLogPath)
-      _ = {
+        .tap(p => logger.info("Trace log will be written to: {}", p))
+
+      query = "I'm planning a trip to Paris. What's the weather like there now?"
+        .tap(q => logger.info("User Query: {}", q))
+
+      _ = logger.info("=== Running Step-by-Step ===")
+
+      initialState = agent
+        .initialize(query, toolRegistry)
+        .tap(s => logger.info("Initial state initialized with {} messages", s.conversation.messages.length))
+
+      _ = agent.writeTraceLog(initialState, traceLogPath)
+
+      // We use a block here to run the steps and return the FINAL state
+      finalState = {
         var stepCount = 0
-        var stat      = state
-        while ((stat.status == AgentStatus.InProgress || stat.status == AgentStatus.WaitingForTools) && stepCount < 5) {
-          println(s"\nRunning step ${stepCount + 1}...")
-          agent.runStep(stat) match {
+        var state     = initialState
+
+        while (
+          (state.status == AgentStatus.InProgress || state.status == AgentStatus.WaitingForTools) && stepCount < 5
+        ) {
+          logger.info("Running step {}...", stepCount + 1)
+
+          agent.runStep(state) match {
             case Right(newState) =>
-              stat = newState
-              println(s"Step completed with status: ${stat.status}")
-              // Print the most recent message
-              stat.conversation.messages.lastOption.foreach { msg =>
-                println(
-                  s"Last message (${msg.role}): ${msg.content.take(100)}${if (msg.content.length > 100) "..." else ""}"
-                )
+              state = newState
+              logger.info("Step completed with status: {}", state.status)
+
+              state.conversation.messages.lastOption.foreach { msg =>
+                val preview = msg.content.take(100) + (if (msg.content.length > 100) "..." else "")
+                logger.info("Last message ({}): {}", msg.role, preview)
               }
-              agent.writeTraceLog(stat, traceLogPath)
+
+              agent.writeTraceLog(state, traceLogPath)
+
             case Left(error) =>
-              println(s"Error running step: $error")
-              stat = stat.withStatus(AgentStatus.Failed(error.toString))
-              agent.writeTraceLog(stat, traceLogPath)
+              logger.error("Error running step: {}", error.formatted)
+              state = state.withStatus(AgentStatus.Failed(error.toString))
+              agent.writeTraceLog(state, traceLogPath)
           }
+
           stepCount += 1
         }
-        println("\n=== Step-by-Step Run Complete ===\n")
-        println(s"Final status: ${stat.status}")
-        println(s"Total messages: ${stat.conversation.messages.length}")
-        println(s"Trace log has been written to: $traceLogPath")
+
+        logger.info("=== Step-by-Step Run Complete ===")
+        logger.info("Final status: {}", state.status)
+        logger.info("Total messages: {}", state.conversation.messages.length)
+        logger.info("Trace log has been written to: {}", traceLogPath)
+
+        state // Return the updated state
       }
-      _ = println("\n=== Complete Agent State Dump ===\n")
-      _ = state.dump()
+
+      _ = logger.info("=== Complete Agent State Dump ===")
+      _ = finalState.dump()
+
     } yield ()
 
     result.fold(
-      err => println(s"Error: ${err.formatted}"),
+      err => logger.error("Error: {}", err.formatted),
       identity
     )
   }

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/BasicLLMCallingExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/BasicLLMCallingExample.scala
@@ -3,6 +3,7 @@ package org.llm4s.samples.basic
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.llmconnect.model._
+import org.slf4j.LoggerFactory
 
 /**
  * Basic example demonstrating simple LLM API calls using LLM4S.
@@ -49,6 +50,7 @@ import org.llm4s.llmconnect.model._
  * For more information, see: https://github.com/llm4s/llm4s#getting-started
  */
 object BasicLLMCallingExample {
+  private val logger = LoggerFactory.getLogger(getClass)
 
   def main(args: Array[String]): Unit = {
     // Create a multi-turn conversation demonstrating different message types
@@ -89,18 +91,21 @@ object BasicLLMCallingExample {
       completion <- client.complete(conversation)
       _ = {
         // Display the response
-        println(s"\n✅ Success! Response from ${completion.model}")
-        println(s"Model ID: ${completion.id}")
-        println(s"Created at: ${completion.created}")
-        println(s"Chat Role: ${completion.message.role}")
-        println("\n--- Response ---")
-        println(completion.message.content)
-        println("--- End Response ---\n")
+        logger.info("Success! Response from {}", completion.model)
+        logger.info("Model ID: {}", completion.id)
+        logger.info("Created at: {}", completion.created)
+        logger.info("Chat Role: {}", completion.message.role)
+        logger.info("--- Response ---")
+        logger.info("{}", completion.message.content)
+        logger.info("--- End Response ---")
 
         // Print usage information if available
         completion.usage.foreach { usage =>
-          println(
-            s"📊 Tokens used: ${usage.totalTokens} (${usage.promptTokens} prompt + ${usage.completionTokens} completion)"
+          logger.info(
+            "Tokens used: {} ({} prompt + {} completion)",
+            usage.totalTokens,
+            usage.promptTokens,
+            usage.completionTokens
           )
         }
       }
@@ -109,9 +114,9 @@ object BasicLLMCallingExample {
     // Handle errors with helpful guidance
     result.fold(
       err => {
-        println(err.formatted)
-        println("\n💡 Tip: Make sure your environment variables or application.conf values are set correctly.")
-        println("For more help, see: https://github.com/llm4s/llm4s#getting-started")
+        logger.error("{}", err.formatted)
+        logger.info("Tip: Make sure your environment variables or application.conf values are set correctly.")
+        logger.info("For more help, see: https://github.com/llm4s/llm4s#getting-started")
         sys.exit(1)
       },
       identity

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/BasicLLMCallingWithTrace.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/BasicLLMCallingWithTrace.scala
@@ -6,8 +6,11 @@ import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.llmconnect.model._
 import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.trace.Tracing
+import org.slf4j.LoggerFactory
 
 object BasicLLMCallingWithTrace {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   def main(args: Array[String]): Unit = {
     val result = for {
       tracingSettings <- Llm4sConfig.tracing()
@@ -31,10 +34,10 @@ object BasicLLMCallingWithTrace {
         // Complete the conversation
         client.complete(conversation) match {
           case Right(completion) =>
-            println(s"Model ID=${completion.id} is created at ${completion.created}")
-            println(s"Chat Role: ${completion.message.role}")
-            println("Message:")
-            println(completion.message.content)
+            logger.info("Model ID={} is created at {}", completion.id, completion.created)
+            logger.info("Chat Role: {}", completion.message.role)
+            logger.info("Message:")
+            logger.info("{}", completion.message.content)
 
             // Trace the completion with token usage
             tracer.traceCompletion(completion, completion.model)
@@ -56,11 +59,11 @@ object BasicLLMCallingWithTrace {
 
           case Left(error) =>
             tracer.traceError(new RuntimeException(error.formatted))
-            println(s"Error: ${error.formatted}")
+            logger.error("Error: {}", error.formatted)
         }
         tracer.traceEvent("LLM conversation finished")
       }
     } yield ()
-    result.fold(err => println(s"Error: ${err.formatted}"), identity)
+    result.fold(err => logger.error("Error: {}", err.formatted), identity)
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/Llm4sConfigProviderExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/Llm4sConfigProviderExample.scala
@@ -2,6 +2,7 @@ package org.llm4s.samples.basic
 
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
+import org.slf4j.LoggerFactory
 
 /**
  * Minimal example showing how to bootstrap an LLM client using PureConfig without any legacy reader.
@@ -15,6 +16,8 @@ import org.llm4s.llmconnect.LLMConnect
  *   sbt "samples/runMain org.llm4s.samples.basic.Llm4sConfigProviderExample"
  */
 object Llm4sConfigProviderExample {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   def main(args: Array[String]): Unit = {
     val result = for {
       providerCfg <- Llm4sConfig.provider()
@@ -22,11 +25,11 @@ object Llm4sConfigProviderExample {
     } yield (providerCfg, client)
 
     result.fold(
-      err => System.err.println(s"[PureConfigProviderExample] Failed to create client: ${err.formatted}"),
+      err => logger.error("[PureConfigProviderExample] Failed to create client: {}", err.formatted),
       { case (cfg, _) =>
-        println("=== PureConfig Provider Example ===")
-        println(s"Provider model: ${cfg.model}")
-        println(s"Context window: ${cfg.contextWindow}, reserveCompletion: ${cfg.reserveCompletion}")
+        logger.info("=== PureConfig Provider Example ===")
+        logger.info("Provider model: {}", cfg.model)
+        logger.info("Context window: {}, reserveCompletion: {}", cfg.contextWindow, cfg.reserveCompletion)
       }
     )
   }

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/OllamaExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/OllamaExample.scala
@@ -3,8 +3,11 @@ package org.llm4s.samples.basic
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.llmconnect.model._
+import org.slf4j.LoggerFactory
 
 object OllamaExample {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   def main(args: Array[String]): Unit = {
     // Configuration is loaded via Typesafe Config (reference.conf + application.conf + optional overlays).
     val conversation = Conversation(
@@ -18,9 +21,12 @@ object OllamaExample {
       providerCfg <- Llm4sConfig.provider()
       client      <- LLMConnect.getClient(providerCfg)
       completion  <- client.complete(conversation, CompletionOptions())
-      _ = Console.println("Assistant:\n" + completion.message.content)
+      _ = {
+        logger.info("Assistant:")
+        logger.info("{}", completion.message.content)
+      }
     } yield ()
 
-    result.fold(err => Console.err.println(s"Error: ${err.formatted}"), identity)
+    result.fold(err => logger.error("Error: {}", err.formatted), identity)
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/OllamaStreamingExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/OllamaStreamingExample.scala
@@ -3,8 +3,11 @@ package org.llm4s.samples.basic
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.llmconnect.model._
+import org.slf4j.LoggerFactory
 
 object OllamaStreamingExample {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   def main(args: Array[String]): Unit = {
     // Works with any configured provider; optimized for local Ollama
     // Env example:
@@ -34,13 +37,17 @@ object OllamaStreamingExample {
           }
       )
       _ = {
-        println("\n--- Final Message ---\n" + completion.message.content)
+        // Ensure line break after streaming
+        println()
+        logger.info("--- Final Message ---")
+        logger.info("{}", completion.message.content)
+
         completion.usage.foreach(u =>
-          println(s"Tokens: prompt=${u.promptTokens}, completion=${u.completionTokens}, total=${u.totalTokens}")
+          logger.info("Tokens: prompt={}, completion={}, total={}", u.promptTokens, u.completionTokens, u.totalTokens)
         )
       }
     } yield ()
 
-    result.fold(err => Console.err.println(s"Error: ${err.formatted}"), identity)
+    result.fold(err => logger.error("Error: {}", err.formatted), identity)
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/compat/CrossCompilationExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/compat/CrossCompilationExample.scala
@@ -1,18 +1,21 @@
 package org.llm4s.samples.compat
 
 import org.llm4s.compat.ScalaCompat
+import org.slf4j.LoggerFactory
 
 /**
  * A simple example demonstrating cross-compilation support
  */
 object CrossCompilationExample {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   def main(args: Array[String]): Unit = {
     // Print the Scala version
-    println(s"Running on Scala ${util.Properties.versionNumberString}")
+    logger.info("Running on Scala {}", util.Properties.versionNumberString)
 
     // Use the compatibility layer
-    println(s"Is Scala 2.13: ${ScalaCompat.isScala213}")
-    println(s"Is Scala 3: ${ScalaCompat.isScala3}")
+    logger.info("Is Scala 2.13: {}", ScalaCompat.isScala213)
+    logger.info("Is Scala 3: {}", ScalaCompat.isScala3)
 
     // Use the version-dependent helper
     val versionText = ScalaCompat.onScala213(
@@ -20,20 +23,20 @@ object CrossCompilationExample {
       ifScala3 = "This is Scala 3 specific code"
     )
 
-    println(versionText)
+    logger.info("{}", versionText)
 
     // Demonstrate cross-compiled code selection
     if (ScalaCompat.isScala213) {
-      println("This branch only executes in Scala 2.13")
+      logger.info("This branch only executes in Scala 2.13")
       // In a real application, here you would access Scala 2.13 specific APIs
     } else {
-      println("This branch only executes in Scala 3")
+      logger.info("This branch only executes in Scala 3")
       // In a real application, here you would access Scala 3 specific APIs
       // For example, use Scala 3 union types, enums, extension methods, etc.
     }
 
     // The code can also pull in the right implementation automatically thanks to
     // the versioned source directories
-    println(s"Running version-specific code optimized for ${util.Properties.versionNumberString}")
+    logger.info("Running version-specific code optimized for {}", util.Properties.versionNumberString)
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/context/tokens/TokenSample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/context/tokens/TokenSample.scala
@@ -2,13 +2,16 @@ package org.llm4s.samples.context.tokens
 
 import org.llm4s.identity.TokenizerId.{ CL100K_BASE, O200K_BASE, R50K_BASE }
 import org.llm4s.context.tokens.Tokenizer
+import org.slf4j.LoggerFactory
 
 object TokenSample {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   def main(args: Array[String]): Unit =
     for (tokenizerId <- List(R50K_BASE, CL100K_BASE, O200K_BASE)) {
       val tokenizer = Tokenizer.lookupStringTokenizer(tokenizerId).get
       val message   = "Hello Scala!"
       val tokens    = tokenizer.encode(message)
-      println(s"`$message` / $tokenizerId -> $tokens")
+      logger.info("`{}` / {} -> {}", message, tokenizerId, tokens)
     }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/embeddingsupport/EmbeddingExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/embeddingsupport/EmbeddingExample.scala
@@ -76,8 +76,10 @@ object EmbeddingExample {
             case Left(err) =>
               val msg = s"${p.getFileName}: ${err.context.get("provider")} -> ${err.message}"
               errors += msg
-              println(red(s"[ERR] $msg")(ui))
+              // Log error diagnostics to logger
+              logger.error("[ERR] {}", msg)
             case Right(Nil) =>
+              // UI warning on stdout
               println(yellow(s"[WARN] ${p.getFileName}: no embeddings.")(ui))
             case Right(vecs) =>
               val rows    = toRows(p.getFileName.toString, vecs, queryVecOpt, ui.topDimsPerRow)

--- a/modules/samples/src/main/scala/org/llm4s/samples/guardrails/BasicInputValidationExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/guardrails/BasicInputValidationExample.scala
@@ -5,6 +5,7 @@ import org.llm4s.agent.guardrails.builtin._
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.toolapi.ToolRegistry
+import org.slf4j.LoggerFactory
 
 /**
  * Example demonstrating basic input validation with guardrails.
@@ -15,7 +16,9 @@ import org.llm4s.toolapi.ToolRegistry
  * Requires: LLM_MODEL and appropriate API key in environment
  */
 object BasicInputValidationExample extends App {
-  println("=== Basic Input Validation Example ===\n")
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  logger.info("=== Basic Input Validation Example ===")
 
   val result = for {
     providerCfg <- Llm4sConfig.provider()
@@ -38,14 +41,14 @@ object BasicInputValidationExample extends App {
 
   result match {
     case Right(state) =>
-      println("✓ Input validation passed!")
-      println(s"\nAgent response:")
-      state.conversation.messages.last.content.split("\n").foreach(line => println(s"  $line"))
+      logger.info("✓ Input validation passed!")
+      logger.info("Agent response:")
+      state.conversation.messages.last.content.split("\n").foreach(line => logger.info("  {}", line))
 
     case Left(error) =>
-      println(s"✗ Validation or execution failed:")
-      println(s"  Error: ${error.formatted}")
+      logger.error("✗ Validation or execution failed:")
+      logger.error("  Error: {}", error.formatted)
   }
 
-  println("\n" + "=" * 50)
+  logger.info("=" * 50)
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/guardrails/CompositeGuardrailExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/guardrails/CompositeGuardrailExample.scala
@@ -6,6 +6,7 @@ import org.llm4s.agent.guardrails.builtin._
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.toolapi.ToolRegistry
+import org.slf4j.LoggerFactory
 
 /**
  * Example demonstrating composite guardrails with different validation modes.
@@ -16,10 +17,12 @@ import org.llm4s.toolapi.ToolRegistry
  * Requires: LLM_MODEL and appropriate API key in environment
  */
 object CompositeGuardrailExample extends App {
-  println("=== Composite Guardrail Example ===\n")
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  logger.info("=== Composite Guardrail Example ===")
 
   // Example 1: All guardrails must pass (AND logic)
-  println("Example 1: All guardrails must pass\n")
+  logger.info("Example 1: All guardrails must pass")
 
   val safetyChecks = CompositeGuardrail.all(
     Seq(
@@ -42,16 +45,16 @@ object CompositeGuardrailExample extends App {
 
   result1 match {
     case Right(_) =>
-      println("✓ All safety checks passed!")
-      println(s"  Length check: PASS")
-      println(s"  Profanity filter: PASS\n")
+      logger.info("✓ All safety checks passed!")
+      logger.info("  Length check: PASS")
+      logger.info("  Profanity filter: PASS")
 
     case Left(error) =>
-      println(s"✗ Validation failed: ${error.formatted}\n")
+      logger.error("✗ Validation failed: {}", error.formatted)
   }
 
   // Example 2: At least one guardrail must pass (OR logic)
-  println("Example 2: At least one guardrail must pass (language detection)\n")
+  logger.info("Example 2: At least one guardrail must pass (language detection)")
 
   val languageDetection = CompositeGuardrail.any(
     Seq(
@@ -75,15 +78,15 @@ object CompositeGuardrailExample extends App {
 
   result2 match {
     case Right(_) =>
-      println("✓ Query matched at least one language pattern!")
-      println(s"  (Contains: scala, functional, java, python, etc.)\n")
+      logger.info("✓ Query matched at least one language pattern!")
+      logger.info("  (Contains: scala, functional, java, python, etc.)")
 
     case Left(error) =>
-      println(s"✗ No language patterns matched: ${error.formatted}\n")
+      logger.error("✗ No language patterns matched: {}", error.formatted)
   }
 
   // Example 3: Sequential validation (short-circuit on failure)
-  println("Example 3: Sequential validation with early termination\n")
+  logger.info("Example 3: Sequential validation with early termination")
 
   val sequentialChecks = CompositeGuardrail.sequential(
     Seq(
@@ -106,16 +109,16 @@ object CompositeGuardrailExample extends App {
 
   result3 match {
     case Right(_) =>
-      println("✓ All sequential checks passed!")
-      println(s"  Step 1 (Length): PASS")
-      println(s"  Step 2 (Profanity): PASS\n")
+      logger.info("✓ All sequential checks passed!")
+      logger.info("  Step 1 (Length): PASS")
+      logger.info("  Step 2 (Profanity): PASS")
 
     case Left(error) =>
-      println(s"✗ Validation failed at some step: ${error.formatted}\n")
+      logger.error("✗ Validation failed at some step: {}", error.formatted)
   }
 
   // Example 4: Combining safety and business logic
-  println("Example 4: Combining safety and business logic\n")
+  logger.info("Example 4: Combining safety and business logic")
 
   val combinedValidation: InputGuardrail = new InputGuardrail {
     val safetyLayer = CompositeGuardrail.all(
@@ -155,15 +158,15 @@ object CompositeGuardrailExample extends App {
 
   result4 match {
     case Right(state) =>
-      println("✓ Combined validation passed!")
-      println(s"  Safety layer: PASS")
-      println(s"  Business layer: PASS")
-      println("\nResponse preview:")
-      state.conversation.messages.last.content.split("\n").take(3).foreach(line => println(s"  $line"))
+      logger.info("✓ Combined validation passed!")
+      logger.info("  Safety layer: PASS")
+      logger.info("  Business layer: PASS")
+      logger.info("Response preview:")
+      state.conversation.messages.last.content.split("\n").take(3).foreach(line => logger.info("  {}", line))
 
     case Left(error) =>
-      println(s"✗ Combined validation failed: ${error.formatted}")
+      logger.error("✗ Combined validation failed: {}", error.formatted)
   }
 
-  println("\n" + "=" * 50)
+  logger.info("=" * 50)
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/guardrails/CustomGuardrailExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/guardrails/CustomGuardrailExample.scala
@@ -7,6 +7,7 @@ import org.llm4s.error.ValidationError
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.types.Result
+import org.slf4j.LoggerFactory
 
 /**
  * Custom guardrail that checks for specific keywords.
@@ -44,7 +45,9 @@ class KeywordRequirementGuardrail(requiredKeywords: Set[String]) extends InputGu
  * Requires: LLM_MODEL and appropriate API key in environment
  */
 object CustomGuardrailExample extends App {
-  println("=== Custom Guardrail Example ===\n")
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  logger.info("=== Custom Guardrail Example ===")
 
   val result = for {
     providerCfg <- Llm4sConfig.provider()
@@ -64,19 +67,19 @@ object CustomGuardrailExample extends App {
 
   result match {
     case Right(state) =>
-      println("✓ Query contained required keywords (scala, programming)")
-      println(s"\nAgent response:")
-      state.conversation.messages.last.content.split("\n").take(5).foreach(line => println(s"  $line"))
+      logger.info("✓ Query contained required keywords (scala, programming)")
+      logger.info("Agent response:")
+      state.conversation.messages.last.content.split("\n").take(5).foreach(line => logger.info("  {}", line))
 
     case Left(error) =>
-      println(s"✗ Validation failed:")
-      println(s"  Error: ${error.formatted}")
+      logger.error("✗ Validation failed:")
+      logger.error("  Error: {}", error.formatted)
   }
 
-  println("\n" + "=" * 50)
+  logger.info("=" * 50)
 
   // Demonstrate failure case
-  println("\n=== Testing with missing keywords ===\n")
+  logger.info("=== Testing with missing keywords ===")
 
   val failureResult = for {
     providerCfg <- Llm4sConfig.provider()
@@ -94,12 +97,12 @@ object CustomGuardrailExample extends App {
 
   failureResult match {
     case Right(_) =>
-      println("Unexpected success")
+      logger.warn("Unexpected success")
 
     case Left(error) =>
-      println(s"✓ Expected validation failure:")
-      println(s"  Error: ${error.formatted}")
+      logger.info("✓ Expected validation failure:")
+      logger.info("  Error: {}", error.formatted)
   }
 
-  println("\n" + "=" * 50)
+  logger.info("=" * 50)
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/guardrails/FactualityGuardrailExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/guardrails/FactualityGuardrailExample.scala
@@ -5,6 +5,7 @@ import org.llm4s.agent.guardrails.builtin._
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.toolapi.ToolRegistry
+import org.slf4j.LoggerFactory
 
 /**
  * Example demonstrating factuality guardrails for RAG applications.
@@ -23,7 +24,9 @@ import org.llm4s.toolapi.ToolRegistry
  * Requires: LLM_MODEL and appropriate API key in environment
  */
 object FactualityGuardrailExample extends App {
-  println("=== Factuality Guardrail Example (RAG Use Case) ===\n")
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  logger.info("=== Factuality Guardrail Example (RAG Use Case) ===")
 
   // Simulated retrieved document content (in real RAG, this comes from vector search)
   val retrievedContext =
@@ -44,9 +47,9 @@ object FactualityGuardrailExample extends App {
     agent = new Agent(client)
 
     // === Example 1: Standard Factuality Check ===
-    _ = println("1. Standard Factuality Check")
-    _ = println("-" * 40)
-    _ = println(s"Reference Context:\n$retrievedContext\n")
+    _ = logger.info("1. Standard Factuality Check")
+    _ = logger.info("-" * 40)
+    _ = logger.info("Reference Context:\n{}\n", retrievedContext)
 
     factualityGuardrail = LLMFactualityGuardrail(
       client,
@@ -66,8 +69,8 @@ object FactualityGuardrailExample extends App {
     _ = printResult(state1, "Standard Factuality")
 
     // === Example 2: Strict Factuality Check ===
-    _ = println("\n2. Strict Factuality Check (Higher Threshold)")
-    _ = println("-" * 40)
+    _ = logger.info("2. Strict Factuality Check (Higher Threshold)")
+    _ = logger.info("-" * 40)
 
     strictGuardrail = LLMFactualityGuardrail.strict(client, retrievedContext)
 
@@ -82,8 +85,8 @@ object FactualityGuardrailExample extends App {
     _ = printResult(state2, "Strict Factuality")
 
     // === Example 3: Combined with Safety ===
-    _ = println("\n3. Factuality + Safety Combined")
-    _ = println("-" * 40)
+    _ = logger.info("3. Factuality + Safety Combined")
+    _ = logger.info("-" * 40)
 
     safetyGuardrail = LLMSafetyGuardrail(client)
     combinedGuardrails = Seq(
@@ -105,25 +108,25 @@ object FactualityGuardrailExample extends App {
 
   result match {
     case Right(_) =>
-      println("\n" + "=" * 50)
-      println("✓ All factuality guardrail examples completed successfully!")
-      println("\nNote: In production RAG systems, the context would come from")
-      println("vector search over your document embeddings.")
+      logger.info("=" * 50)
+      logger.info("✓ All factuality guardrail examples completed successfully!")
+      logger.info("Note: In production RAG systems, the context would come from")
+      logger.info("vector search over your document embeddings.")
 
     case Left(error) =>
-      println(s"\n✗ Example failed with error:")
-      println(s"  ${error.formatted}")
-      println("\nThis might indicate the response contained claims not supported")
-      println("by the reference context (potential hallucination).")
+      logger.error("✗ Example failed with error:")
+      logger.error("  {}", error.formatted)
+      logger.info("This might indicate the response contained claims not supported")
+      logger.info("by the reference context (potential hallucination).")
   }
 
   def printResult(state: org.llm4s.agent.AgentState, checkName: String): Unit = {
     val response = state.conversation.messages.last.content
     val preview  = if (response.length > 300) response.take(300) + "..." else response
 
-    println(s"✓ $checkName Check PASSED (response grounded in context)")
-    println(s"Response:\n$preview")
+    logger.info("✓ {} Check PASSED (response grounded in context)", checkName)
+    logger.info("Response:\n{}", preview)
   }
 
-  println("\n" + "=" * 50)
+  logger.info("=" * 50)
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/guardrails/JSONOutputValidationExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/guardrails/JSONOutputValidationExample.scala
@@ -5,6 +5,7 @@ import org.llm4s.agent.guardrails.builtin._
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.toolapi.ToolRegistry
+import org.slf4j.LoggerFactory
 
 /**
  * Example demonstrating JSON output validation with guardrails.
@@ -15,7 +16,9 @@ import org.llm4s.toolapi.ToolRegistry
  * Requires: LLM_MODEL and appropriate API key in environment
  */
 object JSONOutputValidationExample extends App {
-  println("=== JSON Output Validation Example ===\n")
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  logger.info("=== JSON Output Validation Example ===")
 
   val result = for {
     providerCfg <- Llm4sConfig.provider()
@@ -43,11 +46,11 @@ object JSONOutputValidationExample extends App {
 
   result match {
     case Right(state) =>
-      println("✓ Output validation passed - response is valid JSON!\n")
+      logger.info("✓ Output validation passed - response is valid JSON!")
 
       val response = state.conversation.messages.last.content
-      println(s"JSON Response:")
-      println(response)
+      logger.info("JSON Response:")
+      logger.info("{}", response)
 
       // Can safely parse the JSON now
       import scala.util.Try
@@ -55,21 +58,21 @@ object JSONOutputValidationExample extends App {
 
       Try {
         val json = ujson.read(response)
-        println("\nParsed JSON fields:")
-        println(s"  Name: ${json("name").str}")
-        println(s"  Paradigm: ${json("paradigm").str}")
-        println(s"  Year: ${json("year").num.toInt}")
+        logger.info("Parsed JSON fields:")
+        logger.info("  Name: {}", json("name").str)
+        logger.info("  Paradigm: {}", json("paradigm").str)
+        logger.info("  Year: {}", json("year").num.toInt)
       }.toResult match {
         case Right(_) => // Successfully parsed
         case Left(error) =>
-          println(s"  Note: Could not parse all fields: ${error.message}")
+          logger.warn("  Note: Could not parse all fields: {}", error.message)
       }
 
     case Left(error) =>
-      println(s"✗ Validation or execution failed:")
-      println(s"  Error: ${error.formatted}")
-      println("\nThis error likely means the LLM did not return valid JSON.")
+      logger.error("✗ Validation or execution failed:")
+      logger.error("  Error: {}", error.formatted)
+      logger.info("This error likely means the LLM did not return valid JSON.")
   }
 
-  println("\n" + "=" * 50)
+  logger.info("=" * 50)
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/guardrails/LLMJudgeGuardrailExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/guardrails/LLMJudgeGuardrailExample.scala
@@ -6,6 +6,7 @@ import org.llm4s.agent.guardrails.builtin._
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.toolapi.ToolRegistry
+import org.slf4j.LoggerFactory
 
 /**
  * Example demonstrating LLM-as-Judge guardrails.
@@ -26,7 +27,9 @@ import org.llm4s.toolapi.ToolRegistry
  * Requires: LLM_MODEL and appropriate API key in environment
  */
 object LLMJudgeGuardrailExample extends App {
-  println("=== LLM-as-Judge Guardrail Example ===\n")
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  logger.info("=== LLM-as-Judge Guardrail Example ===")
 
   val result = for {
     providerCfg <- Llm4sConfig.provider()
@@ -34,8 +37,8 @@ object LLMJudgeGuardrailExample extends App {
     agent = new Agent(client)
 
     // === Example 1: Professional Tone Validation ===
-    _ = println("1. Testing Professional Tone Guardrail")
-    _ = println("-" * 40)
+    _ = logger.info("1. Testing Professional Tone Guardrail")
+    _ = logger.info("-" * 40)
 
     // LLM evaluates if the response maintains a professional tone
     toneGuardrail = LLMToneGuardrail.professional(client, threshold = 0.7)
@@ -49,8 +52,8 @@ object LLMJudgeGuardrailExample extends App {
     _ = printResult(state1, "Professional Tone Check")
 
     // === Example 2: Safety Guardrail ===
-    _ = println("\n2. Testing Safety Guardrail")
-    _ = println("-" * 40)
+    _ = logger.info("2. Testing Safety Guardrail")
+    _ = logger.info("-" * 40)
 
     safetyGuardrail = LLMSafetyGuardrail(client, threshold = 0.8)
 
@@ -63,8 +66,8 @@ object LLMJudgeGuardrailExample extends App {
     _ = printResult(state2, "Safety Check")
 
     // === Example 3: Quality Assessment ===
-    _ = println("\n3. Testing Response Quality Guardrail")
-    _ = println("-" * 40)
+    _ = logger.info("3. Testing Response Quality Guardrail")
+    _ = logger.info("-" * 40)
 
     originalQuery    = "What are the benefits of functional programming?"
     qualityGuardrail = LLMQualityGuardrail(client, originalQuery, threshold = 0.7)
@@ -78,8 +81,8 @@ object LLMJudgeGuardrailExample extends App {
     _ = printResult(state3, "Quality Check")
 
     // === Example 4: Custom LLM Guardrail ===
-    _ = println("\n4. Testing Custom LLM Guardrail")
-    _ = println("-" * 40)
+    _ = logger.info("4. Testing Custom LLM Guardrail")
+    _ = logger.info("-" * 40)
 
     // Create a custom LLM guardrail for specific criteria
     customGuardrail = LLMGuardrail(
@@ -98,8 +101,8 @@ object LLMJudgeGuardrailExample extends App {
     _ = printResult(state4, "Custom Criteria Check")
 
     // === Example 5: Combined Function + LLM Guardrails ===
-    _ = println("\n5. Testing Combined Guardrails (Function + LLM)")
-    _ = println("-" * 40)
+    _ = logger.info("5. Testing Combined Guardrails (Function + LLM)")
+    _ = logger.info("-" * 40)
 
     // Use fast function-based guardrails first, then LLM for nuanced checks
     combinedGuardrails = Seq(
@@ -119,21 +122,21 @@ object LLMJudgeGuardrailExample extends App {
 
   result match {
     case Right(_) =>
-      println("\n" + "=" * 50)
-      println("✓ All LLM-as-Judge guardrail examples completed successfully!")
+      logger.info("=" * 50)
+      logger.info("✓ All LLM-as-Judge guardrail examples completed successfully!")
 
     case Left(error) =>
-      println(s"\n✗ Example failed with error:")
-      println(s"  ${error.formatted}")
+      logger.error("✗ Example failed with error:")
+      logger.error("  {}", error.formatted)
   }
 
   def printResult(state: org.llm4s.agent.AgentState, checkName: String): Unit = {
     val response = state.conversation.messages.last.content
     val preview  = if (response.length > 200) response.take(200) + "..." else response
 
-    println(s"✓ $checkName PASSED")
-    println(s"Response preview: $preview")
+    logger.info("✓ {} PASSED", checkName)
+    logger.info("Response preview: {}", preview)
   }
 
-  println("\n" + "=" * 50)
+  logger.info("=" * 50)
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/guardrails/MultiTurnToneValidationExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/guardrails/MultiTurnToneValidationExample.scala
@@ -5,6 +5,7 @@ import org.llm4s.agent.guardrails.builtin._
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.toolapi.ToolRegistry
+import org.slf4j.LoggerFactory
 
 /**
  * Example demonstrating multi-turn conversations with tone validation.
@@ -16,7 +17,9 @@ import org.llm4s.toolapi.ToolRegistry
  * Requires: LLM_MODEL and appropriate API key in environment
  */
 object MultiTurnToneValidationExample extends App {
-  println("=== Multi-Turn Conversation with Tone Validation ===\n")
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  logger.info("=== Multi-Turn Conversation with Tone Validation ===")
 
   // Define guardrails to use across all turns
   val inputGuardrails = Seq(
@@ -34,56 +37,56 @@ object MultiTurnToneValidationExample extends App {
     agent = new Agent(client)
 
     // Turn 1: Ask about Scala
-    _ = println("Turn 1: Asking about Scala...")
+    _ = logger.info("Turn 1: Asking about Scala...")
     state1 <- agent.run(
       "What is Scala?",
       new ToolRegistry(Seq.empty),
       inputGuardrails = inputGuardrails,
       outputGuardrails = outputGuardrails
     )
-    _ = println(s"  ✓ Response passed tone validation\n")
+    _ = logger.info("  ✓ Response passed tone validation")
 
     // Turn 2: Ask for details
-    _ = println("Turn 2: Asking for main features...")
+    _ = logger.info("Turn 2: Asking for main features...")
     state2 <- agent.continueConversation(
       state1,
       "What are its main features?",
       inputGuardrails = inputGuardrails,
       outputGuardrails = outputGuardrails
     )
-    _ = println(s"  ✓ Response passed tone validation\n")
+    _ = logger.info("  ✓ Response passed tone validation")
 
     // Turn 3: Ask for examples
-    _ = println("Turn 3: Asking for code example...")
+    _ = logger.info("Turn 3: Asking for code example...")
     state3 <- agent.continueConversation(
       state2,
       "Can you give me a code example?",
       inputGuardrails = inputGuardrails,
       outputGuardrails = outputGuardrails
     )
-    _ = println(s"  ✓ Response passed tone validation\n")
+    _ = logger.info("  ✓ Response passed tone validation")
 
   } yield state3
 
   result match {
     case Right(finalState) =>
-      println("✓ All turns completed successfully!")
-      println(s"\nFinal conversation stats:")
-      println(s"  Status: ${finalState.status}")
-      println(s"  Total messages: ${finalState.conversation.messages.length}")
-      println(s"  Turns completed: 3")
+      logger.info("✓ All turns completed successfully!")
+      logger.info("Final conversation stats:")
+      logger.info("  Status: {}", finalState.status)
+      logger.info("  Total messages: {}", finalState.conversation.messages.length)
+      logger.info("  Turns completed: 3")
 
-      println("\nFinal response:")
-      finalState.conversation.messages.last.content.split("\n").take(5).foreach(line => println(s"  $line"))
+      logger.info("Final response:")
+      finalState.conversation.messages.last.content.split("\n").take(5).foreach(line => logger.info("  {}", line))
 
     case Left(error) =>
-      println(s"✗ Validation or execution failed:")
-      println(s"  Error: ${error.formatted}")
-      println("\nThis could mean:")
-      println("  - Input validation failed (profanity or length)")
-      println("  - Output tone was not professional or friendly")
-      println("  - Agent execution error")
+      logger.error("✗ Validation or execution failed:")
+      logger.error("  Error: {}", error.formatted)
+      logger.info("This could mean:")
+      logger.info("  - Input validation failed (profanity or length)")
+      logger.info("  - Output tone was not professional or friendly")
+      logger.info("  - Agent execution error")
   }
 
-  println("\n" + "=" * 50)
+  logger.info("=" * 50)
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/handoff/MathSpecialistHandoffExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/handoff/MathSpecialistHandoffExample.scala
@@ -4,6 +4,7 @@ import org.llm4s.agent.{ Agent, Handoff }
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.toolapi.ToolRegistry
+import org.slf4j.LoggerFactory
 
 /**
  * Math Specialist Handoff Example
@@ -12,9 +13,11 @@ import org.llm4s.toolapi.ToolRegistry
  * to a specialist agent with expertise in mathematics.
  */
 object MathSpecialistHandoffExample extends App {
-  println("=" * 80)
-  println("Math Specialist Handoff Example")
-  println("=" * 80)
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  logger.info("=" * 80)
+  logger.info("Math Specialist Handoff Example")
+  logger.info("=" * 80)
 
   val result = for {
     providerCfg <- Llm4sConfig.provider()
@@ -27,8 +30,8 @@ object MathSpecialistHandoffExample extends App {
     mathAgent = new Agent(client)
 
     // Run general agent with math handoff
-    _ = println("\nQuery: 'What is the integral of 2x + 5 from 0 to 10?'")
-    _ = println("\nGeneral agent analyzing query...")
+    _ = logger.info("Query: 'What is the integral of 2x + 5 from 0 to 10?'")
+    _ = logger.info("General agent analyzing query...")
 
     finalState <- generalAgent.run(
       query = "What is the integral of 2x + 5 from 0 to 10?",
@@ -51,23 +54,23 @@ object MathSpecialistHandoffExample extends App {
 
   result match {
     case Right(finalState) =>
-      println("\n" + "=" * 80)
-      println("✅ Math question answered")
-      println("=" * 80)
-      println(s"Status: ${finalState.status}")
-      println(s"\nAnswer:")
-      println(finalState.conversation.messages.last.content)
+      logger.info("=" * 80)
+      logger.info("Math question answered")
+      logger.info("=" * 80)
+      logger.info("Status: {}", finalState.status)
+      logger.info("Answer:")
+      logger.info("{}", finalState.conversation.messages.last.content)
 
       // Check if handoff occurred
       if (finalState.logs.exists(_.contains("handoff"))) {
-        println(s"\n🔄 Handoff occurred:")
-        finalState.logs.filter(_.contains("handoff")).foreach(log => println(s"  $log"))
+        logger.info("Handoff occurred:")
+        finalState.logs.filter(_.contains("handoff")).foreach(log => logger.info("  {}", log))
       }
 
     case Left(error) =>
-      println("\n" + "=" * 80)
-      println("❌ Error occurred")
-      println("=" * 80)
-      println(s"Error: ${error.formatted}")
+      logger.error("=" * 80)
+      logger.error("Error occurred")
+      logger.error("=" * 80)
+      logger.error("Error: {}", error.formatted)
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/handoff/SimpleTriageHandoffExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/handoff/SimpleTriageHandoffExample.scala
@@ -4,6 +4,7 @@ import org.llm4s.agent.{ Agent, Handoff }
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.toolapi.ToolRegistry
+import org.slf4j.LoggerFactory
 
 /**
  * Simple Triage Handoff Example
@@ -12,9 +13,11 @@ import org.llm4s.toolapi.ToolRegistry
  * A triage agent analyzes the query and hands off to the appropriate specialist.
  */
 object SimpleTriageHandoffExample extends App {
-  println("=" * 80)
-  println("Simple Triage Handoff Example")
-  println("=" * 80)
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  logger.info("=" * 80)
+  logger.info("Simple Triage Handoff Example")
+  logger.info("=" * 80)
 
   val result = for {
     providerCfg <- Llm4sConfig.provider()
@@ -29,8 +32,8 @@ object SimpleTriageHandoffExample extends App {
     triageAgent = new Agent(client)
 
     // Run triage agent with handoff options
-    _ = println("\nQuery: 'I want a refund for my order #12345'")
-    _ = println("\nTriaging query to appropriate specialist...")
+    _ = logger.info("Query: 'I want a refund for my order #12345'")
+    _ = logger.info("Triaging query to appropriate specialist...")
 
     finalState <- triageAgent.run(
       query = "I want a refund for my order #12345",
@@ -56,22 +59,22 @@ object SimpleTriageHandoffExample extends App {
 
   result match {
     case Right(finalState) =>
-      println("\n" + "=" * 80)
-      println("✅ Query handled successfully")
-      println("=" * 80)
-      println(s"Status: ${finalState.status}")
-      println(s"\nFinal Response:")
-      println(finalState.conversation.messages.last.content)
+      logger.info("=" * 80)
+      logger.info("Query handled successfully")
+      logger.info("=" * 80)
+      logger.info("Status: {}", finalState.status)
+      logger.info("Final Response:")
+      logger.info("{}", finalState.conversation.messages.last.content)
 
       if (finalState.logs.exists(_.contains("handoff"))) {
-        println(s"\n🔄 Handoff Log:")
-        finalState.logs.filter(_.contains("handoff")).foreach(log => println(s"  - $log"))
+        logger.info("Handoff Log:")
+        finalState.logs.filter(_.contains("handoff")).foreach(log => logger.info("  - {}", log))
       }
 
     case Left(error) =>
-      println("\n" + "=" * 80)
-      println("❌ Error occurred")
-      println("=" * 80)
-      println(s"Error: ${error.formatted}")
+      logger.error("=" * 80)
+      logger.error("Error occurred")
+      logger.error("=" * 80)
+      logger.error("Error: {}", error.formatted)
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/model/ModelMetadataExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/model/ModelMetadataExample.scala
@@ -1,6 +1,7 @@
 package org.llm4s.samples.model
 
 import org.llm4s.model.{ ModelMetadata, ModelMode, ModelRegistry }
+import org.slf4j.LoggerFactory
 
 /**
  * Example demonstrating how to use the ModelRegistry and ModelMetadata.
@@ -13,62 +14,59 @@ import org.llm4s.model.{ ModelMetadata, ModelMode, ModelRegistry }
  * - Registering custom models
  */
 object ModelMetadataExample extends App {
+  private val logger = LoggerFactory.getLogger(getClass)
 
-  println("=" * 80)
-  println("LLM4S Model Metadata Example")
-  println("=" * 80)
-  println()
+  logger.info("=" * 80)
+  logger.info("LLM4S Model Metadata Example")
+  logger.info("=" * 80)
 
   // Initialize the registry (loads embedded metadata)
-  println("Initializing ModelRegistry...")
+  logger.info("Initializing ModelRegistry...")
   ModelRegistry.initialize() match {
     case Right(_) =>
-      println("✓ ModelRegistry initialized successfully")
+      logger.info("ModelRegistry initialized successfully")
     case Left(error) =>
-      println(s"✗ Failed to initialize: $error")
+      logger.error("Failed to initialize: {}", error)
       sys.exit(1)
   }
-  println()
 
   // Example 1: Lookup a specific model
-  println("Example 1: Looking up GPT-4o metadata")
-  println("-" * 80)
+  logger.info("Example 1: Looking up GPT-4o metadata")
+  logger.info("-" * 80)
   ModelRegistry.lookup("gpt-4o") match {
     case Right(metadata) =>
-      println(s"Model ID: ${metadata.modelId}")
-      println(s"Provider: ${metadata.provider}")
-      println(s"Mode: ${metadata.mode.name}")
-      println(s"Context Window: ${metadata.contextWindow.getOrElse("unknown")} tokens")
-      println(s"Max Output: ${metadata.maxOutputTokens.getOrElse("unknown")} tokens")
-      println(s"Input Cost: ${metadata.inputCostPerToken.getOrElse("unknown")} per token")
-      println(s"Output Cost: ${metadata.outputCostPerToken.getOrElse("unknown")} per token")
-      println(s"Description: ${metadata.description}")
+      logger.info("Model ID: {}", metadata.modelId)
+      logger.info("Provider: {}", metadata.provider)
+      logger.info("Mode: {}", metadata.mode.name)
+      logger.info("Context Window: {} tokens", metadata.contextWindow.getOrElse("unknown"))
+      logger.info("Max Output: {} tokens", metadata.maxOutputTokens.getOrElse("unknown"))
+      logger.info("Input Cost: {} per token", metadata.inputCostPerToken.getOrElse("unknown"))
+      logger.info("Output Cost: {} per token", metadata.outputCostPerToken.getOrElse("unknown"))
+      logger.info("Description: {}", metadata.description)
     case Left(error) =>
-      println(s"Error: $error")
+      logger.error("Error: {}", error)
   }
-  println()
 
   // Example 2: Check model capabilities
-  println("Example 2: Checking Claude 3.7 Sonnet capabilities")
-  println("-" * 80)
+  logger.info("Example 2: Checking Claude 3.7 Sonnet capabilities")
+  logger.info("-" * 80)
   ModelRegistry.lookup("claude-3-7-sonnet-latest") match {
     case Right(metadata) =>
-      println(s"Model: ${metadata.modelId}")
-      println(s"Supports function calling: ${metadata.supports("function_calling")}")
-      println(s"Supports vision: ${metadata.supports("vision")}")
-      println(s"Supports prompt caching: ${metadata.supports("caching")}")
-      println(s"Supports reasoning: ${metadata.supports("reasoning")}")
-      println(s"Supports PDFs: ${metadata.supports("pdf")}")
-      println(s"Supports computer use: ${metadata.supports("computer_use")}")
-      println(s"Is deprecated: ${metadata.isDeprecated}")
+      logger.info("Model: {}", metadata.modelId)
+      logger.info("Supports function calling: {}", metadata.supports("function_calling"))
+      logger.info("Supports vision: {}", metadata.supports("vision"))
+      logger.info("Supports prompt caching: {}", metadata.supports("caching"))
+      logger.info("Supports reasoning: {}", metadata.supports("reasoning"))
+      logger.info("Supports PDFs: {}", metadata.supports("pdf"))
+      logger.info("Supports computer use: {}", metadata.supports("computer_use"))
+      logger.info("Is deprecated: {}", metadata.isDeprecated)
     case Left(error) =>
-      println(s"Error: $error")
+      logger.error("Error: {}", error)
   }
-  println()
 
   // Example 3: List models by provider
-  println("Example 3: Listing OpenAI chat models")
-  println("-" * 80)
+  logger.info("Example 3: Listing OpenAI chat models")
+  logger.info("-" * 80)
   val openaiModels = for {
     allOpenAI  <- ModelRegistry.listByProvider("openai")
     chatModels <- Right(allOpenAI.filter(_.mode == ModelMode.Chat))
@@ -76,38 +74,36 @@ object ModelMetadataExample extends App {
 
   openaiModels match {
     case Right(models) =>
-      println(s"Found ${models.size} OpenAI chat models:")
+      logger.info("Found {} OpenAI chat models:", models.size)
       models.take(10).foreach { model =>
         val ctx = model.contextWindow.map(c => f"${c / 1000}%dK").getOrElse("?")
-        println(f"  - ${model.modelId}%-40s (${ctx} context)")
+        logger.info(f"  - ${model.modelId}%-40s (${ctx} context)")
       }
-      if (models.size > 10) println(s"  ... and ${models.size - 10} more")
+      if (models.size > 10) logger.info("  ... and {} more", models.size - 10)
     case Left(error) =>
-      println(s"Error: $error")
+      logger.error("Error: {}", error)
   }
-  println()
 
   // Example 4: Find models with specific capabilities
-  println("Example 4: Finding models with vision support")
-  println("-" * 80)
+  logger.info("Example 4: Finding models with vision support")
+  logger.info("-" * 80)
   ModelRegistry.findByCapability("vision") match {
     case Right(models) =>
-      println(s"Found ${models.size} models with vision support:")
+      logger.info("Found {} models with vision support:", models.size)
       models
         .filter(_.mode == ModelMode.Chat) // Only chat models
         .take(5)
         .foreach { model =>
           val provider = model.provider
-          println(f"  - ${model.modelId}%-50s ($provider)")
+          logger.info(f"  - ${model.modelId}%-50s ($provider)")
         }
     case Left(error) =>
-      println(s"Error: $error")
+      logger.error("Error: {}", error)
   }
-  println()
 
   // Example 5: Estimate costs
-  println("Example 5: Estimating completion costs")
-  println("-" * 80)
+  logger.info("Example 5: Estimating completion costs")
+  logger.info("-" * 80)
   ModelRegistry.lookup("gpt-4o") match {
     case Right(metadata) =>
       val inputTokens  = 10000
@@ -115,21 +111,20 @@ object ModelMetadataExample extends App {
 
       metadata.pricing.estimateCost(inputTokens, outputTokens) match {
         case Some(cost) =>
-          println(s"Model: ${metadata.modelId}")
-          println(s"Input tokens: $inputTokens")
-          println(s"Output tokens: $outputTokens")
-          println(f"Estimated cost: $$${cost}%.6f")
+          logger.info("Model: {}", metadata.modelId)
+          logger.info("Input tokens: {}", inputTokens)
+          logger.info("Output tokens: {}", outputTokens)
+          logger.info(f"Estimated cost: $$${cost}%.6f")
         case None =>
-          println("Pricing information not available")
+          logger.info("Pricing information not available")
       }
     case Left(error) =>
-      println(s"Error: $error")
+      logger.error("Error: {}", error)
   }
-  println()
 
   // Example 6: Register a custom model
-  println("Example 6: Registering a custom model")
-  println("-" * 80)
+  logger.info("Example 6: Registering a custom model")
+  logger.info("-" * 80)
   val customModel = ModelMetadata(
     modelId = "my-custom-llm-v1",
     provider = "custom",
@@ -151,46 +146,43 @@ object ModelMetadataExample extends App {
   )
 
   ModelRegistry.register(customModel)
-  println(s"✓ Registered custom model: ${customModel.modelId}")
+  logger.info("Registered custom model: {}", customModel.modelId)
 
   ModelRegistry.lookup("my-custom-llm-v1") match {
     case Right(metadata) =>
-      println(s"  Description: ${metadata.description}")
-      println(s"  Context window: ${metadata.contextWindow.get} tokens")
+      logger.info("  Description: {}", metadata.description)
+      logger.info("  Context window: {} tokens", metadata.contextWindow.get)
     case Left(error) =>
-      println(s"  Error retrieving: $error")
+      logger.error("  Error retrieving: {}", error)
   }
-  println()
 
   // Example 7: Get registry statistics
-  println("Example 7: Registry statistics")
-  println("-" * 80)
+  logger.info("Example 7: Registry statistics")
+  logger.info("-" * 80)
   val stats = ModelRegistry.statistics()
-  println(s"Total models: ${stats("totalModels")}")
-  println(s"Embedded models: ${stats("embeddedModels")}")
-  println(s"Custom models: ${stats("customModels")}")
-  println(s"Providers: ${stats("providers")}")
-  println(s"Chat models: ${stats("chatModels")}")
-  println(s"Embedding models: ${stats("embeddingModels")}")
-  println(s"Image generation models: ${stats("imageGenerationModels")}")
-  println(s"Deprecated models: ${stats("deprecatedModels")}")
-  println()
+  logger.info("Total models: {}", stats("totalModels"))
+  logger.info("Embedded models: {}", stats("embeddedModels"))
+  logger.info("Custom models: {}", stats("customModels"))
+  logger.info("Providers: {}", stats("providers"))
+  logger.info("Chat models: {}", stats("chatModels"))
+  logger.info("Embedding models: {}", stats("embeddingModels"))
+  logger.info("Image generation models: {}", stats("imageGenerationModels"))
+  logger.info("Deprecated models: {}", stats("deprecatedModels"))
 
   // Example 8: List all providers
-  println("Example 8: Available providers")
-  println("-" * 80)
+  logger.info("Example 8: Available providers")
+  logger.info("-" * 80)
   ModelRegistry.listProviders() match {
     case Right(providers) =>
-      println(s"Found ${providers.size} providers:")
-      providers.foreach(p => println(s"  - $p"))
+      logger.info("Found {} providers:", providers.size)
+      providers.foreach(p => logger.info("  - {}", p))
     case Left(error) =>
-      println(s"Error: $error")
+      logger.error("Error: {}", error)
   }
-  println()
 
   // Example 9: Load custom metadata from JSON
-  println("Example 9: Loading custom metadata from JSON")
-  println("-" * 80)
+  logger.info("Example 9: Loading custom metadata from JSON")
+  logger.info("-" * 80)
   val customJson = """{
     "my-experimental-model": {
       "litellm_provider": "experimental",
@@ -206,21 +198,20 @@ object ModelMetadataExample extends App {
 
   ModelRegistry.loadCustomMetadataFromString(customJson) match {
     case Right(_) =>
-      println("✓ Custom metadata loaded successfully")
+      logger.info("Custom metadata loaded successfully")
       ModelRegistry.lookup("my-experimental-model") match {
         case Right(metadata) =>
-          println(s"  Model: ${metadata.modelId}")
-          println(s"  Provider: ${metadata.provider}")
-          println(s"  Context: ${metadata.contextWindow.getOrElse("unknown")} tokens")
+          logger.info("  Model: {}", metadata.modelId)
+          logger.info("  Provider: {}", metadata.provider)
+          logger.info("  Context: {} tokens", metadata.contextWindow.getOrElse("unknown"))
         case Left(error) =>
-          println(s"  Error: $error")
+          logger.error("  Error: {}", error)
       }
     case Left(error) =>
-      println(s"✗ Failed to load: $error")
+      logger.error("Failed to load: {}", error)
   }
-  println()
 
-  println("=" * 80)
-  println("Example complete!")
-  println("=" * 80)
+  logger.info("=" * 80)
+  logger.info("Example complete!")
+  logger.info("=" * 80)
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/DocumentLoaderExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/DocumentLoaderExample.scala
@@ -1,6 +1,8 @@
 package org.llm4s.samples.rag
 
 import org.llm4s.rag.loader._
+import org.slf4j.LoggerFactory
+import scala.util.chaining._
 
 /**
  * Example demonstrating the DocumentLoader API for RAG pipelines.
@@ -17,11 +19,12 @@ import org.llm4s.rag.loader._
  * }}}
  */
 object DocumentLoaderExample extends App {
+  private val logger = LoggerFactory.getLogger(getClass)
 
-  println("=== Document Loader Example ===\n")
+  logger.info("=== Document Loader Example ===")
 
   // ========== 1. Basic TextLoader Usage ==========
-  println("1. Creating documents with TextLoader...")
+  logger.info("1. Creating documents with TextLoader...")
 
   val textLoader = TextLoader
     .builder()
@@ -29,35 +32,35 @@ object DocumentLoaderExample extends App {
     .add("doc-2", "LLM4S is a framework for building LLM-powered applications in Scala.")
     .add("doc-3", "RAG (Retrieval-Augmented Generation) improves LLM responses by providing relevant context.")
     .build()
-
-  println(s"   Created loader with ${textLoader.estimatedCount.getOrElse("?")} documents")
+    .tap(l => logger.info("   Created loader with {} documents", l.estimatedCount.getOrElse("?")))
 
   // ========== 2. FileLoader and DirectoryLoader ==========
-  println("\n2. FileLoader and DirectoryLoader...")
+  logger.info("2. FileLoader and DirectoryLoader...")
 
   // Single file loader
   val fileLoader = FileLoader("./README.md")
-  println(s"   FileLoader: ${fileLoader.description}")
+    .tap(l => logger.info("   FileLoader: {}", l.description))
 
   // Directory loader with filtering
   val dirLoader = DirectoryLoader("./docs")
     .withExtensions(Set(".md", ".txt"))
     .withRecursive(true)
-  println(s"   DirectoryLoader: ${dirLoader.description}")
+    .tap(l => logger.info("   DirectoryLoader: {}", l.description))
 
   // ========== 3. Combining Loaders ==========
-  println("\n3. Combining multiple loaders...")
+  logger.info("3. Combining multiple loaders...")
 
-  val combinedLoader = textLoader ++ fileLoader
-  println(s"   Combined: ${combinedLoader.description}")
+  val combinedLoader = (textLoader ++ fileLoader)
+    .tap(l => logger.info("   Combined: {}", l.description))
 
   // Using DocumentLoaders combinators
-  val filteredLoader = DocumentLoaders.filter(textLoader)(doc => doc.content.contains("Scala"))
-  println(s"   Filtered: {filteredLoader.description}")
+  val filteredLoader = DocumentLoaders
+    .filter(textLoader)(doc => doc.content.contains("Scala"))
+    .tap(l => logger.info("   Filtered: {}", l.description))
 
   // ========== 4. Build-Time Loading ==========
-  println("\n4. Build-time loading with RAG.builder()...")
-  println("   (Requires embedding provider environment variables)")
+  logger.info("4. Build-time loading with RAG.builder()...")
+  logger.info("   (Requires embedding provider environment variables)")
 
   // Example of build-time loading:
   // val rag = RAG.builder()
@@ -68,49 +71,47 @@ object DocumentLoaderExample extends App {
   //   .toOption.get
 
   // ========== 5. Ingest-Time Loading ==========
-  println("\n5. Ingest-time loading...")
-  println("   Example: rag.ingest(DirectoryLoader(\"./new-docs\"))")
+  logger.info("5. Ingest-time loading...")
+  logger.info("   Example: rag.ingest(DirectoryLoader(\"./new-docs\"))")
 
   // val stats = rag.ingest(DirectoryLoader("./new-docs"))
   // stats match {
   //   case Right(s) =>
-  //     println(s"   Loaded ${s.successful} documents, ${s.failed} failed, ${s.skipped} skipped")
+  //     logger.info("Loaded {} documents, {} failed, {} skipped", s.successful, s.failed, s.skipped)
   //   case Left(error) =>
-  //     println(s"   Error: ${error.message}")
+  //     logger.error("Error: {}", error.message)
   // }
 
   // ========== 6. Incremental Sync ==========
-  println("\n6. Incremental sync operations...")
-  println("   Example: rag.sync(DirectoryLoader(\"./docs\"))")
+  logger.info("6. Incremental sync operations...")
+  logger.info("   Example: rag.sync(DirectoryLoader(\"./docs\"))")
 
   // Sync only processes changed documents:
   // val syncStats = rag.sync(DirectoryLoader("./docs"))
   // syncStats match {
   //   case Right(s) =>
-  //     println(s"   Added: ${s.added}, Updated: ${s.updated}, Deleted: ${s.deleted}, Unchanged: ${s.unchanged}")
+  //     logger.info("Added: {}, Updated: {}, Deleted: {}, Unchanged: {}", s.added, s.updated, s.deleted, s.unchanged)
   //   case Left(error) =>
-  //     println(s"   Error: ${error.message}")
+  //     logger.error("Error: {}", error.message)
   // }
 
   // ========== 7. Document Hints ==========
-  println("\n7. Using document hints for chunking optimization...")
+  logger.info("7. Using document hints for chunking optimization...")
 
   val codeDoc = Document(
     id = "code-sample",
     content = "```scala\ndef hello(): Unit = println(\"Hello\")\n```",
     hints = Some(DocumentHints.code)
-  )
-  println(s"   Code document with hints: ${codeDoc.hints.map(_.chunkingStrategy).flatten}")
+  ).tap(d => logger.info("   Code document with hints: {}", d.hints.map(_.chunkingStrategy).flatten))
 
   val markdownDoc = Document(
     id = "markdown-sample",
     content = "# Title\n\nSome markdown content",
     hints = Some(DocumentHints.markdown)
-  )
-  println(s"   Markdown document with hints: ${markdownDoc.hints.map(_.chunkingStrategy).flatten}")
+  ).tap(d => logger.info("   Markdown document with hints: {}", d.hints.map(_.chunkingStrategy).flatten))
 
   // ========== 8. LoadResult Handling ==========
-  println("\n8. Handling LoadResults...")
+  logger.info("8. Handling LoadResults...")
 
   val results = textLoader.load().toList
   val summary = results.groupBy {
@@ -119,48 +120,44 @@ object DocumentLoaderExample extends App {
     case _: LoadResult.Skipped => "skipped"
   }
 
-  println(s"   Results: ${summary.map { case (k, v) => s"$k=${v.size}" }.mkString(", ")}")
+  logger.info("   Results: {}", summary.map { case (k, v) => s"$k=${v.size}" }.mkString(", "))
 
   // ========== 9. Version Tracking ==========
-  println("\n9. Document version tracking...")
+  logger.info("9. Document version tracking...")
 
-  val docWithVersion = Document.create("Some content with auto-generated version")
-  println(s"   Document ID: ${docWithVersion.id}")
-  println(s"   Content hash: ${docWithVersion.version.map(_.contentHash.take(16) + "...").getOrElse("none")}")
+  val docWithVersion = Document
+    .create("Some content with auto-generated version")
+    .tap(d => logger.info("   Document ID: {}", d.id))
+    .tap(d => logger.info("   Content hash: {}", d.version.map(_.contentHash.take(16) + "...").getOrElse("none")))
 
   // ========== 10. Loading Configuration ==========
-  println("\n10. Loading configuration options...")
+  logger.info("10. Loading configuration options...")
 
   val strictConfig   = LoadingConfig.strict          // Fail on first error
   val lenientConfig  = LoadingConfig.lenient         // Continue on errors, skip empty
   val highPerfConfig = LoadingConfig.highPerformance // More parallelism
 
-  println(s"    Strict: failFast=${strictConfig.failFast}")
-  println(s"    Lenient: failFast=${lenientConfig.failFast}, skipEmpty=${lenientConfig.skipEmptyDocuments}")
-  println(s"    HighPerf: parallelism=${highPerfConfig.parallelism}, batchSize=${highPerfConfig.batchSize}")
+  logger.info("   Strict: failFast={}", strictConfig.failFast)
+  logger.info("   Lenient: failFast={}, skipEmpty={}", lenientConfig.failFast, lenientConfig.skipEmptyDocuments)
+  logger.info("   HighPerf: parallelism={}, batchSize={}", highPerfConfig.parallelism, highPerfConfig.batchSize)
 
   // ========== 11. Async Operations ==========
-  println("\n11. Async/parallel operations...")
-  println("    RAG supports async operations for parallel document processing:")
-  println("")
-  println("    // Async ingest with parallel processing")
-  println("    import scala.concurrent.ExecutionContext.Implicits.global")
-  println("    import scala.concurrent.Await")
-  println("    import scala.concurrent.duration._")
-  println("")
-  println("    val futureStats = rag.ingestAsync(DirectoryLoader(\"./large-docs\"))")
-  println("    val stats = Await.result(futureStats, 5.minutes)")
-  println("")
-  println("    // Async sync for parallel change detection")
-  println("    val futureSyncStats = rag.syncAsync(DirectoryLoader(\"./docs\"))")
-  println("")
-  println("    // Async refresh")
-  println("    val futureRefreshStats = rag.refreshAsync(DirectoryLoader(\"./docs\"))")
-  println("")
-  println("    // Configure parallelism via LoadingConfig")
-  println("    val customConfig = LoadingConfig.default")
-  println("      .withParallelism(16)    // Up to 16 concurrent operations")
-  println("      .withBatchSize(50)      // Process 50 documents per batch")
+  logger.info("11. Async/parallel operations...")
+  logger.info("   RAG supports async operations for parallel document processing:")
+  logger.info("   // Async ingest with parallel processing")
+  logger.info("   import scala.concurrent.ExecutionContext.Implicits.global")
+  logger.info("   import scala.concurrent.Await")
+  logger.info("   import scala.concurrent.duration._")
+  logger.info("   val futureStats = rag.ingestAsync(DirectoryLoader(\"./large-docs\"))")
+  logger.info("   val stats = Await.result(futureStats, 5.minutes)")
+  logger.info("   // Async sync for parallel change detection")
+  logger.info("   val futureSyncStats = rag.syncAsync(DirectoryLoader(\"./docs\"))")
+  logger.info("   // Async refresh")
+  logger.info("   val futureRefreshStats = rag.refreshAsync(DirectoryLoader(\"./docs\"))")
+  logger.info("   // Configure parallelism via LoadingConfig")
+  logger.info("   val customConfig = LoadingConfig.default")
+  logger.info("     .withParallelism(16)    // Up to 16 concurrent operations")
+  logger.info("     .withBatchSize(50)      // Process 50 documents per batch")
 
-  println("\n=== Example Complete ===")
+  logger.info("=== Example Complete ===")
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/RAGBuilderExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/RAGBuilderExample.scala
@@ -5,6 +5,8 @@ import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.rag.{ EmbeddingProvider, RAG, RAGConfig }
 import org.llm4s.rag.RAG.RAGConfigOps
+import org.slf4j.LoggerFactory
+import scala.util.chaining._
 
 /**
  * RAG Builder API Example
@@ -28,14 +30,15 @@ import org.llm4s.rag.RAG.RAGConfigOps
  *   sbt "samples/runMain org.llm4s.samples.rag.RAGBuilderExample"
  */
 object RAGBuilderExample extends App {
+  private val logger = LoggerFactory.getLogger(getClass)
 
-  println("=" * 60)
-  println("RAG Builder API Example")
-  println("=" * 60)
+  logger.info("=" * 60)
+  logger.info("RAG Builder API Example")
+  logger.info("=" * 60)
 
   // ========== Example 1: Minimal Configuration ==========
-  println("\n--- Example 1: Minimal Configuration ---")
-  println("""
+  logger.info("--- Example 1: Minimal Configuration ---")
+  logger.info("""
     |val rag = RAG.builder()
     |  .withEmbeddings(EmbeddingProvider.OpenAI)
     |  .build()
@@ -44,15 +47,14 @@ object RAGBuilderExample extends App {
   val minimalConfig = RAG
     .builder()
     .withEmbeddings(EmbeddingProvider.OpenAI)
-
-  println(s"Embedding provider: ${minimalConfig.embeddingProvider.name}")
-  println(s"Chunking strategy: ${minimalConfig.chunkingStrategy}")
-  println(s"Fusion strategy: ${minimalConfig.fusionStrategy}")
-  println(s"Top K: ${minimalConfig.topK}")
+    .tap(c => logger.info("Embedding provider: {}", c.embeddingProvider.name))
+    .tap(c => logger.info("Chunking strategy: {}", c.chunkingStrategy))
+    .tap(c => logger.info("Fusion strategy: {}", c.fusionStrategy))
+    .tap(c => logger.info("Top K: {}", c.topK))
 
   // ========== Example 2: Full Customization ==========
-  println("\n--- Example 2: Full Customization ---")
-  println("""
+  logger.info("--- Example 2: Full Customization ---")
+  logger.info("""
     |val rag = RAG.builder()
     |  .withEmbeddings(EmbeddingProvider.OpenAI, "text-embedding-3-large")
     |  .withChunking(ChunkerFactory.Strategy.Sentence, 800, 150)
@@ -71,60 +73,66 @@ object RAGBuilderExample extends App {
     .withCohereReranking()
     .withSQLite("./rag.db")
     .withTopK(10)
-
-  println(s"Embedding model: ${fullConfig.embeddingModel.getOrElse("default")}")
-  println(s"Chunk size: ${fullConfig.chunkingConfig.targetSize}")
-  println(s"Chunk overlap: ${fullConfig.chunkingConfig.overlap}")
-  println(s"Storage path: ${fullConfig.vectorStorePath.getOrElse("in-memory")}")
-  println(s"Reranking: ${fullConfig.rerankingStrategy}")
+    .tap(c => logger.info("Embedding model: {}", c.embeddingModel.getOrElse("default")))
+    .tap(c => logger.info("Chunk size: {}", c.chunkingConfig.targetSize))
+    .tap(c => logger.info("Chunk overlap: {}", c.chunkingConfig.overlap))
+    .tap(c => logger.info("Storage path: {}", c.vectorStorePath.getOrElse("in-memory")))
+    .tap(c => logger.info("Reranking: {}", c.rerankingStrategy))
 
   // ========== Example 3: Preset Configurations ==========
-  println("\n--- Example 3: Preset Configurations ---")
+  logger.info("--- Example 3: Preset Configurations ---")
 
-  println("\nRAGConfig.development:")
+  logger.info("RAGConfig.development:")
   val devConfig = RAGConfig.development
-  println(s"  Storage: ${devConfig.vectorStorePath.getOrElse("in-memory")}")
-  println(s"  Top K: ${devConfig.topK}")
+    .tap(c => logger.info("  Storage: {}", c.vectorStorePath.getOrElse("in-memory")))
+    .tap(c => logger.info("  Top K: {}", c.topK))
 
-  println("\nRAGConfig.production(\"/var/data/rag.db\"):")
-  val prodConfig = RAGConfig.production("/var/data/rag.db")
-  println(s"  Storage: ${prodConfig.vectorStorePath.getOrElse("in-memory")}")
-  println(s"  Chunk size: ${prodConfig.chunkingConfig.targetSize}")
+  logger.info("RAGConfig.production(\"/var/data/rag.db\"):")
+  val prodConfig = RAGConfig
+    .production("/var/data/rag.db")
+    .tap(c => logger.info("  Storage: {}", c.vectorStorePath.getOrElse("in-memory")))
+    .tap(c => logger.info("  Chunk size: {}", c.chunkingConfig.targetSize))
 
   // ========== Example 4: Different Embedding Providers ==========
-  println("\n--- Example 4: Different Embedding Providers ---")
+  logger.info("--- Example 4: Different Embedding Providers ---")
 
-  println("\nOllama (local, no API key):")
+  logger.info("Ollama (local, no API key):")
   val ollamaConfig = RAG
     .builder()
     .withEmbeddings(EmbeddingProvider.Ollama, "nomic-embed-text")
-  println(s"  Provider: ${ollamaConfig.embeddingProvider.name}")
-  println(s"  Model: ${ollamaConfig.embeddingModel.getOrElse("default")}")
+    .tap(c => logger.info("  Provider: {}", c.embeddingProvider.name))
+    .tap(c => logger.info("  Model: {}", c.embeddingModel.getOrElse("default")))
 
-  println("\nVoyage AI:")
+  logger.info("Voyage AI:")
   val voyageConfig = RAG
     .builder()
     .withEmbeddings(EmbeddingProvider.Voyage, "voyage-3")
-  println(s"  Provider: ${voyageConfig.embeddingProvider.name}")
-  println(s"  Model: ${voyageConfig.embeddingModel.getOrElse("default")}")
+    .tap(c => logger.info("  Provider: {}", c.embeddingProvider.name))
+    .tap(c => logger.info("  Model: {}", c.embeddingModel.getOrElse("default")))
 
   // ========== Example 5: Different Fusion Strategies ==========
-  println("\n--- Example 5: Fusion Strategies ---")
+  logger.info("--- Example 5: Fusion Strategies ---")
 
-  println("\nVector-only search:")
-  val vectorOnly = RAG.builder().vectorOnly
-  println(s"  Strategy: ${vectorOnly.fusionStrategy}")
+  logger.info("Vector-only search:")
+  val vectorOnly = RAG
+    .builder()
+    .vectorOnly
+    .tap(c => logger.info("  Strategy: {}", c.fusionStrategy))
 
-  println("\nKeyword-only search:")
-  val keywordOnly = RAG.builder().keywordOnly
-  println(s"  Strategy: ${keywordOnly.fusionStrategy}")
+  logger.info("Keyword-only search:")
+  val keywordOnly = RAG
+    .builder()
+    .keywordOnly
+    .tap(c => logger.info("  Strategy: {}", c.fusionStrategy))
 
-  println("\nWeighted score (70% vector, 30% keyword):")
-  val weighted = RAG.builder().withWeightedScore(0.7, 0.3)
-  println(s"  Strategy: ${weighted.fusionStrategy}")
+  logger.info("Weighted score (70% vector, 30% keyword):")
+  val weighted = RAG
+    .builder()
+    .withWeightedScore(0.7, 0.3)
+    .tap(c => logger.info("  Strategy: {}", c.fusionStrategy))
 
   // ========== Example 6: Building and Using (Demo) ==========
-  println("\n--- Example 6: Building a Real RAG Pipeline ---")
+  logger.info("--- Example 6: Building a Real RAG Pipeline ---")
 
   // Check if we have LLM configured for answer generation
   val llmResult = for {
@@ -134,7 +142,7 @@ object RAGBuilderExample extends App {
   val hasLLM = llmResult.isRight
 
   if (hasLLM) {
-    println("LLM configured - building RAG with answer generation...")
+    logger.info("LLM configured - building RAG with answer generation...")
 
     val result = for {
       llmClient <- llmResult
@@ -145,9 +153,9 @@ object RAGBuilderExample extends App {
         .withLLM(llmClient)
         .build()
     } yield {
-      println(s"RAG pipeline created successfully!")
-      println(s"Document count: ${rag.documentCount}")
-      println(s"Chunk count: ${rag.chunkCount}")
+      logger.info("RAG pipeline created successfully!")
+      logger.info("Document count: {}", rag.documentCount)
+      logger.info("Chunk count: {}", rag.chunkCount)
 
       // Ingest sample text
       val ingestResult = rag.ingestText(
@@ -157,25 +165,25 @@ object RAGBuilderExample extends App {
           |The API uses immutable configuration with sensible defaults.""".stripMargin,
         "sample-doc-1"
       )
-      ingestResult.foreach(count => println(s"Ingested document with $count chunks"))
+      ingestResult.foreach(count => logger.info("Ingested document with {} chunks", count))
 
       // Query
       val searchResult = rag.query("What embedding providers are supported?")
       searchResult.foreach { results =>
-        println(s"\nSearch found ${results.size} results:")
-        results.foreach(r => println(s"  - Score: ${r.score}: ${r.content.take(80)}..."))
+        logger.info("Search found {} results:", results.size)
+        results.foreach(r => logger.info("  - Score: {}: {}...", r.score, r.content.take(80)))
       }
 
       rag.close()
     }
 
-    result.left.foreach(error => println(s"Error: $error"))
+    result.left.foreach(error => logger.error("Error: {}", error))
   } else {
-    println("LLM not configured - skipping live demo")
-    println("Set LLM_MODEL and OPENAI_API_KEY (or equivalent) to run the full demo")
+    logger.info("LLM not configured - skipping live demo")
+    logger.info("Set LLM_MODEL and OPENAI_API_KEY (or equivalent) to run the full demo")
   }
 
-  println("\n" + "=" * 60)
-  println("RAG Builder API Example Complete")
-  println("=" * 60)
+  logger.info("=" * 60)
+  logger.info("RAG Builder API Example Complete")
+  logger.info("=" * 60)
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/S3LoaderExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/S3LoaderExample.scala
@@ -4,6 +4,7 @@ import org.llm4s.rag.loader.s3.{ S3DocumentSource, S3Loader }
 import org.llm4s.rag.{ EmbeddingProvider, RAG, RAGSearchResult }
 import org.llm4s.rag.RAG.RAGConfigOps
 import org.slf4j.LoggerFactory
+import scala.util.chaining._
 
 /**
  * Example demonstrating S3 document loading and ingestion.
@@ -27,9 +28,9 @@ object S3LoaderExample extends App {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  println("=" * 60)
-  println("S3 Document Loader Example")
-  println("=" * 60)
+  logger.info("=" * 60)
+  logger.info("S3 Document Loader Example")
+  logger.info("=" * 60)
 
   // Configuration - adjust these for your environment
   val bucket        = sys.env.getOrElse("S3_BUCKET", "my-documents")
@@ -37,11 +38,11 @@ object S3LoaderExample extends App {
   val region        = sys.env.getOrElse("AWS_REGION", "us-east-1")
   val useLocalStack = sys.env.getOrElse("USE_LOCALSTACK", "false").toBoolean
 
-  println(s"\nConfiguration:")
-  println(s"  Bucket: $bucket")
-  println(s"  Prefix: $prefix")
-  println(s"  Region: $region")
-  println(s"  LocalStack: $useLocalStack")
+  logger.info("Configuration:")
+  logger.info("  Bucket: {}", bucket)
+  logger.info("  Prefix: {}", prefix)
+  logger.info("  Region: {}", region)
+  logger.info("  LocalStack: {}", useLocalStack)
 
   // Create RAG pipeline using the builder API
   val ragResult = RAG
@@ -51,10 +52,10 @@ object S3LoaderExample extends App {
 
   ragResult match {
     case Left(err) =>
-      logger.error(s"Failed to create RAG pipeline: ${err.message}")
-      println(s"\nError: ${err.message}")
-      println("\nMake sure you have set:")
-      println("  - OPENAI_API_KEY")
+      logger.error("Failed to create RAG pipeline: {}", err.message)
+      logger.error("Error: {}", err.message)
+      logger.error("Make sure you have set:")
+      logger.error("  - OPENAI_API_KEY")
       sys.exit(1)
 
     case Right(rag) =>
@@ -71,67 +72,65 @@ object S3LoaderExample extends App {
     region: String,
     useLocalStack: Boolean
   ): Unit = {
-    println("\nRAG pipeline created successfully.")
+    logger.info("RAG pipeline created successfully.")
 
     // Create S3 document loader
-    val loader = if (useLocalStack) {
-      println("\nUsing LocalStack for local testing...")
-      println("Make sure LocalStack is running: docker run -d -p 4566:4566 localstack/localstack")
-      S3Loader.forLocalStack(bucket, prefix)
-    } else {
-      S3Loader(
-        bucket = bucket,
-        prefix = prefix,
-        region = region
-      )
-    }
-
-    println(s"\nLoader created: ${loader.description}")
+    val loader = (if (useLocalStack) {
+                    logger.info("Using LocalStack for local testing...")
+                    logger.info("Make sure LocalStack is running: docker run -d -p 4566:4566 localstack/localstack")
+                    S3Loader.forLocalStack(bucket, prefix)
+                  } else {
+                    S3Loader(
+                      bucket = bucket,
+                      prefix = prefix,
+                      region = region
+                    )
+                  })
+    .tap(l => logger.info("Loader created: {}", l.description))
 
     // Sync documents from S3
-    println("\n--- Syncing documents from S3 ---")
+    logger.info("--- Syncing documents from S3 ---")
     rag.sync(loader) match {
       case Right(stats) =>
-        println(s"\nSync completed successfully!")
-        println(s"  Documents added:     ${stats.added}")
-        println(s"  Documents updated:   ${stats.updated}")
-        println(s"  Documents deleted:   ${stats.deleted}")
-        println(s"  Documents unchanged: ${stats.unchanged}")
-        println(s"  Total:               ${stats.total}")
+        logger.info("Sync completed successfully!")
+        logger.info("  Documents added:     {}", stats.added)
+        logger.info("  Documents updated:   {}", stats.updated)
+        logger.info("  Documents deleted:   {}", stats.deleted)
+        logger.info("  Documents unchanged: {}", stats.unchanged)
+        logger.info("  Total:               {}", stats.total)
 
         if (stats.hasChanges) {
-          println("\nDocuments were indexed. You can now query them.")
+          logger.info("Documents were indexed. You can now query them.")
         } else {
-          println("\nNo changes detected since last sync.")
+          logger.info("No changes detected since last sync.")
         }
 
       case Left(err) =>
-        logger.error(s"Sync failed: ${err.message}")
-        println(s"\nSync failed: ${err.message}")
-        println("\nCommon issues:")
-        println("  - Check AWS credentials are configured")
-        println("  - Verify the bucket exists and is accessible")
-        println("  - Check network connectivity to S3")
+        logger.error("Sync failed: {}", err.message)
+        logger.error("Common issues:")
+        logger.error("  - Check AWS credentials are configured")
+        logger.error("  - Verify the bucket exists and is accessible")
+        logger.error("  - Check network connectivity to S3")
     }
 
     // Example query (if RAG has documents)
-    println("\n--- Example Query ---")
+    logger.info("--- Example Query ---")
     rag.query("What topics are covered in the documents?", Some(3)) match {
       case Right(results) if results.nonEmpty =>
-        println(s"Found ${results.size} relevant chunks:")
+        logger.info("Found {} relevant chunks:", results.size)
         results.zipWithIndex.foreach { case (result: RAGSearchResult, idx: Int) =>
-          println(s"\n${idx + 1}. Score: ${result.score}")
-          println(s"   ${result.content.take(200)}...")
+          logger.info("{}. Score: {}", idx + 1, result.score)
+          logger.info("   {}...", result.content.take(200))
         }
       case Right(_) =>
-        println("No results found. The index may be empty.")
+        logger.info("No results found. The index may be empty.")
       case Left(err) =>
-        println(s"Query failed: ${err.message}")
+        logger.error("Query failed: {}", err.message)
     }
 
-    println("\n" + "=" * 60)
-    println("Example complete")
-    println("=" * 60)
+    logger.info("=" * 60)
+    logger.info("Example complete")
+    logger.info("=" * 60)
   }
 }
 
@@ -139,49 +138,49 @@ object S3LoaderExample extends App {
  * Advanced example showing custom S3 configuration.
  */
 object S3LoaderAdvancedExample extends App {
+  private val logger = LoggerFactory.getLogger(getClass)
 
-  println("=" * 60)
-  println("S3 Document Loader - Advanced Configuration")
-  println("=" * 60)
+  logger.info("=" * 60)
+  logger.info("S3 Document Loader - Advanced Configuration")
+  logger.info("=" * 60)
 
   // Example 1: Custom file extensions
-  println("\n--- Example 1: Custom Extensions ---")
+  logger.info("--- Example 1: Custom Extensions ---")
   val pdfOnlyLoader = S3Loader(
     bucket = "my-bucket",
     prefix = "reports/",
     extensions = Set("pdf") // Only PDF files
-  )
-  println(s"PDF-only loader: ${pdfOnlyLoader.description}")
+  ).tap(l => logger.info("PDF-only loader: {}", l.description))
 
   // Example 2: Explicit credentials
-  println("\n--- Example 2: Explicit Credentials ---")
-  val withCredsLoader = S3Loader.withCredentials(
-    bucket = "private-bucket",
-    accessKeyId = sys.env.getOrElse("AWS_ACCESS_KEY_ID", "test"),
-    secretAccessKey = sys.env.getOrElse("AWS_SECRET_ACCESS_KEY", "test"),
-    region = "eu-west-1"
-  )
-  println(s"Credentials loader: ${withCredsLoader.description}")
+  logger.info("--- Example 2: Explicit Credentials ---")
+  val withCredsLoader = S3Loader
+    .withCredentials(
+      bucket = "private-bucket",
+      accessKeyId = sys.env.getOrElse("AWS_ACCESS_KEY_ID", "test"),
+      secretAccessKey = sys.env.getOrElse("AWS_SECRET_ACCESS_KEY", "test"),
+      region = "eu-west-1"
+    )
+    .tap(l => logger.info("Credentials loader: {}", l.description))
 
   // Example 3: Using the source directly for advanced configuration
-  println("\n--- Example 3: Advanced Source Configuration ---")
+  logger.info("--- Example 3: Advanced Source Configuration ---")
   val source = S3DocumentSource(
     bucket = "my-bucket",
     prefix = "docs/",
     extensions = Set("txt", "md", "pdf", "docx"),
     metadata = Map("environment" -> "production")
   ).withEndpoint("http://localhost:4566") // For MinIO or LocalStack
-
-  println(s"Advanced source: ${source.description}")
+    .tap(s => logger.info("Advanced source: {}", s.description))
 
   // Example 4: Combining loaders
-  println("\n--- Example 4: Multi-Source Loading ---")
-  val docsLoader     = S3Loader("company-docs", prefix = "public/")
-  val reportsLoader  = S3Loader("company-docs", prefix = "reports/2024/")
-  val combinedLoader = docsLoader ++ reportsLoader
-  println(s"Combined loader: ${combinedLoader.description}")
+  logger.info("--- Example 4: Multi-Source Loading ---")
+  val docsLoader    = S3Loader("company-docs", prefix = "public/")
+  val reportsLoader = S3Loader("company-docs", prefix = "reports/2024/")
+  val combinedLoader = (docsLoader ++ reportsLoader)
+    .tap(l => logger.info("Combined loader: {}", l.description))
 
-  println("\n" + "=" * 60)
-  println("Advanced examples complete")
-  println("=" * 60)
+  logger.info("=" * 60)
+  logger.info("Advanced examples complete")
+  logger.info("=" * 60)
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/WebCrawlerExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/WebCrawlerExample.scala
@@ -1,6 +1,8 @@
 package org.llm4s.samples.rag
 
 import org.llm4s.rag.loader._
+import org.slf4j.LoggerFactory
+import scala.util.chaining._
 
 /**
  * Example demonstrating the WebCrawlerLoader for crawling web content into RAG.
@@ -20,33 +22,33 @@ import org.llm4s.rag.loader._
  * unless you uncomment the crawling sections.
  */
 object WebCrawlerExample extends App {
+  private val logger = LoggerFactory.getLogger(getClass)
 
-  println("=== Web Crawler Loader Example ===\n")
+  logger.info("=== Web Crawler Loader Example ===")
 
   // ========== 1. Basic WebCrawlerLoader Creation ==========
-  println("1. Creating a basic WebCrawlerLoader...")
+  logger.info("1. Creating a basic WebCrawlerLoader...")
 
   val basicCrawler = WebCrawlerLoader("https://docs.example.com")
-  println(s"   Description: ${basicCrawler.description}")
-  println(s"   Seed URLs: ${basicCrawler.seedUrls}")
-  println(s"   Max depth: ${basicCrawler.config.maxDepth}")
-  println(s"   Max pages: ${basicCrawler.config.maxPages}")
+    .tap(c => logger.info("   Description: {}", c.description))
+    .tap(c => logger.info("   Seed URLs: {}", c.seedUrls))
+    .tap(c => logger.info("   Max depth: {}", c.config.maxDepth))
+    .tap(c => logger.info("   Max pages: {}", c.config.maxPages))
 
   // ========== 2. Configuring Crawl Behavior ==========
-  println("\n2. Configuring crawl behavior...")
+  logger.info("2. Configuring crawl behavior...")
 
   val configuredCrawler = WebCrawlerLoader("https://docs.example.com")
     .withMaxDepth(3)    // Follow links up to 3 levels deep
     .withMaxPages(500)  // Crawl at most 500 pages
     .withDelay(1000)    // Wait 1 second between requests
     .withTimeout(30000) // 30 second timeout per request
-
-  println(s"   Max depth: ${configuredCrawler.config.maxDepth}")
-  println(s"   Max pages: ${configuredCrawler.config.maxPages}")
-  println(s"   Delay: ${configuredCrawler.config.delayMs}ms")
+    .tap(c => logger.info("   Max depth: {}", c.config.maxDepth))
+    .tap(c => logger.info("   Max pages: {}", c.config.maxPages))
+    .tap(c => logger.info("   Delay: {}ms", c.config.delayMs))
 
   // ========== 3. URL Pattern Filtering ==========
-  println("\n3. Using URL patterns to control scope...")
+  logger.info("3. Using URL patterns to control scope...")
 
   val patternCrawler = WebCrawlerLoader("https://docs.example.com")
     .withFollowPatterns(
@@ -57,53 +59,50 @@ object WebCrawlerExample extends App {
       "https://docs.example.com/*/archive/**",  // Skip archive pages
       "https://docs.example.com/*/changelog/**" // Skip changelogs
     )
-
-  println(s"   Follow patterns: ${patternCrawler.config.followPatterns.mkString(", ")}")
-  println(s"   Exclude patterns: ${patternCrawler.config.excludePatterns.mkString(", ")}")
+    .tap(c => logger.info("   Follow patterns: {}", c.config.followPatterns.mkString(", ")))
+    .tap(c => logger.info("   Exclude patterns: {}", c.config.excludePatterns.mkString(", ")))
 
   // ========== 4. Domain Restrictions ==========
-  println("\n4. Domain restrictions...")
+  logger.info("4. Domain restrictions...")
 
   // By default, crawling is restricted to the seed URL domain
   val sameDomainCrawler = WebCrawlerLoader("https://docs.example.com")
-  println(s"   Same domain only: ${sameDomainCrawler.config.sameDomainOnly} (default)")
+    .tap(c => logger.info("   Same domain only: {} (default)", c.config.sameDomainOnly))
 
   // Can disable for cross-domain crawling (use with caution)
   val crossDomainCrawler = WebCrawlerLoader("https://docs.example.com")
     .withSameDomainOnly(false)
-  println(s"   Cross-domain enabled: ${!crossDomainCrawler.config.sameDomainOnly}")
+    .tap(c => logger.info("   Cross-domain enabled: {}", !c.config.sameDomainOnly))
 
   // ========== 5. robots.txt Handling ==========
-  println("\n5. robots.txt respect...")
+  logger.info("5. robots.txt respect...")
 
   val politeBot = WebCrawlerLoader("https://example.com")
     .withRobotsTxt(true) // Default - respects robots.txt
-  println(s"   Respects robots.txt: ${politeBot.config.respectRobotsTxt}")
+    .tap(c => logger.info("   Respects robots.txt: {}", c.config.respectRobotsTxt))
 
   // Can disable for testing (not recommended for production)
   val testBot = WebCrawlerLoader("https://example.com")
     .withRobotsTxt(false)
-  println(s"   Ignores robots.txt: ${!testBot.config.respectRobotsTxt}")
+    .tap(c => logger.info("   Ignores robots.txt: {}", !c.config.respectRobotsTxt))
 
   // ========== 6. Preset Configurations ==========
-  println("\n6. Using preset configurations...")
+  logger.info("6. Using preset configurations...")
 
   // Polite crawler for documentation sites
-  val politeLoader = WebCrawlerLoader.forDocs("https://docs.example.com")
-  println(
-    s"   forDocs: depth=${politeLoader.config.maxDepth}, " +
-      s"pages=${politeLoader.config.maxPages}, delay=${politeLoader.config.delayMs}ms"
-  )
+  val politeLoader = WebCrawlerLoader
+    .forDocs("https://docs.example.com")
+    .tap(l =>
+      logger.info("   forDocs: depth={}, pages={}, delay={}ms", l.config.maxDepth, l.config.maxPages, l.config.delayMs)
+    )
 
   // Single page only (no link following)
-  val singlePageLoader = WebCrawlerLoader.singlePage("https://example.com/specific-page")
-  println(
-    s"   singlePage: depth=${singlePageLoader.config.maxDepth}, " +
-      s"pages=${singlePageLoader.config.maxPages}"
-  )
+  val singlePageLoader = WebCrawlerLoader
+    .singlePage("https://example.com/specific-page")
+    .tap(l => logger.info("   singlePage: depth={}, pages={}", l.config.maxDepth, l.config.maxPages))
 
   // ========== 7. Adding Metadata ==========
-  println("\n7. Adding metadata to crawled documents...")
+  logger.info("7. Adding metadata to crawled documents...")
 
   val metadataCrawler = WebCrawlerLoader("https://docs.example.com")
     .withMetadata(
@@ -113,11 +112,10 @@ object WebCrawlerExample extends App {
         "crawl_date" -> java.time.LocalDate.now.toString
       )
     )
-
-  println(s"   Metadata: ${metadataCrawler.metadata}")
+    .tap(c => logger.info("   Metadata: {}", c.metadata))
 
   // ========== 8. Multiple Seed URLs ==========
-  println("\n8. Crawling from multiple seed URLs...")
+  logger.info("8. Crawling from multiple seed URLs...")
 
   val multiSeedCrawler = WebCrawlerLoader(
     "https://docs.example.com/getting-started",
@@ -125,12 +123,11 @@ object WebCrawlerExample extends App {
     "https://docs.example.com/api"
   )
     .withSeed("https://docs.example.com/faq") // Add another seed
-
-  println(s"   Seed URLs: ${multiSeedCrawler.seedUrls.size}")
-  multiSeedCrawler.seedUrls.foreach(url => println(s"     - $url"))
+    .tap(c => logger.info("   Seed URLs: {}", c.seedUrls.size))
+    .tap(c => c.seedUrls.foreach(url => logger.info("     - {}", url)))
 
   // ========== 9. Combining with Other Loaders ==========
-  println("\n9. Combining with other document loaders...")
+  logger.info("9. Combining with other document loaders...")
 
   val webDocs = WebCrawlerLoader("https://docs.example.com")
     .withMaxPages(100)
@@ -141,58 +138,58 @@ object WebCrawlerExample extends App {
     .add("local-2", "Additional local notes")
     .build()
 
-  val combined = webDocs ++ localDocs
-  println(s"   Combined loader: ${combined.description}")
+  val combined = (webDocs ++ localDocs)
+    .tap(c => logger.info("   Combined loader: {}", c.description))
 
   // ========== 10. Query Parameter Handling ==========
-  println("\n10. Query parameter handling...")
+  logger.info("10. Query parameter handling...")
 
   // By default, query params are stripped (deduplication)
   val defaultParams = WebCrawlerLoader("https://example.com")
-  println(s"   Include query params: ${defaultParams.config.includeQueryParams} (default)")
-  println("   URLs like /page?id=1 and /page?id=2 treated as same page")
+    .tap(c => logger.info("   Include query params: {} (default)", c.config.includeQueryParams))
+  logger.info("   URLs like /page?id=1 and /page?id=2 treated as same page")
 
   // Can include query params for dynamic sites
   val withParams = WebCrawlerLoader("https://example.com")
     .withQueryParams(true)
-  println(s"   Include query params: ${withParams.config.includeQueryParams}")
-  println("   URLs like /page?id=1 and /page?id=2 treated as different pages")
+    .tap(c => logger.info("   Include query params: {}", c.config.includeQueryParams))
+  logger.info("   URLs like /page?id=1 and /page?id=2 treated as different pages")
 
   // ========== 11. Example RAG Integration ==========
-  println("\n11. RAG integration example (code only, not executed)...")
-  println("")
-  println("    // Build-time crawl integration:")
-  println("    val rag = RAG.builder()")
-  println("      .withEmbeddings(EmbeddingProvider.OpenAI)")
-  println("      .withDocuments(WebCrawlerLoader.forDocs(\"https://docs.example.com\"))")
-  println("      .build()")
-  println("      .toOption.get")
-  println("")
-  println("    // Runtime crawl integration:")
-  println("    val stats = rag.ingest(")
-  println("      WebCrawlerLoader(\"https://newdocs.example.com\")")
-  println("        .withMaxPages(200)")
-  println("    )")
-  println("    println(s\"Crawled $${stats.map(_.successful).getOrElse(0)} pages\")")
+  logger.info("11. RAG integration example (code only, not executed)...")
+
+  logger.info("    // Build-time crawl integration:")
+  logger.info("    val rag = RAG.builder()")
+  logger.info("      .withEmbeddings(EmbeddingProvider.OpenAI)")
+  logger.info("      .withDocuments(WebCrawlerLoader.forDocs(\"https://docs.example.com\"))")
+  logger.info("      .build()")
+  logger.info("      .toOption.get")
+  logger.info("")
+  logger.info("    // Runtime crawl integration:")
+  logger.info("    val stats = rag.ingest(")
+  logger.info("      WebCrawlerLoader(\"https://newdocs.example.com\")")
+  logger.info("        .withMaxPages(200)")
+  logger.info("    )")
+  logger.info("    logger.info(\"Crawled {} pages\", stats.map(_.successful).getOrElse(0))")
 
   // ========== 12. Content Types ==========
-  println("\n12. Content type filtering...")
+  logger.info("12. Content type filtering...")
 
   val htmlOnlyCrawler = WebCrawlerLoader("https://example.com")
-  println(s"   Accepted types: ${htmlOnlyCrawler.config.acceptContentTypes.mkString(", ")}")
-  println("   Non-HTML content (PDFs, images, etc.) is automatically skipped")
+    .tap(c => logger.info("   Accepted types: {}", c.config.acceptContentTypes.mkString(", ")))
+  logger.info("   Non-HTML content (PDFs, images, etc.) is automatically skipped")
 
   // ========== 13. Memory Management ==========
-  println("\n13. Memory management...")
+  logger.info("13. Memory management...")
 
   val safeCrawler = WebCrawlerLoader("https://example.com")
     .withMaxQueueSize(10000) // Limit URL queue size
     .withMaxPages(1000)      // Limit total pages
+    .tap(c => logger.info("   Max queue size: {}", c.config.maxQueueSize))
 
-  println(s"   Max queue size: ${safeCrawler.config.maxQueueSize}")
-  println("   Prevents unbounded memory usage during large crawls")
+  logger.info("   Prevents unbounded memory usage during large crawls")
 
-  println("\n=== Example Complete ===")
-  println("\nTo perform actual crawling, configure environment variables and uncomment")
-  println("the RAG integration code above.")
+  logger.info("=== Example Complete ===")
+  logger.info("To perform actual crawling, configure environment variables and uncomment")
+  logger.info("the RAG integration code above.")
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/streaming/EventCollectionExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/streaming/EventCollectionExample.scala
@@ -5,6 +5,7 @@ import org.llm4s.agent.streaming.AgentEvent._
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.toolapi.ToolRegistry
+import org.slf4j.LoggerFactory
 
 /**
  * Example demonstrating how to collect and analyze streaming events.
@@ -19,11 +20,11 @@ import org.llm4s.toolapi.ToolRegistry
  * Note: Requires LLM_MODEL and appropriate API key environment variables.
  */
 object EventCollectionExample extends App {
+  private val logger = LoggerFactory.getLogger(getClass)
 
-  println("=" * 60)
-  println("Event Collection Example")
-  println("=" * 60)
-  println()
+  logger.info("=" * 60)
+  logger.info("Event Collection Example")
+  logger.info("=" * 60)
 
   val result = for {
     providerCfg <- Llm4sConfig.provider()
@@ -41,10 +42,9 @@ object EventCollectionExample extends App {
   result match {
     case Right((state, events)) =>
       // Analyze the collected events
-      println("Collected Events Summary")
-      println("-" * 40)
-      println(s"Total events: ${events.size}")
-      println()
+      logger.info("Collected Events Summary")
+      logger.info("-" * 40)
+      logger.info("Total events: {}", events.size)
 
       // Count by type
       val textDeltas   = events.collect { case e: TextDelta => e }
@@ -53,28 +53,26 @@ object EventCollectionExample extends App {
       val toolCalls    = events.collect { case e: ToolCallStarted => e }
       val completions  = events.collect { case e: AgentCompleted => e }
 
-      println("Event breakdown:")
-      println(s"  - TextDelta events: ${textDeltas.size}")
-      println(s"  - TextComplete events: ${textComplete.size}")
-      println(s"  - StepStarted events: ${steps.size}")
-      println(s"  - ToolCallStarted events: ${toolCalls.size}")
-      println(s"  - AgentCompleted events: ${completions.size}")
-      println()
+      logger.info("Event breakdown:")
+      logger.info("  - TextDelta events: {}", textDeltas.size)
+      logger.info("  - TextComplete events: {}", textComplete.size)
+      logger.info("  - StepStarted events: {}", steps.size)
+      logger.info("  - ToolCallStarted events: {}", toolCalls.size)
+      logger.info("  - AgentCompleted events: {}", completions.size)
 
       // Calculate total streamed characters
       val totalChars = textDeltas.map(_.delta.length).sum
-      println(s"Total characters streamed: $totalChars")
+      logger.info("Total characters streamed: {}", totalChars)
 
       // Show timing if available
       completions.headOption.foreach { completion =>
-        println(s"Total duration: ${completion.durationMs}ms")
-        println(s"Total steps: ${completion.totalSteps}")
+        logger.info("Total duration: {}ms", completion.durationMs)
+        logger.info("Total steps: {}", completion.totalSteps)
       }
-      println()
 
       // Show event timeline
-      println("Event Timeline:")
-      println("-" * 40)
+      logger.info("Event Timeline:")
+      logger.info("-" * 40)
       events.zipWithIndex.foreach { case (event, idx) =>
         val eventType = event.getClass.getSimpleName
         val summary = event match {
@@ -88,17 +86,16 @@ object EventCollectionExample extends App {
           case ToolCallCompleted(_, name, _, _, ms, _) => s"$name completed in ${ms}ms"
           case _                                       => ""
         }
-        println(f"  $idx%3d. $eventType%-25s $summary")
+        logger.info(f"  $idx%3d. $eventType%-25s $summary")
       }
-      println()
 
       // Show final response
-      println("Final Response:")
-      println("-" * 40)
-      state.conversation.messages.lastOption.foreach(msg => println(msg.content))
+      logger.info("Final Response:")
+      logger.info("-" * 40)
+      state.conversation.messages.lastOption.foreach(msg => logger.info("{}", msg.content))
 
     case Left(error) =>
-      println(s"Error: ${error.message}")
+      logger.error("Error: {}", error.message)
       System.exit(1)
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/toolapi/ErrorMessageDemonstration.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/toolapi/ErrorMessageDemonstration.scala
@@ -2,11 +2,13 @@ package org.llm4s.samples.toolapi
 
 import org.llm4s.toolapi._
 import upickle.default._
+import org.slf4j.LoggerFactory
 
 /**
  * Demonstration of improved error messages for tool parameter validation
  */
 object ErrorMessageDemonstration extends App {
+  private val logger = LoggerFactory.getLogger(getClass)
 
   // Define a simple result type
   case class Result(message: String)
@@ -33,22 +35,24 @@ object ErrorMessageDemonstration extends App {
     }.build()
   }
 
-  println("=" * 60)
-  println("Tool Parameter Validation - Error Message Examples")
-  println("=" * 60)
+  logger.info("=" * 60)
+  logger.info("Tool Parameter Validation - Error Message Examples")
+  logger.info("=" * 60)
 
   // Example 1: Null arguments
-  println("\n1. Null arguments:")
+  logger.info("")
+  logger.info("1. Null arguments:")
   val nullResult = inventoryTool.execute(ujson.Null)
   nullResult match {
     case Left(error) =>
-      println(s"   Error: ${error.getMessage}")
+      logger.info("   Error: {}", error.getMessage)
     case Right(_) =>
-      println("   Unexpected success")
+      logger.info("   Unexpected success")
   }
 
   // Example 2: Missing required parameter
-  println("\n2. Missing 'quantity' parameter:")
+  logger.info("")
+  logger.info("2. Missing 'quantity' parameter:")
   val missingParamResult = inventoryTool.execute(
     ujson.Obj(
       "item"     -> "Apple",
@@ -58,13 +62,14 @@ object ErrorMessageDemonstration extends App {
   )
   missingParamResult match {
     case Left(error) =>
-      println(s"   Error: ${error.getMessage}")
+      logger.info("   Error: {}", error.getMessage)
     case Right(_) =>
-      println("   Unexpected success")
+      logger.info("   Unexpected success")
   }
 
   // Example 3: Type mismatch
-  println("\n3. Type mismatch (string instead of number for quantity):")
+  logger.info("")
+  logger.info("3. Type mismatch (string instead of number for quantity):")
   val typeMismatchResult = inventoryTool.execute(
     ujson.Obj(
       "item"     -> "Apple",
@@ -74,13 +79,14 @@ object ErrorMessageDemonstration extends App {
   )
   typeMismatchResult match {
     case Left(error) =>
-      println(s"   Error: ${error.getMessage}")
+      logger.info("   Error: {}", error.getMessage)
     case Right(_) =>
-      println("   Unexpected success")
+      logger.info("   Unexpected success")
   }
 
   // Example 4: Null value for required field
-  println("\n4. Null value for required 'location' field:")
+  logger.info("")
+  logger.info("4. Null value for required 'location' field:")
   val nullFieldResult = inventoryTool.execute(
     ujson.Obj(
       "item"     -> "Apple",
@@ -90,13 +96,14 @@ object ErrorMessageDemonstration extends App {
   )
   nullFieldResult match {
     case Left(error) =>
-      println(s"   Error: ${error.getMessage}")
+      logger.info("   Error: {}", error.getMessage)
     case Right(_) =>
-      println("   Unexpected success")
+      logger.info("   Unexpected success")
   }
 
   // Example 5: Successful execution
-  println("\n5. Successful execution with all parameters:")
+  logger.info("")
+  logger.info("5. Successful execution with all parameters:")
   val successResult = inventoryTool.execute(
     ujson.Obj(
       "item"     -> "Apple",
@@ -106,17 +113,18 @@ object ErrorMessageDemonstration extends App {
   )
   successResult match {
     case Left(error) =>
-      println(s"   Error: ${error.getMessage}")
+      logger.info("   Error: {}", error.getMessage)
     case Right(result) =>
-      println(s"   Success: ${result.render()}")
+      logger.info("   Success: {}", result.render())
   }
 
-  println("\n" + "=" * 60)
-  println("The improved error messages now clearly indicate:")
-  println("- Which tool failed")
-  println("- What parameter is problematic")
-  println("- What the actual issue is (null, missing, wrong type)")
-  println("- What was expected")
-  println("- Available alternatives when applicable")
-  println("=" * 60)
+  logger.info("")
+  logger.info("=" * 60)
+  logger.info("The improved error messages now clearly indicate:")
+  logger.info("- Which tool failed")
+  logger.info("- What parameter is problematic")
+  logger.info("- What the actual issue is (null, missing, wrong type)")
+  logger.info("- What was expected")
+  logger.info("- Available alternatives when applicable")
+  logger.info("=" * 60)
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/toolapi/ImprovedErrorMessageDemo.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/toolapi/ImprovedErrorMessageDemo.scala
@@ -1,52 +1,60 @@
 package org.llm4s.samples.toolapi
 
 import org.llm4s.toolapi._
+import org.slf4j.LoggerFactory
 
 /**
  * Demonstration of the improved error messages with consistent formatting
  */
 object ImprovedErrorMessageDemo extends App {
+  private val logger = LoggerFactory.getLogger(getClass)
 
-  println("=" * 70)
-  println("IMPROVED ERROR MESSAGE DEMONSTRATION")
-  println("=" * 70)
+  logger.info("=" * 70)
+  logger.info("IMPROVED ERROR MESSAGE DEMONSTRATION")
+  logger.info("=" * 70)
 
   // Example 1: Unknown tool
-  println("\n1. Unknown tool:")
+  logger.info("")
+  logger.info("1. Unknown tool:")
   val unknownTool = ToolCallError.UnknownFunction("calculate_tax")
-  println(s"   ${unknownTool.getFormattedMessage}")
+  logger.info("   {}", unknownTool.getFormattedMessage)
 
   // Example 2: Null arguments
-  println("\n2. Null arguments:")
+  logger.info("")
+  logger.info("2. Null arguments:")
   val nullArgs = ToolCallError.NullArguments("add_inventory_item")
-  println(s"   ${nullArgs.getFormattedMessage}")
+  logger.info("   {}", nullArgs.getFormattedMessage)
 
   // Example 3: Missing required parameter
-  println("\n3. Missing required parameter:")
+  logger.info("")
+  logger.info("3. Missing required parameter:")
   val missingParam = ToolCallError.InvalidArguments(
     "add_inventory_item",
     List(ToolParameterError.MissingParameter("quantity", "number", List("item", "location")))
   )
-  println(s"   ${missingParam.getFormattedMessage}")
+  logger.info("   {}", missingParam.getFormattedMessage)
 
   // Example 4: Null value for required parameter
-  println("\n4. Parameter is null:")
+  logger.info("")
+  logger.info("4. Parameter is null:")
   val nullParam = ToolCallError.InvalidArguments(
     "add_inventory_item",
     List(ToolParameterError.NullParameter("quantity", "number"))
   )
-  println(s"   ${nullParam.getFormattedMessage}")
+  logger.info("   {}", nullParam.getFormattedMessage)
 
   // Example 5: Type mismatch
-  println("\n5. Type mismatch:")
+  logger.info("")
+  logger.info("5. Type mismatch:")
   val typeMismatch = ToolCallError.InvalidArguments(
     "add_inventory_item",
     List(ToolParameterError.TypeMismatch("quantity", "number", "string"))
   )
-  println(s"   ${typeMismatch.getFormattedMessage}")
+  logger.info("   {}", typeMismatch.getFormattedMessage)
 
   // Example 6: Multiple parameter errors
-  println("\n6. Multiple parameter errors:")
+  logger.info("")
+  logger.info("6. Multiple parameter errors:")
   val multipleErrors = ToolCallError.InvalidArguments(
     "submit_order",
     List(
@@ -55,47 +63,52 @@ object ImprovedErrorMessageDemo extends App {
       ToolParameterError.NullParameter("product_id", "string")
     )
   )
-  println(s"   ${multipleErrors.getFormattedMessage}")
+  logger.info("   {}", multipleErrors.getFormattedMessage)
 
   // Example 7: Nested parameter error
-  println("\n7. Nested parameter error:")
+  logger.info("")
+  logger.info("7. Nested parameter error:")
   val nestedError = ToolCallError.InvalidArguments(
     "update_profile",
     List(ToolParameterError.InvalidNesting("email", "user", "string"))
   )
-  println(s"   ${nestedError.getFormattedMessage}")
+  logger.info("   {}", nestedError.getFormattedMessage)
 
   // Example 8: Execution error
-  println("\n8. Execution error (after validation):")
+  logger.info("")
+  logger.info("8. Execution error (after validation):")
   val execError = ToolCallError.ExecutionError(
     "process_payment",
     new RuntimeException("Network timeout while contacting payment gateway")
   )
-  println(s"   ${execError.getFormattedMessage}")
+  logger.info("   {}", execError.getFormattedMessage)
 
   // Example 9: Handler error (business logic failure)
-  println("\n9. Handler error (business logic):")
+  logger.info("")
+  logger.info("9. Handler error (business logic):")
   val handlerError = ToolCallError.HandlerError(
     "divide_numbers",
     "cannot divide by zero"
   )
-  println(s"   ${handlerError.getFormattedMessage}")
+  logger.info("   {}", handlerError.getFormattedMessage)
 
-  println("\n" + "=" * 70)
-  println("KEY IMPROVEMENTS:")
-  println("=" * 70)
-  println("✓ Consistent 'Tool call <name>' prefix for all errors")
-  println("✓ Clear distinction between missing, null, and wrong type")
-  println("✓ Parameter types included in error messages")
-  println("✓ Available parameters shown when one is missing")
-  println("✓ Execution vs validation errors clearly separated")
-  println("✓ Multi-line formatting for multiple errors")
-  println("=" * 70)
+  logger.info("")
+  logger.info("=" * 70)
+  logger.info("KEY IMPROVEMENTS:")
+  logger.info("=" * 70)
+  logger.info("- Consistent 'Tool call <name>' prefix for all errors")
+  logger.info("- Clear distinction between missing, null, and wrong type")
+  logger.info("- Parameter types included in error messages")
+  logger.info("- Available parameters shown when one is missing")
+  logger.info("- Execution vs validation errors clearly separated")
+  logger.info("- Multi-line formatting for multiple errors")
+  logger.info("=" * 70)
 
   // Show JSON format as it would appear in Agent responses
-  println("\n" + "=" * 70)
-  println("JSON FORMAT (as returned to LLM):")
-  println("=" * 70)
+  logger.info("")
+  logger.info("=" * 70)
+  logger.info("JSON FORMAT (as returned to LLM):")
+  logger.info("=" * 70)
 
   def toJsonError(error: ToolCallError): String = {
     val message = error.getFormattedMessage
@@ -105,15 +118,20 @@ object ImprovedErrorMessageDemo extends App {
     s"""{ "isError": true, "error": "$message" }"""
   }
 
-  println("\nExample JSON responses:")
-  println("\n1. Missing parameter:")
-  println(toJsonError(missingParam))
+  logger.info("")
+  logger.info("Example JSON responses:")
+  logger.info("")
+  logger.info("1. Missing parameter:")
+  logger.info("{}", toJsonError(missingParam))
 
-  println("\n2. Multiple errors:")
-  println(toJsonError(multipleErrors))
+  logger.info("")
+  logger.info("2. Multiple errors:")
+  logger.info("{}", toJsonError(multipleErrors))
 
-  println("\n3. Execution error:")
-  println(toJsonError(execError))
+  logger.info("")
+  logger.info("3. Execution error:")
+  logger.info("{}", toJsonError(execError))
 
-  println("\n" + "=" * 70)
+  logger.info("")
+  logger.info("=" * 70)
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/toolapi/WeatherToolExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/toolapi/WeatherToolExample.scala
@@ -2,11 +2,14 @@ package org.llm4s.samples.toolapi
 
 import org.llm4s.toolapi._
 import org.llm4s.toolapi.tools.WeatherTool
+import org.slf4j.LoggerFactory
 
 /**
  * Example demonstrating how to use the weather tool
  */
 object WeatherToolExample {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   def main(args: Array[String]): Unit = {
     // Create a tool registry with the weather tool
     val toolRegistry = new ToolRegistry(Seq(WeatherTool.tool))
@@ -20,16 +23,16 @@ object WeatherToolExample {
     // Execute the tool call
     val result = toolRegistry.execute(weatherRequest)
 
-    println("Tool execution result:")
+    logger.info("Tool execution result:")
     result match {
-      case Right(json) => println(json.render(indent = 2))
-      case Left(error) => println(s"Error: $error")
+      case Right(json) => logger.info("{}", json.render(indent = 2))
+      case Left(error) => logger.error("Error: {}", error)
     }
 
     // Generate tool definitions for OpenAI
     val openaiTools = toolRegistry.getToolDefinitions("openai")
 
-    println("\nOpenAI tool definition:")
-    println(openaiTools.render(indent = 2))
+    logger.info("OpenAI tool definition:")
+    logger.info("{}", openaiTools.render(indent = 2))
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/types/TypeUsage.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/types/TypeUsage.scala
@@ -2,6 +2,7 @@ package org.llm4s.samples.types
 
 import org.llm4s.AsyncResult
 import org.llm4s.types._
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 
@@ -14,14 +15,16 @@ import scala.concurrent.Future
 
 object TypeUsage {
 
+  private val logger = LoggerFactory.getLogger(getClass)
+
   // Example: Using type-safe IDs
   def exampleTypeSafeIds(): Unit = {
     val modelName = ModelName.GPT_4
     val provider  = ProviderName.OPENAI
     val apiKey    = ApiKey("sk-test123").getOrElse(throw new RuntimeException("Invalid API key"))
 
-    println(s"Using model $modelName from provider $provider")
-    println(s"API key: $apiKey") // Safely prints masked version
+    logger.info("Using model {} from provider {}", modelName, provider)
+    logger.info("API key: {}", apiKey) // Safely prints masked version
   }
 
   // Example: Using Result types
@@ -48,7 +51,7 @@ object TypeUsage {
     val agentId     = AgentId("agent-123")
     val workflowId  = WorkflowId("workflow-456")
 
-    println(s"Future features: image generation with prompt '$imagePrompt'")
-    println(s"Agent system with agent $agentId in workflow $workflowId")
+    logger.info("Future features: image generation with prompt '{}'", imagePrompt)
+    logger.info("Agent system with agent {} in workflow {}", agentId, workflowId)
   }
 }


### PR DESCRIPTION
This PR continues the work started in my previous PR, where I migrated the `samples/memory` examples to structured logging.

Based on that change, I’ve now extended the same approach consistently across the rest of the `samples` module.

### Changes that I made
- Replaced `println` usage with `slf4j` logging across sample files
- Used `scala.util.chaining.tap` for side effect logging in for comprehensions
- Preserved `print` / `println` only where required for streaming UX

This PR aims to:
- Make all samples feel consistent 
- Avoid Scala 3 warnings in example code
- Keep samples aligned with the logging style used in the core library

### Testing

- `sbt test`

All tests pass locally.
