### PR TITLE
ci: make test report artifacts easier to identify on CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,8 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports-${{ matrix.os }}-scala-${{ matrix.scala }}
+          # Include job name to make CI failures easier to diagnose
+          name: test-reports-${{ github.job }}-${{ matrix.os }}-scala-${{ matrix.scala }}
           path: |
             **/target/test-reports/
             **/target/scala-${{ matrix.scala }}/test-reports/


### PR DESCRIPTION
This PR improves CI failure diagnostics by making uploaded test report artifacts more descriptive.

By including the GitHub job name in the artifact name, it becomes easier to quickly identify which job, OS, and Scala version produced a failing report when reviewing CI artifacts.

This change does not modify test execution or CI behavior and is intended purely to improve debuggability and maintainability of the CI workflow.

No functional changes; artifact naming only.