### PR TITLE
docs: align test coverage documentation with build config

### DIFF
--- a/docs/reference/test-coverage.md
+++ b/docs/reference/test-coverage.md
@@ -2,7 +2,7 @@ Test Coverage (scoverage)
 
 Overview
 - Uses `sbt-scoverage` to measure line and branch coverage for Scala 2.13 and Scala 3 builds.
-- CI enforces a minimum coverage threshold (currently 54%); builds fail if coverage drops below this.
+- CI enforces a minimum coverage threshold (currently 50%); builds fail if coverage drops below this.
 - Production target is 80% coverage for core library code.
 
 How To Run Locally
@@ -24,7 +24,7 @@ CI Usage
 
 Configuration
 - Defined in `build.sbt`:
-  - `coverageMinimumStmtTotal := 54` — current minimum statement coverage (will be raised incrementally toward 80%).
+  - `coverageMinimumStmtTotal := 50` — current minimum statement coverage (will be raised incrementally toward 80%).
   - `coverageFailOnMinimum := true` — CI fails if coverage drops below the minimum.
   - `coverageHighlighting := true` — better highlighting for coverage in reports.
   - `coverageExcludedPackages` — excludes runner and samples packages by default.
@@ -34,7 +34,7 @@ On‑the‑fly Overrides
 - To disable fail on minimum for local runs: `sbt "set coverageFailOnMinimum := false" coverage test`
 
 Expectations
-- Current coverage is approximately 60%, with a CI-enforced minimum of 54%.
+- Current coverage is approximately 60%, with a CI-enforced minimum of 50%.
 - Production target is 80% coverage for core library code; the threshold will be raised incrementally as coverage improves.
 - Generated/entrypoint code (e.g., runner, samples) is excluded to keep focus on library logic.
 


### PR DESCRIPTION
Aligns test coverage documentation with the actual configuration
enforced in build.sbt and CI.

fixes : https://github.com/llm4s/llm4s/issues/404 part-1