### PR TITLE
fix(test): Increase timeout for flaky PoliciesSpec test

### DIFF
--- a/modules/core/src/test/scala/org/llm4s/agent/orchestration/PoliciesSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/orchestration/PoliciesSpec.scala
@@ -193,7 +193,7 @@ class PoliciesSpec extends AnyFlatSpec with Matchers with ScalaFutures {
       fallback = Some(fallbackAgent)
     )
 
-    whenReady(enhancedAgent.execute("test")) { result =>
+    whenReady(enhancedAgent.execute("test"), timeout(500.millis)) { result =>
       // Should timeout on each retry attempt, then use fallback
       result shouldBe Right("fallback: test")
     }


### PR DESCRIPTION
Found when working on #407 
The 'Policy composition' test was timing out at 150ms (default whenReady timeout) because the test involves:
- 200ms slow operation
- 50ms timeout per attempt
- 2 retry attempts
- 10ms delays between retries
- Fallback execution

Total time can exceed 150ms, causing intermittent failures.

Changed to explicit 500ms timeout to ensure test stability. Fixes #412 