### PR TITLE
added multi-provider fallback example for basic usage 

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -224,9 +224,10 @@ sbt "samples/runMain org.llm4s.samples.basic.AgentLLMCallingExample"
 - Agent state tracking
 
 ---
- ### ProviderFallBackExample
+### ProviderFallbackExample
 
 **File:** [`ProviderFallbackExample.scala`](https://github.com/llm4s/llm4s/blob/main/modules/samples/src/main/scala/org/llm4s/samples/basic/ProviderFallbackExample.scala)
+
 LLM calls with automatic provider fallback for reliability.
 
 ```bash

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/ProviderFallbackExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/ProviderFallbackExample.scala
@@ -4,6 +4,7 @@ import org.llm4s.llmconnect._
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.config._
 import org.slf4j.LoggerFactory
+
 /**
  * Provider fallback example demonstrating multi-provider support in LLM4S.
  *
@@ -12,13 +13,13 @@ import org.slf4j.LoggerFactory
  * - Attempting a request across providers using fallback logic
  * - Running the same prompt across providers without changing application code
  * - Using the first provider that successfully generates a response
- * 
+ *
  * == Quick Start ==
  *
  * 1. This example demonstrates provider fallback using providers
  *    configured directly in `providerConfigs`. Providers are tried
  *    in the order listed there (not via `LLM_MODEL`).
- 
+ *
  * 2. (Optional) Set API keys for cloud providers:
  *    {{{
  *    export OPENAI_API_KEY=sk-...
@@ -44,7 +45,6 @@ import org.slf4j.LoggerFactory
  * - '''Anthropic''': `LLM_MODEL=anthropic/<model>`, requires `ANTHROPIC_API_KEY`
  * - '''Ollama''': `LLM_MODEL=ollama/<model>`, no API key required (local)
  */
-
 
 object ProviderFallbackExample extends App {
 
@@ -81,7 +81,7 @@ object ProviderFallbackExample extends App {
         reserveCompletion = 4096
       )
     )
-)
+  )
   val providers: Seq[(String, LLMClient)] =
     providerConfigs.flatMap { case (name, config) =>
       LLMConnect.getClient(config) match {
@@ -96,7 +96,7 @@ object ProviderFallbackExample extends App {
     }
   def completeWithFallback(prompt: String): Either[String, String] = {
     val conversation = Conversation(Seq(UserMessage(prompt)))
-    val options = CompletionOptions()
+    val options      = CompletionOptions()
     providers.foldLeft[Either[String, String]](Left("All providers failed")) {
       case (success @ Right(_), _) =>
         success


### PR DESCRIPTION
Issue #394 
### Description
Add a new sample demonstrating multi-provider LLM calls with automatic fallback for reliability. 
Also added this example in docs/examples/index.md

### What included
- Automatic fallback across multiple LLM providers
- Priority-based provider selection (OpenAI → Anthropic → Ollama)
- Clear runtime logging for fallback and success states
- Works with cloud and local (Ollama) setups

### Testing
- Shows [FALLBACK] for each failed provider(OpenAi and Anthropic), then [SUCCESS] from Ollama
- Full test suite executed successfully (2754 tests run, 0 failures)

