### PR TITLE
Add cross-version tests for OllamaConfig parsing

### DIFF
--- a/modules/crossTest/scala2/src/test/scala/org/llm4s/sc2/OllamaConfigCrossTest.scala
+++ b/modules/crossTest/scala2/src/test/scala/org/llm4s/sc2/OllamaConfigCrossTest.scala
@@ -1,0 +1,34 @@
+package org.llm4s.sc2
+
+import org.llm4s.llmconnect.config.OllamaConfig
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Cross-version test for OllamaConfig parsing.
+ * Verifies that provider config built from values behaves identically in Scala 2.13 and 3.x.
+ * No network, no env, no config files — deterministic fromValues only.
+ */
+class OllamaConfigCrossTest extends AnyFlatSpec with Matchers {
+
+  "OllamaConfig.fromValues" should "build config with expected model and baseUrl" in {
+    val config = OllamaConfig.fromValues("llama2", "http://localhost:11434")
+    config.model shouldBe "llama2"
+    config.baseUrl shouldBe "http://localhost:11434"
+  }
+
+  it should "set contextWindow and reserveCompletion from model fallback" in {
+    val config = OllamaConfig.fromValues("llama2", "http://localhost:11434")
+    config.contextWindow shouldBe 4096
+    config.reserveCompletion shouldBe 4096
+  }
+
+  it should "use default context window for unknown model name" in {
+    val config = OllamaConfig.fromValues("custom-model", "http://127.0.0.1:11434")
+    config.model shouldBe "custom-model"
+    config.baseUrl shouldBe "http://127.0.0.1:11434"
+    config.contextWindow shouldBe 8192
+    config.reserveCompletion shouldBe 4096
+  }
+}
+

--- a/modules/crossTest/scala3/src/test/scala/org/llm4s/sc3/OllamaConfigCrossTest.scala
+++ b/modules/crossTest/scala3/src/test/scala/org/llm4s/sc3/OllamaConfigCrossTest.scala
@@ -1,0 +1,34 @@
+package org.llm4s.sc3
+
+import org.llm4s.llmconnect.config.OllamaConfig
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Cross-version test for OllamaConfig parsing.
+ * Verifies that provider config built from values behaves identically in Scala 2.13 and 3.x.
+ * No network, no env, no config files — deterministic fromValues only.
+ */
+class OllamaConfigCrossTest extends AnyFlatSpec with Matchers {
+
+  "OllamaConfig.fromValues" should "build config with expected model and baseUrl" in {
+    val config = OllamaConfig.fromValues("llama2", "http://localhost:11434")
+    config.model shouldBe "llama2"
+    config.baseUrl shouldBe "http://localhost:11434"
+  }
+
+  it should "set contextWindow and reserveCompletion from model fallback" in {
+    val config = OllamaConfig.fromValues("llama2", "http://localhost:11434")
+    config.contextWindow shouldBe 4096
+    config.reserveCompletion shouldBe 4096
+  }
+
+  it should "use default context window for unknown model name" in {
+    val config = OllamaConfig.fromValues("custom-model", "http://127.0.0.1:11434")
+    config.model shouldBe "custom-model"
+    config.baseUrl shouldBe "http://127.0.0.1:11434"
+    config.contextWindow shouldBe 8192
+    config.reserveCompletion shouldBe 4096
+  }
+}
+


### PR DESCRIPTION
This PR implements Phase 1 of issue https://github.com/llm4s/llm4s/issues/482 :

It adds a cross-version test for `OllamaConfig.fromValues` to ensure provider
config parsing behaves consistently across Scala 2.13 and Scala 3.x.

The test is deterministic and offline (no env vars, config files, or network).

If this approach looks good, I can continue with the next phases:
- extend provider config crossTests to other providers,
- add cross-version tests for `BuiltinTools` / `ToolRegistry`,
- add cross-version tests for tool schema (de)serialization.
