### PR TITLE
Update GSoC 2026 stepwise instructions and add calendar links

### DIFF
--- a/Google Summer of Code/Project Ideas/2026.md
+++ b/Google Summer of Code/Project Ideas/2026.md
@@ -29,27 +29,28 @@ However, here are some rules that we'd like to emphasize since they are not visi
 ## Stepwise Instructions to prepare for GSoC 2026 with LLM4S
 
 1. [Join our Discord community.](https://discord.gg/YXSmPjDp)
-2. Introduce Yourself first in `#introduce-yourself` discord channel
-3. [Add your details to the GSoC 2026 Aspirants spreadsheet.] That every mentor will know you well..(https://docs.google.com/spreadsheets/d/1GzQDQaFCp4iJz8WIMwiooVDk0JWPh6hvODWRzEZRHxY/edit?gid=0#gid=0)
+2. Introduce yourself in the `#introduce-yourself` Discord channel.
+3. [Add your details to the GSoC 2026 Aspirants spreadsheet](https://docs.google.com/spreadsheets/d/1GzQDQaFCp4iJz8WIMwiooVDk0JWPh6hvODWRzEZRHxY/edit?gid=0#gid=0) so that every mentor knows you.
 4. Attend LLM4S Dev Hour:
-    - We meet every Sunday 9am London time! (Weekly changing link for [LLM4S Dev Hours](https://luma.com/calendar/cal-Zd9BLb5jbZewxLA) )
+    - We meet every Sunday 9am London time! (Weekly changing link for [LLM4S Dev Hours](https://luma.com/calendar/cal-Zd9BLb5jbZewxLA))
     - [Subscribe to add all 2026 Dev Hour events to your Google Calendar.](https://api2.luma.com/ics/get?entity=calendar&id=cal-Zd9BLb5jbZewxLA)
-    - Show up regularly. Speak. Ask crisp questions.Clear your doubts.Discuss your ideas.
+    - Show up regularly. Speak. Ask crisp questions. Clear your doubts. Discuss your ideas.
 5. Work in a pair-programming setup to enhance learning and productivity.
-    - Find a pair within the community if you don't already have one, and actively collaborate, ask doubts in discords regarding your problems or findouts...
+    - Find a pair within the community if you don't already have one, and actively collaborate. Ask questions on Discord about any problems or findings.
 6. Update your LinkedIn experience. Ensure your Discord profile contains both GitHub and LinkedIn links, and use a professional photo.
-    - Post your project contributions on LinkedIn and tag `@LLM4S Foundation`
-7. Those who take initiative and help other aspirants in the community are given significant advantage for selection in excited internships...
-8. Read the resources and understand LLM4S more properly via this site: https://llm4s.org/
-9. Do not wait for permissions to create issues or raising PR's. Take inspiration from the production roadmap to create issues proactively.Also review the codebase, even if you find some small bug make sure to create issue & raise PR for it.
-10. After Raising PR, make sure to ping maintainers in discord `#pr-review` channel
-11. After Raising issues, make sure to ping maintainers in discord `#creating-github-issues` channel & if the issue is much more major fix ups or enhancements, also discuss in `#design-discussions` channel.
+    - Post your project contributions on LinkedIn and tag `@LLM4S Foundation`.
+7. Those who take initiative and help other aspirants in the community are given significant advantage for selection.
+8. Read the resources and understand LLM4S via this site: https://llm4s.org/
+9. Do not wait for permissions to create issues or raise PRs. Take inspiration from the production roadmap to create issues proactively. Also review the codebase — even if you find a small bug, create an issue and raise a PR for it.
+10. After raising a PR, make sure to ping maintainers in the Discord `#pr-review` channel.
+11. After raising issues, make sure to ping maintainers in the Discord `#creating-github-issues` channel. If the issue involves major fixes or enhancements, also discuss in `#design-discussions`.
+12. For the Production Roadmap, check out:
+    - [docs/reference/roadmap.md](../../docs/reference/roadmap.md)
+    - [docs/roadmap/llm4s-hardware-design-roadmap.md](../../docs/roadmap/llm4s-hardware-design-roadmap.md)
+13. For more discussions and GSoC-related questions, ask in the `#gsoc-2026-aspirants` Discord channel.
 
-12. For Production Roadmap, checkout this:
-    - See [docs/reference/roadmap.md](../../docs/reference/roadmap.md)
-    - See [docs/roadmap/llm4s-hardware-design-roadmap.md](../../docs/roadmap/llm4s-hardware-design-roadmap.md)
-13. For more discussions & GSoC related doubts, ask at `#gsoc-2026-aspirants` discord channel
-14. Looking forward to your contribution in LLM4S 
+Looking forward to your contributions to LLM4S!
+
 ---
 
 ## Project Ideas


### PR DESCRIPTION
This PR updates the “Stepwise Instructions for GSoC 2026 Preparation with LLM4S” section.

Changes include:
- Added collaboration + LinkedIn guidelines
- added relevant links of llm4s calendar and the link for adding it to google calendar
- Added aspirant details spreadsheet link
- Added production roadmap references

@Sukuna0007Abhi please apply any necessary updates if required.  
@kannupriyakalra requesting your review on this PR.

Fixes #483
