### PR TITLE
feat(samples): add UniversalExtractor sample runner for visual inspec…

### DIFF
--- a/modules/samples/src/main/scala/org/llm4s/samples/extractors/PdfExtractionDemo.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/extractors/PdfExtractionDemo.scala
@@ -1,0 +1,68 @@
+package org.llm4s.samples.extractors
+
+import org.llm4s.llmconnect.extractors.UniversalExtractor
+import java.io.File
+
+/**
+ * Demo utility to manually test UniversalExtractor.
+ *
+ * HOW TO USE:
+ * 1. Place a text-based PDF at: modules/samples/docs/sample.pdf
+ *    (Scanned PDFs are NOT supported – OCR is not implemented.)
+ *
+ * 2. Run from project root:
+ *    sbt "samples/runMain org.llm4s.samples.extractors.PdfExtractionDemo"
+ *
+ * 3. To test another file, pass the path as an argument:
+ *    sbt "samples/runMain org.llm4s.samples.extractors.PdfExtractionDemo docs/another.pdf"
+ *
+ * NOTE:
+ * - The extractor returns the FULL text.
+ * - Only the console preview is limited for readability.
+ */
+object PdfExtractionDemo {
+
+  def main(args: Array[String]): Unit = {
+
+    // Default file path used when no argument is provided
+    val defaultRelativePath = "docs/sample.pdf"
+
+    // Read optional CLI argument (file path)
+    val rawPath = Option(args).flatMap(_.headOption).getOrElse(defaultRelativePath)
+
+    // Resolve relative paths against current working directory
+    val file = new File(rawPath)
+    val path =
+      if (file.isAbsolute) file.getPath
+      else new File(System.getProperty("user.dir"), rawPath).getPath
+
+    // Run UniversalExtractor on the given file
+    UniversalExtractor.extract(path) match {
+
+      case Left(err) =>
+        // Extraction failed (file not found, unsupported type, etc.)
+        println(
+          s"Extraction failed: type=${err.`type`}, message=${err.message}, path=${err.path.getOrElse(path)}"
+        )
+
+      case Right(text) =>
+        // Preview limit is ONLY for console output
+        val previewChars = 4000
+        val preview      = text.take(previewChars)
+
+        println(s"Input file       : $path")
+        println(s"Extracted chars  : ${text.length}")
+        println(s"Extracted lines  : ${text.linesIterator.length}")
+        println("=" * 80)
+
+        // Print first N characters for visual inspection
+        println(preview)
+
+        // Indicate that output is truncated only for display
+        if (text.length > previewChars) {
+          println("=" * 80)
+          println(s"[Preview truncated: showing first $previewChars characters only]")
+        }
+    }
+  }
+}


### PR DESCRIPTION
### ✨ Add sample demo to visually inspect UniversalExtractor output

This PR adds a small demo runner under the `samples` module to help developers and contributors **visually inspect document extraction results** produced by `UniversalExtractor`.

While working on tests for `UniversalExtractor`, it became clear that although extraction works correctly, there was no simple way to manually evaluate **extraction quality** (e.g., text structure, line breaks, readability) without digging into tests or logs.

---

### 🧩 What’s included

- A demo class (`PdfExtractionDemo`) under the `samples` module
- Allows passing a file path (PDF / DOCX / text) via command-line argument
- Uses `UniversalExtractor` internally
- Prints:
  - extracted character count
  - extracted line count
  - a limited preview of extracted text for console readability
- Inline comments explaining:
  - where to place sample documents
  - how to run the demo
  - that preview truncation is only for display (not extraction)

---

### ✅ Why this change is useful

- Enables **manual / visual inspection** of extraction quality
- Complements existing automated tests
- Improves contributor onboarding and developer experience (DX)
- Keeps core extraction logic unchanged and clean

---

### 📦 Scope & Safety

- Demo-only change (no modifications to `UniversalExtractor`)
- No new dependencies introduced
- No impact on production or runtime behavior

---

### 🔗 Related Issue

Closes #478

