### PR TITLE
fix: prevent resource leak in OllamaClient streaming

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OllamaClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OllamaClient.scala
@@ -72,41 +72,43 @@ class OllamaClient(config: OllamaConfig) extends LLMClient {
     val accumulator = StreamingAccumulator.create()
     val reader      = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
     val processEither = Try {
-      var line: String = null
-      while ({ line = reader.readLine(); line != null }) {
-        val trimmed = line.trim
-        if (trimmed.nonEmpty) {
-          val json = ujson.read(trimmed)
-          // Ollama streams incremental content in json lines
-          val done = json.obj.get("done").exists(_.bool)
-          val contentOpt = json.obj
-            .get("message")
-            .flatMap(_.obj.get("content"))
-            .flatMap(_.strOpt)
-            .filter(_.nonEmpty)
+      try {
+        var line: String = null
+        while ({ line = reader.readLine(); line != null }) {
+          val trimmed = line.trim
+          if (trimmed.nonEmpty) {
+            val json = ujson.read(trimmed)
+            // Ollama streams incremental content in json lines
+            val done = json.obj.get("done").exists(_.bool)
+            val contentOpt = json.obj
+              .get("message")
+              .flatMap(_.obj.get("content"))
+              .flatMap(_.strOpt)
+              .filter(_.nonEmpty)
 
-          val chunk = StreamedChunk(
-            id = json.obj.get("id").flatMap(_.strOpt).getOrElse(""),
-            content = contentOpt,
-            toolCall = None,
-            finishReason = if (done) Some("stop") else None
-          )
+            val chunk = StreamedChunk(
+              id = json.obj.get("id").flatMap(_.strOpt).getOrElse(""),
+              content = contentOpt,
+              toolCall = None,
+              finishReason = if (done) Some("stop") else None
+            )
 
-          accumulator.addChunk(chunk)
-          onChunk(chunk)
+            accumulator.addChunk(chunk)
+            onChunk(chunk)
 
-          // token counts (if present) only appear at the end
-          if (done) {
-            val prompt = json.obj.get("prompt_eval_count").flatMap(_.numOpt).map(_.toInt).getOrElse(0)
-            val comp   = json.obj.get("eval_count").flatMap(_.numOpt).map(_.toInt).getOrElse(0)
-            if (prompt > 0 || comp > 0) accumulator.updateTokens(prompt, comp)
+            // token counts (if present) only appear at the end
+            if (done) {
+              val prompt = json.obj.get("prompt_eval_count").flatMap(_.numOpt).map(_.toInt).getOrElse(0)
+              val comp   = json.obj.get("eval_count").flatMap(_.numOpt).map(_.toInt).getOrElse(0)
+              if (prompt > 0 || comp > 0) accumulator.updateTokens(prompt, comp)
+            }
           }
         }
+      } finally {
+        Try(reader.close())
+        Try(response.body().close())
       }
     }.toEither
-    // close resources regardless
-    Try(reader.close())
-    Try(response.body().close())
     processEither.left.foreach(_ => ())
 
     accumulator.toCompletion


### PR DESCRIPTION
Found a resource leak issue in OllamaClient.streamComplete() where the BufferedReader and response body weren't being closed properly in all error scenarios.

The current code closes resources after the Try block completes, which works fine for normal exceptions. However, in edge cases like OutOfMemoryError or ThreadDeath (fatal exceptions that aren't caught by Try), the cleanup code gets skipped and resources leak.

The fix wraps the stream processing in a proper try-finally block to guarantee cleanup happens regardless of what exception occurs. This matches the pattern already used in ZaiClient.streamComplete(), making the codebase more consistent.

The actual functional change is just wrapping the existing code with proper resource cleanup.

All tests passed

Pls review @rorygraves @vim89 