### PR TITLE
add PostgresMemoryStore reference documentation

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -18,6 +18,7 @@ Technical reference materials for LLM4S development and maintenance.
 - **[Code Review Guidelines](review-guidelines)** - Best practices from PR feedback
 - **[Release Process](release)** - How releases are created
 - **[Configuration Boundary](configuration-boundary)** - How configuration is isolated from core code
+- **[Postgres Memory Store](postgres-memory-store)** - PostgreSQL-backed agent memory persistence
 
 ## Roadmap & Planning
 

--- a/docs/reference/postgres-memory-store.md
+++ b/docs/reference/postgres-memory-store.md
@@ -1,3 +1,10 @@
+---
+layout: page
+title: Postgres Memory Store
+nav_order: 10
+parent: Reference
+---
+
 # Postgres Memory Store
 
 `PostgresMemoryStore` is a PostgreSQL backed implementation of the `MemoryStore` abstraction used by LLM4S agents. It provides durable persistence for agent memories, including metadata and optional vector embeddings.


### PR DESCRIPTION
This PR adds reference documentation for the `PostgresMemoryStore`. It explains how the current Postgres-backed memory store works .
This is meant to make the existing implementation easier to understand for new contributors .

This is the first PR in reference to the isse  #429

#### What’s included
- Configuration details and validation rules
- Database schema and indexes
- How `MemoryFilter` maps to SQL
- Error handling philosophy
- Clear documentation of current limitations (semantic search, compound filters)

#### Scope of the PR 
- Documentation only
- No code or behavior changes
