### PR TITLE
feat: Image Generation Module (Issues #497-501)

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/ImageGeneration.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/ImageGeneration.scala
@@ -2,9 +2,10 @@ package org.llm4s.imagegeneration
 
 import java.time.Instant
 import java.nio.file.Path
-import org.llm4s.imagegeneration.provider.{ HttpClient, HuggingFaceClient, OpenAIImageClient, StableDiffusionClient }
+import org.llm4s.imagegeneration.provider.{ BedrockClient, FalAIClient, HttpClient, HuggingFaceClient, OpenAIImageClient, StabilityAIClient, StableDiffusionClient, VertexAIClient }
 
 import scala.util.Try
+import scala.concurrent.{Future, ExecutionContext}
 
 // ===== ERROR HANDLING =====
 
@@ -48,6 +49,15 @@ object ImageSize {
     val width  = 512
     val height = 768
   }
+  // New sizes for GPT Image models
+  case object Landscape1536x1024 extends ImageSize {
+    val width  = 1536
+    val height = 1024
+  }
+  case object Portrait1024x1536 extends ImageSize {
+    val width  = 1024
+    val height = 1536
+  }
 }
 
 /** Image format enumeration */
@@ -65,6 +75,7 @@ object ImageFormat {
     val extension = "jpg"
     val mimeType  = "image/jpeg"
   }
+  // WebP support can be added if needed, but keeping it simple for now as per plan
 }
 
 /** Options for image generation */
@@ -75,7 +86,22 @@ case class ImageGenerationOptions(
   guidanceScale: Double = 7.5,
   inferenceSteps: Int = 20,
   negativePrompt: Option[String] = None,
-  samplerName: Option[String] = None // Optional sampler name
+  samplerName: Option[String] = None, // Optional sampler name
+  // New options for GPT Image models
+  quality: Option[String] = None,     // "standard" or "hd"
+  style: Option[String] = None,       // "vivid" or "natural"
+  responseFormat: Option[String] = None, // "url" or "b64_json"
+  user: Option[String] = None         // End-user identifier for abuse monitoring
+)
+
+/** Options for image editing */
+case class ImageEditOptions(
+  size: Option[ImageSize] = None,
+  n: Int = 1,
+  responseFormat: Option[String] = None,
+  quality: Option[String] = None,     // "standard" or "hd" (OpenAI)
+  strength: Option[Double] = None,    // 0.0 to 1.0 (Stable Diffusion)
+  user: Option[String] = None
 )
 
 /** Service health status */
@@ -110,7 +136,9 @@ case class GeneratedImage(
   /** Seed used for generation (if available) */
   seed: Option[Long] = None,
   /** Optional file path if saved to disk */
-  filePath: Option[Path] = None
+  filePath: Option[Path] = None,
+  /** Optional URL if generated via URL method */
+  url: Option[String] = None
 ) {
 
   /** Get the image data as bytes */
@@ -138,6 +166,10 @@ object ImageGenerationProvider {
   case object DALLE           extends ImageGenerationProvider
   case object Midjourney      extends ImageGenerationProvider
   case object HuggingFace     extends ImageGenerationProvider
+  case object VertexAI        extends ImageGenerationProvider
+  case object Bedrock         extends ImageGenerationProvider
+  case object StabilityAI     extends ImageGenerationProvider
+  case object FalAI           extends ImageGenerationProvider
 }
 
 sealed trait ImageGenerationConfig {
@@ -186,11 +218,95 @@ case class OpenAIConfig(
   /** OpenAI API key */
   apiKey: String,
   /** Model to use (dall-e-2 or dall-e-3) */
-  model: String = "dall-e-2",
+  model: String = "gpt-image-1",
   /** Request timeout in milliseconds */
   override val timeout: Int = 30000 // 30 seconds for image generation
 ) extends ImageGenerationConfig {
   def provider: ImageGenerationProvider = ImageGenerationProvider.DALLE
+}
+
+/**
+ * Configuration for Google Vertex AI Imagen API.
+ *
+ * @param projectId Your Google Cloud project ID
+ * @param location The Google Cloud region (default: us-central1)
+ * @param model The Imagen model to use
+ * @param accessToken OAuth2 access token (if None, uses Application Default Credentials)
+ * @param timeout Request timeout in milliseconds
+ */
+case class VertexAIConfig(
+  /** Google Cloud project ID */
+  projectId: String,
+  /** Google Cloud region */
+  location: String = "us-central1",
+  /** Model to use */
+  model: String = "imagen-4.0-generate-001",
+  /** OAuth2 access token (optional, uses ADC if not provided) */
+  accessToken: Option[String] = None,
+  /** Request timeout in milliseconds */
+  override val timeout: Int = 120000 // 2 minutes for image generation
+) extends ImageGenerationConfig {
+  def provider: ImageGenerationProvider = ImageGenerationProvider.VertexAI
+}
+
+/**
+ * Configuration for AWS Bedrock Image Generation API.
+ *
+ * @param region AWS region (default: us-east-1)
+ * @param model The Bedrock model ID to use
+ * @param accessKeyId AWS access key ID (optional, uses environment/IAM if not provided)
+ * @param secretAccessKey AWS secret access key (optional, uses environment/IAM if not provided)
+ * @param timeout Request timeout in milliseconds
+ */
+case class BedrockConfig(
+  /** AWS region */
+  region: String = "us-east-1",
+  /** Model ID to use */
+  model: String = "amazon.titan-image-generator-v1",
+  /** AWS Access Key ID (optional, uses default credentials if not provided) */
+  accessKeyId: Option[String] = None,
+  /** AWS Secret Access Key (optional, uses default credentials if not provided) */
+  secretAccessKey: Option[String] = None,
+  /** Request timeout in milliseconds */
+  override val timeout: Int = 120000 // 2 minutes for image generation
+) extends ImageGenerationConfig {
+  def provider: ImageGenerationProvider = ImageGenerationProvider.Bedrock
+}
+
+/**
+ * Configuration for Stability AI Direct API.
+ *
+ * @param apiKey Your Stability AI API key
+ * @param model The model endpoint to use (ultra or core)
+ * @param timeout Request timeout in milliseconds
+ */
+case class StabilityAIConfig(
+  /** Stability AI API key */
+  apiKey: String,
+  /** Model endpoint (ultra or core) */
+  model: String = "ultra",
+  /** Request timeout in milliseconds */
+  override val timeout: Int = 120000 // 2 minutes for image generation
+) extends ImageGenerationConfig {
+  def provider: ImageGenerationProvider = ImageGenerationProvider.StabilityAI
+}
+
+/**
+ * Configuration for Fal AI API.
+ *
+ * @param apiKey Your Fal AI API key
+ * @param model The model to use (e.g., fal-ai/flux/dev, fal-ai/fast-sdxl)
+ * @param timeout Request timeout in milliseconds
+ */
+case class FalAIConfig(
+  /** Fal AI API key */
+  apiKey: String,
+  /** Model to use */
+  model: String = "fal-ai/flux/dev",
+  /** Request timeout in milliseconds */
+  override val timeout: Int = 120000 // 2 minutes for image generation
+) extends ImageGenerationConfig {
+  def provider: ImageGenerationProvider = ImageGenerationProvider.FalAI
 }
 
 // ===== CLIENT INTERFACE =====
@@ -210,6 +326,35 @@ trait ImageGenerationClient {
     options: ImageGenerationOptions = ImageGenerationOptions()
   ): Either[ImageGenerationError, Seq[GeneratedImage]]
 
+  /** Edit an existing image based on a prompt and optional mask */
+  def editImage(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    options: ImageEditOptions = ImageEditOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]]
+
+  /** Generate an image asynchronously */
+  def generateImageAsync(
+      prompt: String,
+      options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, GeneratedImage]]
+
+  /** Generate multiple images asynchronously */
+  def generateImagesAsync(
+      prompt: String,
+      count: Int,
+      options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]]
+
+  /** Edit an existing image asynchronously */
+  def editImageAsync(
+      imagePath: Path,
+      prompt: String,
+      maskPath: Option[Path] = None,
+      options: ImageEditOptions = ImageEditOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]]
+
   /** Check the health/status of the image generation service */
   def health(): Either[ImageGenerationError, ServiceStatus]
 }
@@ -228,6 +373,14 @@ object ImageGeneration {
         new HuggingFaceClient(hfConfig, httpClient)
       case openAIConfig: OpenAIConfig =>
         new OpenAIImageClient(openAIConfig)
+      case vertexConfig: VertexAIConfig =>
+        new VertexAIClient(vertexConfig)
+      case bedrockConfig: BedrockConfig =>
+        new BedrockClient(bedrockConfig)
+      case stabilityConfig: StabilityAIConfig =>
+        new StabilityAIClient(stabilityConfig)
+      case falConfig: FalAIConfig =>
+        new FalAIClient(falConfig)
     }
 
   /** Convenience method for quick image generation */
@@ -246,6 +399,43 @@ object ImageGeneration {
     options: ImageGenerationOptions = ImageGenerationOptions()
   ): Either[ImageGenerationError, Seq[GeneratedImage]] =
     client(config).generateImages(prompt, count, options)
+
+  /** Convenience method for editing an image */
+  def editImage(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    config: ImageGenerationConfig,
+    options: ImageEditOptions = ImageEditOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] =
+    client(config).editImage(imagePath, prompt, maskPath, options)
+
+  /** Convenience method for generating an image asynchronously */
+  def generateImageAsync(
+      prompt: String,
+      config: ImageGenerationConfig,
+      options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, GeneratedImage]] =
+    client(config).generateImageAsync(prompt, options)
+
+  /** Convenience method for generating multiple images asynchronously */
+  def generateImagesAsync(
+      prompt: String,
+      count: Int,
+      config: ImageGenerationConfig,
+      options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    client(config).generateImagesAsync(prompt, count, options)
+
+  /** Convenience method for editing an image asynchronously */
+  def editImageAsync(
+      imagePath: Path,
+      prompt: String,
+      maskPath: Option[Path] = None,
+      config: ImageGenerationConfig,
+      options: ImageEditOptions = ImageEditOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    client(config).editImageAsync(imagePath, prompt, maskPath, options)
 
   /** Get a Stable Diffusion client with default local configuration */
   def stableDiffusionClient(
@@ -275,18 +465,18 @@ object ImageGeneration {
   }
 
   /**
-   * Get an OpenAI DALL-E client with the required API key.
+   * Get an OpenAI client with the required API key.
    *
    * This is a convenience method for creating a client that connects to the
-   * OpenAI API for DALL-E image generation.
+   * OpenAI API for image generation.
    *
    * @param apiKey Your OpenAI API key (required).
-   * @param model The DALL-E model version to use. Defaults to dall-e-2.
-   * @return An `ImageGenerationClient` instance configured for OpenAI DALL-E.
+   * @param model The model version to use. Defaults to gpt-image-1.
+   * @return An `ImageGenerationClient` instance configured for OpenAI.
    */
   def openAIClient(
     apiKey: String,
-    model: String = "dall-e-2"
+    model: String = "gpt-image-1"
   ): ImageGenerationClient = {
     val config = OpenAIConfig(apiKey = apiKey, model = model)
     client(config)
@@ -302,12 +492,12 @@ object ImageGeneration {
     generateImage(prompt, config, options)
   }
 
-  /** Convenience method for quick OpenAI DALL-E image generation */
+  /** Convenience method for quick OpenAI image generation */
   def generateWithOpenAI(
     prompt: String,
     apiKey: String,
     options: ImageGenerationOptions = ImageGenerationOptions(),
-    model: String = "dall-e-2"
+    model: String = "gpt-image-1"
   ): Either[ImageGenerationError, GeneratedImage] = {
     val config = OpenAIConfig(apiKey = apiKey, model = model)
     generateImage(prompt, config, options)

--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/ImagePricingRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/ImagePricingRegistry.scala
@@ -1,0 +1,151 @@
+package org.llm4s.imagegeneration
+
+import org.llm4s.imagegeneration.ImageGenerationProvider
+
+/**
+ * Registry for image generation pricing data.
+ *
+ * Provides cost estimation for various image generation providers and models.
+ * Pricing is approximate and should be verified against current provider pricing.
+ */
+object ImagePricingRegistry {
+
+  /**
+   * Pricing data for a specific image model configuration.
+   *
+   * @param provider Provider name
+   * @param model Model name
+   * @param size Image size (e.g., "1024x1024")
+   * @param quality Quality setting if applicable (e.g., "standard", "hd")
+   * @param costPerImageUsd Cost per image in USD
+   */
+  case class ImagePricing(
+    provider: String,
+    model: String,
+    size: String,
+    quality: Option[String],
+    costPerImageUsd: Double
+  )
+
+  // OpenAI GPT Image / DALL-E Pricing (as of 2026)
+  private val openAIPricing: Seq[ImagePricing] = Seq(
+    // DALL-E 3 Standard
+    ImagePricing("openai", "dall-e-3", "1024x1024", Some("standard"), 0.040),
+    ImagePricing("openai", "dall-e-3", "1024x1792", Some("standard"), 0.080),
+    ImagePricing("openai", "dall-e-3", "1792x1024", Some("standard"), 0.080),
+    // DALL-E 3 HD
+    ImagePricing("openai", "dall-e-3", "1024x1024", Some("hd"), 0.080),
+    ImagePricing("openai", "dall-e-3", "1024x1792", Some("hd"), 0.120),
+    ImagePricing("openai", "dall-e-3", "1792x1024", Some("hd"), 0.120),
+    // GPT Image (gpt-4o-mini)
+    ImagePricing("openai", "gpt-image-1", "1024x1024", Some("low"), 0.011),
+    ImagePricing("openai", "gpt-image-1", "1024x1024", Some("medium"), 0.042),
+    ImagePricing("openai", "gpt-image-1", "1024x1024", Some("high"), 0.167),
+    // DALL-E 2
+    ImagePricing("openai", "dall-e-2", "1024x1024", None, 0.020),
+    ImagePricing("openai", "dall-e-2", "512x512", None, 0.018),
+    ImagePricing("openai", "dall-e-2", "256x256", None, 0.016)
+  )
+
+  // Stability AI Pricing
+  private val stabilityPricing: Seq[ImagePricing] = Seq(
+    ImagePricing("stability", "ultra", "1024x1024", None, 0.080),
+    ImagePricing("stability", "core", "1024x1024", None, 0.030),
+    ImagePricing("stability", "sd3.5-large", "1024x1024", None, 0.065),
+    ImagePricing("stability", "sd3.5-medium", "1024x1024", None, 0.035)
+  )
+
+  // Google Vertex AI Imagen Pricing
+  private val vertexPricing: Seq[ImagePricing] = Seq(
+    ImagePricing("vertex", "imagen-4.0-generate-001", "1024x1024", None, 0.040),
+    ImagePricing("vertex", "imagegeneration@006", "1024x1024", None, 0.020)
+  )
+
+  // AWS Bedrock Pricing (Titan)
+  private val bedrockPricing: Seq[ImagePricing] = Seq(
+    ImagePricing("bedrock", "amazon.titan-image-generator-v1", "1024x1024", None, 0.010),
+    ImagePricing("bedrock", "amazon.titan-image-generator-v2:0", "1024x1024", None, 0.008)
+  )
+
+  // Fal AI Pricing
+  private val falPricing: Seq[ImagePricing] = Seq(
+    ImagePricing("fal", "fal-ai/flux/dev", "1024x1024", None, 0.025),
+    ImagePricing("fal", "fal-ai/fast-sdxl", "1024x1024", None, 0.003)
+  )
+
+  // HuggingFace Pricing (typically free tier or per-inference)
+  private val huggingfacePricing: Seq[ImagePricing] = Seq(
+    ImagePricing("huggingface", "stabilityai/stable-diffusion-xl-base-1.0", "1024x1024", None, 0.001)
+  )
+
+  // All pricing combined
+  private val allPricing: Seq[ImagePricing] =
+    openAIPricing ++ stabilityPricing ++ vertexPricing ++ bedrockPricing ++ falPricing ++ huggingfacePricing
+
+  /**
+   * Get the cost per image for a given provider, model, and size.
+   *
+   * @param provider Provider name
+   * @param model Model name
+   * @param size Image size (default: "1024x1024")
+   * @param quality Quality setting if applicable
+   * @return Cost per image in USD, or default fallback
+   */
+  def getCostPerImage(
+    provider: String,
+    model: String,
+    size: String = "1024x1024",
+    quality: Option[String] = None
+  ): Double = {
+    allPricing
+      .find { p =>
+        p.provider.equalsIgnoreCase(provider) &&
+        (p.model.equalsIgnoreCase(model) || model.contains(p.model) || p.model.contains(model)) &&
+        (p.size == size || size == "*") &&
+        (p.quality == quality || quality.isEmpty || p.quality.isEmpty)
+      }
+      .map(_.costPerImageUsd)
+      .getOrElse(0.020) // Default fallback: $0.02/image
+  }
+
+  /**
+   * Estimate total cost for image generation.
+   *
+   * @param provider Provider name
+   * @param model Model name
+   * @param imageCount Number of images
+   * @param size Image size
+   * @param quality Quality setting
+   * @return Estimated total cost in USD
+   */
+  def estimateCost(
+    provider: String,
+    model: String,
+    imageCount: Int,
+    size: String = "1024x1024",
+    quality: Option[String] = None
+  ): Double = {
+    getCostPerImage(provider, model, size, quality) * imageCount
+  }
+
+  /**
+   * Get pricing for a specific ImageGenerationProvider enum.
+   */
+  def getCostForProvider(
+    providerEnum: ImageGenerationProvider,
+    model: String,
+    size: String = "1024x1024"
+  ): Double = {
+    val providerName = providerEnum match {
+      case ImageGenerationProvider.DALLE           => "openai"
+      case ImageGenerationProvider.StableDiffusion => "stability"
+      case ImageGenerationProvider.StabilityAI     => "stability"
+      case ImageGenerationProvider.VertexAI        => "vertex"
+      case ImageGenerationProvider.Bedrock         => "bedrock"
+      case ImageGenerationProvider.FalAI           => "fal"
+      case ImageGenerationProvider.HuggingFace     => "huggingface"
+      case ImageGenerationProvider.Midjourney      => "midjourney"
+    }
+    getCostPerImage(providerName, model, size)
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/BedrockClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/BedrockClient.scala
@@ -1,0 +1,292 @@
+package org.llm4s.imagegeneration.provider
+
+import org.llm4s.imagegeneration._
+import org.slf4j.LoggerFactory
+import upickle.default._
+import java.nio.file.Path
+import scala.util.Try
+import scala.concurrent.{Future, ExecutionContext}
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import java.time.{ZonedDateTime, ZoneOffset}
+import java.time.format.DateTimeFormatter
+import java.security.MessageDigest
+
+/**
+ * AWS Bedrock client for image generation.
+ *
+ * This client connects to AWS Bedrock for text-to-image generation using
+ * Amazon Titan Image Generator or Stability AI models.
+ *
+ * @param config Configuration containing region, model, and authentication settings
+ *
+ * @example
+ * {{{
+ * val config = BedrockConfig(
+ *   region = "us-east-1",
+ *   model = "amazon.titan-image-generator-v1",
+ *   accessKeyId = Some("your-access-key"),
+ *   secretAccessKey = Some("your-secret-key")
+ * )
+ * val client = new BedrockClient(config)
+ *
+ * client.generateImage("a beautiful landscape") match {
+ *   case Right(image) => println(s"Generated image: ${image.size}")
+ *   case Left(error) => println(s"Error: ${error.message}")
+ * }
+ * }}}
+ */
+class BedrockClient(config: BedrockConfig) extends ImageGenerationClient {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+  private val service = "bedrock"
+  private val host = s"bedrock-runtime.${config.region}.amazonaws.com"
+
+  private def apiUrl: String =
+    s"https://$host/model/${config.model}/invoke"
+
+  override def generateImage(
+    prompt: String,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  ): Either[ImageGenerationError, GeneratedImage] =
+    generateImages(prompt, 1, options).map(_.head)
+
+  override def generateImages(
+    prompt: String,
+    count: Int,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+    for {
+      _        <- validatePrompt(prompt)
+      _        <- validateCount(count)
+      payload  <- Right(buildPayload(prompt, count, options))
+      response <- makeHttpRequest(payload)
+      images   <- parseResponse(response, prompt, options)
+    } yield images
+  }
+
+  override def editImage(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    options: ImageEditOptions = ImageEditOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] =
+    Left(ValidationError("Image editing is not yet supported for Bedrock provider"))
+
+  override def generateImageAsync(
+    prompt: String,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, GeneratedImage]] =
+    Future {
+      generateImage(prompt, options)
+    }
+
+  override def generateImagesAsync(
+    prompt: String,
+    count: Int,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      generateImages(prompt, count, options)
+    }
+
+  override def editImageAsync(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    options: ImageEditOptions = ImageEditOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      editImage(imagePath, prompt, maskPath, options)
+    }
+
+  override def health(): Either[ImageGenerationError, ServiceStatus] = {
+    // Bedrock doesn't have a dedicated health endpoint
+    // Check if credentials are available
+    val hasCredentials = config.accessKeyId.isDefined && config.secretAccessKey.isDefined
+    if (hasCredentials) {
+      Right(ServiceStatus(HealthStatus.Healthy, "AWS Bedrock credentials configured"))
+    } else {
+      Right(ServiceStatus(HealthStatus.Degraded, "AWS credentials not explicitly configured (using environment/IAM)"))
+    }
+  }
+
+  private def validatePrompt(prompt: String): Either[ImageGenerationError, String] =
+    Either.cond(prompt.trim.nonEmpty, prompt, ValidationError("Prompt cannot be empty"))
+
+  private def validateCount(count: Int): Either[ImageGenerationError, Int] =
+    Either.cond(count > 0 && count <= 5, count, ValidationError("Count must be between 1 and 5 for Bedrock"))
+
+  private def buildPayload(prompt: String, count: Int, options: ImageGenerationOptions): ujson.Value = {
+    val (width, height) = (options.size.width, options.size.height)
+
+    // Titan Image Generator format
+    if (config.model.startsWith("amazon.titan")) {
+      val imageGenConfig = ujson.Obj(
+        "numberOfImages" -> count,
+        "width" -> width,
+        "height" -> height
+      )
+
+      options.seed.foreach { seed =>
+        imageGenConfig("seed") = seed
+      }
+
+      ujson.Obj(
+        "taskType" -> "TEXT_IMAGE",
+        "textToImageParams" -> ujson.Obj(
+          "text" -> prompt
+        ),
+        "imageGenerationConfig" -> imageGenConfig
+      )
+    } else {
+      // Stability AI format
+      ujson.Obj(
+        "text_prompts" -> ujson.Arr(
+          ujson.Obj("text" -> prompt)
+        ),
+        "cfg_scale" -> 7,
+        "seed" -> options.seed.map(_.toInt).getOrElse(0),
+        "steps" -> 50,
+        "width" -> width,
+        "height" -> height,
+        "samples" -> count
+      )
+    }
+  }
+
+  private def makeHttpRequest(payload: ujson.Value): Either[ImageGenerationError, requests.Response] = {
+    val payloadBytes = write(payload).getBytes("UTF-8")
+
+
+    val headers = (config.accessKeyId, config.secretAccessKey) match {
+      case (Some(accessKey), Some(secretKey)) =>
+        buildSignedHeaders(payloadBytes, accessKey, secretKey)
+      case _ =>
+        // Fallback to environment credentials
+        val envAccessKey = sys.env.getOrElse("AWS_ACCESS_KEY_ID", "")
+        val envSecretKey = sys.env.getOrElse("AWS_SECRET_ACCESS_KEY", "")
+        if (envAccessKey.isEmpty || envSecretKey.isEmpty) {
+          return Left(AuthenticationError("AWS credentials not provided"))
+        }
+        buildSignedHeaders(payloadBytes, envAccessKey, envSecretKey)
+    }
+
+    logger.debug(s"Making request to: $apiUrl")
+    logger.debug(s"Payload: ${write(payload, indent = 2)}")
+
+    Try {
+      requests.post(
+        url = apiUrl,
+        data = payloadBytes,
+        headers = headers,
+        readTimeout = config.timeout,
+        connectTimeout = 10000
+      )
+    }.toEither.left.map(e => UnknownError(e))
+  }
+
+  private def buildSignedHeaders(payload: Array[Byte], accessKey: String, secretKey: String): Map[String, String] = {
+    val now = ZonedDateTime.now(ZoneOffset.UTC)
+    val amzDate = now.format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'"))
+    val dateStamp = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"))
+
+    val payloadHash = sha256Hex(payload)
+    val contentType = "application/json"
+
+    val canonicalHeaders = s"content-type:$contentType\nhost:$host\nx-amz-date:$amzDate\n"
+    val signedHeaders = "content-type;host;x-amz-date"
+
+    val canonicalRequest = s"POST\n/model/${config.model}/invoke\n\n$canonicalHeaders\n$signedHeaders\n$payloadHash"
+
+    val algorithm = "AWS4-HMAC-SHA256"
+    val credentialScope = s"$dateStamp/${config.region}/$service/aws4_request"
+    val stringToSign = s"$algorithm\n$amzDate\n$credentialScope\n${sha256Hex(canonicalRequest.getBytes("UTF-8"))}"
+
+    val signingKey = getSignatureKey(secretKey, dateStamp, config.region, service)
+    val signature = hmacSha256Hex(signingKey, stringToSign)
+
+    val authorizationHeader = s"$algorithm Credential=$accessKey/$credentialScope, SignedHeaders=$signedHeaders, Signature=$signature"
+
+    Map(
+      "Content-Type" -> contentType,
+      "X-Amz-Date" -> amzDate,
+      "Authorization" -> authorizationHeader,
+      "X-Amz-Content-Sha256" -> payloadHash
+    )
+  }
+
+  private def sha256Hex(data: Array[Byte]): String = {
+    val digest = MessageDigest.getInstance("SHA-256")
+    digest.digest(data).map("%02x".format(_)).mkString
+  }
+
+  private def hmacSha256(key: Array[Byte], data: String): Array[Byte] = {
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(new SecretKeySpec(key, "HmacSHA256"))
+    mac.doFinal(data.getBytes("UTF-8"))
+  }
+
+  private def hmacSha256Hex(key: Array[Byte], data: String): String = {
+    hmacSha256(key, data).map("%02x".format(_)).mkString
+  }
+
+  private def getSignatureKey(key: String, dateStamp: String, region: String, service: String): Array[Byte] = {
+    val kDate = hmacSha256(("AWS4" + key).getBytes("UTF-8"), dateStamp)
+    val kRegion = hmacSha256(kDate, region)
+    val kService = hmacSha256(kRegion, service)
+    hmacSha256(kService, "aws4_request")
+  }
+
+  private def parseResponse(
+    response: requests.Response,
+    prompt: String,
+    options: ImageGenerationOptions
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      return Left(AuthenticationError("Invalid or missing AWS credentials"))
+    }
+
+    if (response.statusCode != 200) {
+      val errorMsg = s"API request failed with status ${response.statusCode}: ${response.text()}"
+      logger.error(errorMsg)
+      return Left(ServiceError(errorMsg, response.statusCode))
+    }
+
+    Try {
+      val responseJson = read[ujson.Value](response.text())
+      responseJson
+    }.toEither.left
+      .map(e => UnknownError(e))
+      .flatMap { responseJson =>
+        // Titan returns images in "images" array
+        val imagesOpt = responseJson.obj.get("images").map(_.arr.toSeq)
+        // Stability returns in "artifacts" array
+        val artifactsOpt = responseJson.obj.get("artifacts").map(_.arr.toSeq)
+
+        val imageDataList = imagesOpt.orElse(artifactsOpt.map(_.flatMap { artifact =>
+          artifact.obj.get("base64").map(_.str)
+        })).getOrElse(Seq.empty)
+
+        if (imageDataList.isEmpty) {
+          Left(ValidationError("No images returned from the API"))
+        } else {
+          val generatedImages = imageDataList.map { imageData =>
+            val data = imageData match {
+              case s: ujson.Str => s.str
+              case other => other.toString
+            }
+            GeneratedImage(
+              data = data,
+              format = ImageFormat.PNG,
+              size = options.size,
+              prompt = prompt,
+              seed = options.seed
+            )
+          }
+          logger.info(s"Successfully generated ${generatedImages.length} image(s)")
+          Right(generatedImages)
+        }
+      }
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/FalAIClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/FalAIClient.scala
@@ -1,0 +1,195 @@
+package org.llm4s.imagegeneration.provider
+
+import org.llm4s.imagegeneration._
+import org.slf4j.LoggerFactory
+import upickle.default._
+import java.nio.file.Path
+import scala.util.Try
+import scala.concurrent.{Future, ExecutionContext}
+
+/**
+ * Fal AI client for image generation.
+ *
+ * This client connects to Fal AI's REST API for text-to-image generation
+ * using Flux or SDXL models.
+ *
+ * @param config Configuration containing API key, model, and timeout settings
+ *
+ * @example
+ * {{{
+ * val config = FalAIConfig(
+ *   apiKey = "your-fal-api-key",
+ *   model = "fal-ai/flux/dev"
+ * )
+ * val client = new FalAIClient(config)
+ *
+ * client.generateImage("a beautiful landscape") match {
+ *   case Right(image) => println(s"Generated image: ${image.size}")
+ *   case Left(error) => println(s"Error: ${error.message}")
+ * }
+ * }}}
+ */
+class FalAIClient(config: FalAIConfig) extends ImageGenerationClient {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private def apiUrl: String =
+    s"https://fal.run/${config.model}"
+
+  override def generateImage(
+    prompt: String,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  ): Either[ImageGenerationError, GeneratedImage] =
+    generateImages(prompt, 1, options).map(_.head)
+
+  override def generateImages(
+    prompt: String,
+    count: Int,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+    for {
+      _        <- validatePrompt(prompt)
+      _        <- validateCount(count)
+      payload  <- Right(buildPayload(prompt, count, options))
+      response <- makeHttpRequest(payload)
+      images   <- parseResponse(response, prompt, options)
+    } yield images
+  }
+
+  override def editImage(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    options: ImageEditOptions = ImageEditOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] =
+    Left(ValidationError("Image editing is not yet supported for Fal AI provider"))
+
+  override def generateImageAsync(
+    prompt: String,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, GeneratedImage]] =
+    Future {
+      generateImage(prompt, options)
+    }
+
+  override def generateImagesAsync(
+    prompt: String,
+    count: Int,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      generateImages(prompt, count, options)
+    }
+
+  override def editImageAsync(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    options: ImageEditOptions = ImageEditOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      editImage(imagePath, prompt, maskPath, options)
+    }
+
+  override def health(): Either[ImageGenerationError, ServiceStatus] = {
+    if (config.apiKey.isEmpty) {
+      Right(ServiceStatus(HealthStatus.Degraded, "Fal AI API key not configured"))
+    } else {
+      Right(ServiceStatus(HealthStatus.Healthy, "Fal AI API key configured"))
+    }
+  }
+
+  private def validatePrompt(prompt: String): Either[ImageGenerationError, String] =
+    Either.cond(prompt.trim.nonEmpty, prompt, ValidationError("Prompt cannot be empty"))
+
+  private def validateCount(count: Int): Either[ImageGenerationError, Int] =
+    Either.cond(count > 0 && count <= 4, count, ValidationError("Count must be between 1 and 4 for Fal AI"))
+
+  private def buildPayload(prompt: String, count: Int, options: ImageGenerationOptions): ujson.Value = {
+    val imageSize = options.size match {
+      case ImageSize.Square512 | ImageSize.Square1024 => "square_hd"
+      case ImageSize.Landscape768x512 | ImageSize.Landscape1536x1024 => "landscape_16_9"
+      case ImageSize.Portrait512x768 | ImageSize.Portrait1024x1536 => "portrait_16_9"
+    }
+
+    val payload = ujson.Obj(
+      "prompt" -> prompt,
+      "image_size" -> imageSize,
+      "num_images" -> count
+    )
+
+    options.negativePrompt.foreach { np =>
+      payload("negative_prompt") = np
+    }
+
+    options.seed.foreach { seed =>
+      payload("seed") = seed.toInt
+    }
+
+    payload
+  }
+
+  private def makeHttpRequest(payload: ujson.Value): Either[ImageGenerationError, requests.Response] = {
+    logger.debug(s"Making request to: $apiUrl")
+    logger.debug(s"Payload: ${write(payload, indent = 2)}")
+
+    Try {
+      requests.post(
+        url = apiUrl,
+        data = write(payload),
+        headers = Map(
+          "Authorization" -> s"Key ${config.apiKey}",
+          "Content-Type" -> "application/json"
+        ),
+        readTimeout = config.timeout,
+        connectTimeout = 10000
+      )
+    }.toEither.left.map(e => UnknownError(e))
+  }
+
+  private def parseResponse(
+    response: requests.Response,
+    prompt: String,
+    options: ImageGenerationOptions
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      return Left(AuthenticationError("Invalid or missing Fal AI API key"))
+    }
+
+    if (response.statusCode != 200) {
+      val errorMsg = s"API request failed with status ${response.statusCode}: ${response.text()}"
+      logger.error(errorMsg)
+      return Left(ServiceError(errorMsg, response.statusCode))
+    }
+
+    Try {
+      val responseJson = read[ujson.Value](response.text())
+      responseJson
+    }.toEither.left
+      .map(e => UnknownError(e))
+      .flatMap { responseJson =>
+        // Fal AI returns images in "images" array with "url" field
+        responseJson.obj.get("images") match {
+          case Some(imagesArr) =>
+            val generatedImages = imagesArr.arr.map { imageObj =>
+              val imageUrl = imageObj.obj.get("url").map(_.str).getOrElse("")
+              logger.info(s"Generated image URL: $imageUrl")
+              GeneratedImage(
+                data = imageUrl, // Fal returns URL, not base64
+                format = ImageFormat.PNG,
+                size = options.size,
+                prompt = prompt,
+                seed = options.seed
+              )
+            }.toSeq
+            if (generatedImages.isEmpty) {
+              Left(ValidationError("No images returned from the API"))
+            } else {
+              Right(generatedImages)
+            }
+          case None =>
+            Left(ValidationError("No 'images' field in API response"))
+        }
+      }
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/HuggingFaceClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/HuggingFaceClient.scala
@@ -3,8 +3,10 @@ package org.llm4s.imagegeneration.provider
 import org.llm4s.imagegeneration._
 
 import java.time.Instant
+import java.nio.file.Path
 import java.util.Base64
 import scala.util.Try
+import scala.concurrent.{Future, ExecutionContext}
 
 /**
  * HuggingFace Inference API client for image generation.
@@ -145,6 +147,46 @@ class HuggingFaceClient(config: HuggingFaceConfig, httpClient: BaseHttpClient) e
 
     result
   }
+
+  /**
+   * Edit an existing image based on a prompt and optional mask.
+   *
+   * Not currently supported for HuggingFace provider.
+   */
+  override def editImage(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    options: ImageEditOptions = ImageEditOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] =
+    Left(ValidationError("Image editing is not yet supported for HuggingFace provider"))
+
+  override def generateImageAsync(
+      prompt: String,
+      options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, GeneratedImage]] =
+    Future {
+      generateImage(prompt, options)
+    }
+
+  override def generateImagesAsync(
+      prompt: String,
+      count: Int,
+      options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      generateImages(prompt, count, options)
+    }
+
+  override def editImageAsync(
+      imagePath: Path,
+      prompt: String,
+      maskPath: Option[Path] = None,
+      options: ImageEditOptions = ImageEditOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      editImage(imagePath, prompt, maskPath, options)
+    }
 
   /**
    * Check the health status of the HuggingFace Inference API.

--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/OpenAIImageClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/OpenAIImageClient.scala
@@ -4,7 +4,9 @@ import org.llm4s.imagegeneration._
 import org.slf4j.LoggerFactory
 import ujson._
 import java.time.Instant
+import java.nio.file.Path
 import scala.util.Try
+import scala.concurrent.{Future, ExecutionContext}
 
 /**
  * OpenAI DALL-E API client for image generation.
@@ -80,6 +82,108 @@ class OpenAIImageClient(config: OpenAIConfig) extends ImageGenerationClient {
   }
 
   /**
+   * Edit an existing image based on a prompt and optional mask.
+   *
+   * @param imagePath Path to the image to edit (PNG, < 4MB)
+   * @param prompt The text description of the desired edit
+   * @param maskPath Optional path to the mask image (PNG, < 4MB)
+   * @param options Optional generation parameters
+   * @return Either an error or a sequence of generated images
+   */
+  override def editImage(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    options: ImageEditOptions = ImageEditOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+    // Validate image format manually as simple check, real validation happens at API
+    if (!imagePath.toString.toLowerCase.endsWith(".png")) {
+      return Left(ValidationError("Image must be a PNG file"))
+    }
+    
+    val editUrl = "https://api.openai.com/v1/images/edits"
+    
+    val parts = scala.collection.mutable.ListBuffer[requests.MultiItem](
+      requests.MultiItem("image", imagePath, filename = imagePath.getFileName.toString),
+      requests.MultiItem("prompt", prompt),
+      requests.MultiItem("n", options.n.toString),
+      requests.MultiItem("response_format", options.responseFormat.getOrElse("b64_json"))
+    )
+
+    if (config.model.startsWith("dall-e")) {
+       parts += requests.MultiItem("model", "dall-e-2") // Edits only supported on DALL-E 2 currently
+    } else {
+       // Fallback to dall-e-2 for edits as GPT models don't support it yet
+       parts += requests.MultiItem("model", "dall-e-2") 
+    }
+
+    maskPath.foreach(path => parts += requests.MultiItem("mask", path, filename = path.getFileName.toString))
+    options.size.foreach(s => parts += requests.MultiItem("size", sizeToApiFormat(s)))
+    options.user.foreach(u => parts += requests.MultiItem("user", u))
+
+    val response = requests.post(
+      editUrl,
+      headers = Map("Authorization" -> s"Bearer ${config.apiKey}"),
+      data = requests.MultiPart(parts.toSeq: _*),
+      readTimeout = config.timeout,
+      connectTimeout = 10000
+    )
+
+    if (response.statusCode == 200) {
+       // reuse parseResponse logic but map ImageEditOptions to ImageGenerationOptions for compatibility
+       // Note: Size might be different if None was passed, but parseResponse uses options.size
+       // We'll create a dummy ImageGenerationOptions
+       val genOptions = ImageGenerationOptions(
+         size = options.size.getOrElse(ImageSize.Square1024), // API default
+         format = ImageFormat.PNG, // Default
+         responseFormat = options.responseFormat, // Pass through
+       )
+       parseResponse(response, prompt, genOptions)
+    } else {
+      handleErrorResponse(response) match {
+          case Left(e) => Left(e)
+          case Right(_) => Left(UnknownError(new RuntimeException("Unexpected successful response during error handling")))
+      }
+    }
+  }
+
+  /**
+   * Generate an image asynchronously
+   */
+  override def generateImageAsync(
+      prompt: String,
+      options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, GeneratedImage]] =
+    Future {
+      generateImage(prompt, options)
+    }
+
+  /**
+   * Generate multiple images asynchronously
+   */
+  override def generateImagesAsync(
+      prompt: String,
+      count: Int,
+      options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      generateImages(prompt, count, options)
+    }
+
+  /**
+   * Edit an existing image asynchronously
+   */
+  override def editImageAsync(
+      imagePath: Path,
+      prompt: String,
+      maskPath: Option[Path] = None,
+      options: ImageEditOptions = ImageEditOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      editImage(imagePath, prompt, maskPath, options)
+    }
+
+  /**
    * Check the health/status of the OpenAI API service.
    *
    * Note: OpenAI doesn't provide a dedicated health endpoint,
@@ -120,20 +224,22 @@ class OpenAIImageClient(config: OpenAIConfig) extends ImageGenerationClient {
   /**
    * Validate the prompt to ensure it meets OpenAI's requirements.
    */
-  private def validatePrompt(prompt: String): Either[ImageGenerationError, String] =
+  private def validatePrompt(prompt: String): Either[ImageGenerationError, String] = {
+    val maxChars = if (config.model.startsWith("gpt-image")) 32000 else 4000
     if (prompt.trim.isEmpty) {
       Left(ValidationError("Prompt cannot be empty"))
-    } else if (prompt.length > 4000) {
-      Left(ValidationError("Prompt cannot exceed 4000 characters"))
+    } else if (prompt.length > maxChars) {
+      Left(ValidationError(s"Prompt cannot exceed $maxChars characters"))
     } else {
       Right(prompt)
     }
+  }
 
   /**
    * Validate the count based on the model being used.
    */
   private def validateCount(count: Int): Either[ImageGenerationError, Int] = {
-    val maxCount = if (config.model == "dall-e-3") 1 else 10
+    val maxCount = if (config.model.startsWith("gpt-image")) 10 else if (config.model == "dall-e-3") 1 else 10
     if (count < 1 || count > maxCount) {
       Left(ValidationError(s"Count must be between 1 and $maxCount for ${config.model}"))
     } else {
@@ -151,6 +257,8 @@ class OpenAIImageClient(config: OpenAIConfig) extends ImageGenerationClient {
       case ImageSize.Square1024       => "1024x1024"
       case ImageSize.Landscape768x512 => if (config.model == "dall-e-3") "1792x1024" else "512x512"
       case ImageSize.Portrait512x768  => if (config.model == "dall-e-3") "1024x1792" else "512x512"
+      case ImageSize.Landscape1536x1024 => "1792x1024" // Closest matching for DALL-E 3/GPT
+      case ImageSize.Portrait1024x1536  => "1024x1792" // Closest matching for DALL-E 3/GPT
     }
 
   /**
@@ -161,17 +269,27 @@ class OpenAIImageClient(config: OpenAIConfig) extends ImageGenerationClient {
     count: Int,
     options: ImageGenerationOptions
   ): Either[ImageGenerationError, requests.Response] = {
+    // Deprecation warning
+    if (config.model.startsWith("dall-e")) {
+      logger.warn(s"Model ${config.model} is deprecated and will be removed on May 12, 2026. Please migrate to gpt-image models.")
+    }
+
     val requestBody = Obj(
       "model"           -> config.model,
       "prompt"          -> prompt,
       "n"               -> count,
       "size"            -> sizeToApiFormat(options.size),
-      "response_format" -> "b64_json"
+      "response_format" -> options.responseFormat.getOrElse("b64_json")
     )
 
-    // Add quality parameter for DALL-E 3
-    if (config.model == "dall-e-3") {
-      requestBody("quality") = "standard" // or "hd" for higher quality
+    // Optional parameters
+    options.quality.foreach(q => requestBody("quality") = q)
+    options.style.foreach(s => requestBody("style") = s)
+    options.user.foreach(u => requestBody("user") = u)
+
+    // Backward compatibility defaults for DALL-E 3 if not specified
+    if (config.model == "dall-e-3" && options.quality.isEmpty) {
+      requestBody("quality") = "standard"
     }
 
     val response = requests.post(
@@ -222,16 +340,23 @@ class OpenAIImageClient(config: OpenAIConfig) extends ImageGenerationClient {
     val imagesData = json("data").arr
 
     val images = imagesData.map { imageData =>
-      val base64Data = imageData("b64_json").str
+      val (data, url) = if (imageData.obj.contains("b64_json")) {
+        (imageData("b64_json").str, None)
+      } else if (imageData.obj.contains("url")) {
+        ("", Some(imageData("url").str))
+      } else {
+        ("", None)
+      }
 
       GeneratedImage(
-        data = base64Data,
+        data = data,
         format = options.format,
         size = options.size,
         createdAt = Instant.now(),
         prompt = prompt,
         seed = options.seed,
-        filePath = None
+        filePath = None,
+        url = url
       )
     }.toSeq
 

--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/StabilityAIClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/StabilityAIClient.scala
@@ -1,0 +1,204 @@
+package org.llm4s.imagegeneration.provider
+
+import org.llm4s.imagegeneration._
+import org.slf4j.LoggerFactory
+import upickle.default._
+import java.nio.file.Path
+import scala.util.Try
+import scala.concurrent.{Future, ExecutionContext}
+
+/**
+ * Stability AI Direct API client for image generation.
+ *
+ * This client connects to Stability AI's REST API for text-to-image generation
+ * using Stable Diffusion 3.5 models (ultra or core endpoints).
+ *
+ * @param config Configuration containing API key, model, and timeout settings
+ *
+ * @example
+ * {{{
+ * val config = StabilityAIConfig(
+ *   apiKey = "your-stability-api-key",
+ *   model = "ultra"
+ * )
+ * val client = new StabilityAIClient(config)
+ *
+ * client.generateImage("a beautiful landscape") match {
+ *   case Right(image) => println(s"Generated image: ${image.size}")
+ *   case Left(error) => println(s"Error: ${error.message}")
+ * }
+ * }}}
+ */
+class StabilityAIClient(config: StabilityAIConfig) extends ImageGenerationClient {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private def apiUrl: String =
+    s"https://api.stability.ai/v2beta/stable-image/generate/${config.model}"
+
+  override def generateImage(
+    prompt: String,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  ): Either[ImageGenerationError, GeneratedImage] =
+    generateImages(prompt, 1, options).map(_.head)
+
+  override def generateImages(
+    prompt: String,
+    count: Int,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+    for {
+      _        <- validatePrompt(prompt)
+      _        <- validateCount(count)
+      images   <- generateMultipleImages(prompt, count, options)
+    } yield images
+  }
+
+  private def generateMultipleImages(
+    prompt: String,
+    count: Int,
+    options: ImageGenerationOptions
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+    // Stability AI generates one image per request, so loop for multiple
+    val results = (1 to count).map { _ =>
+      generateSingleImage(prompt, options)
+    }
+
+    val errors = results.collect { case Left(e) => e }
+    if (errors.nonEmpty) {
+      Left(errors.head)
+    } else {
+      Right(results.collect { case Right(img) => img })
+    }
+  }
+
+  private def generateSingleImage(
+    prompt: String,
+    options: ImageGenerationOptions
+  ): Either[ImageGenerationError, GeneratedImage] = {
+    val aspectRatio = options.size match {
+      case ImageSize.Square512 | ImageSize.Square1024 => "1:1"
+      case ImageSize.Landscape768x512 | ImageSize.Landscape1536x1024 => "16:9"
+      case ImageSize.Portrait512x768 | ImageSize.Portrait1024x1536 => "9:16"
+    }
+
+    logger.debug(s"Making request to: $apiUrl")
+    logger.debug(s"Prompt: $prompt, Aspect Ratio: $aspectRatio")
+
+    val baseItems = Seq(
+      requests.MultiItem("prompt", prompt),
+      requests.MultiItem("aspect_ratio", aspectRatio),
+      requests.MultiItem("output_format", "png")
+    )
+
+    val allItems = options.negativePrompt match {
+      case Some(np) => baseItems :+ requests.MultiItem("negative_prompt", np)
+      case None => baseItems
+    }
+
+    val formData = requests.MultiPart(allItems: _*)
+
+    Try {
+      requests.post(
+        url = apiUrl,
+        data = formData,
+        headers = Map(
+          "Authorization" -> s"Bearer ${config.apiKey}",
+          "Accept" -> "application/json"
+        ),
+        readTimeout = config.timeout,
+        connectTimeout = 10000
+      )
+    }.toEither.left.map(e => UnknownError(e))
+      .flatMap(parseResponse(_, prompt, options))
+  }
+
+  override def editImage(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    options: ImageEditOptions = ImageEditOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] =
+    Left(ValidationError("Image editing is not yet supported for Stability AI provider"))
+
+  override def generateImageAsync(
+    prompt: String,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, GeneratedImage]] =
+    Future {
+      generateImage(prompt, options)
+    }
+
+  override def generateImagesAsync(
+    prompt: String,
+    count: Int,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      generateImages(prompt, count, options)
+    }
+
+  override def editImageAsync(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    options: ImageEditOptions = ImageEditOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      editImage(imagePath, prompt, maskPath, options)
+    }
+
+  override def health(): Either[ImageGenerationError, ServiceStatus] = {
+    // Check if API key is provided
+    if (config.apiKey.isEmpty) {
+      Right(ServiceStatus(HealthStatus.Degraded, "Stability AI API key not configured"))
+    } else {
+      Right(ServiceStatus(HealthStatus.Healthy, "Stability AI API key configured"))
+    }
+  }
+
+  private def validatePrompt(prompt: String): Either[ImageGenerationError, String] =
+    Either.cond(prompt.trim.nonEmpty, prompt, ValidationError("Prompt cannot be empty"))
+
+  private def validateCount(count: Int): Either[ImageGenerationError, Int] =
+    Either.cond(count > 0 && count <= 10, count, ValidationError("Count must be between 1 and 10 for Stability AI"))
+
+  private def parseResponse(
+    response: requests.Response,
+    prompt: String,
+    options: ImageGenerationOptions
+  ): Either[ImageGenerationError, GeneratedImage] = {
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      return Left(AuthenticationError("Invalid or missing Stability AI API key"))
+    }
+
+    if (response.statusCode != 200) {
+      val errorMsg = s"API request failed with status ${response.statusCode}: ${response.text()}"
+      logger.error(errorMsg)
+      return Left(ServiceError(errorMsg, response.statusCode))
+    }
+
+    Try {
+      val responseJson = read[ujson.Value](response.text())
+      responseJson
+    }.toEither.left
+      .map(e => UnknownError(e))
+      .flatMap { responseJson =>
+        // Response contains base64 image data
+        responseJson.obj.get("image").orElse(responseJson.obj.get("artifacts").flatMap(_.arr.headOption.flatMap(_.obj.get("base64")))) match {
+          case Some(imageData) =>
+            val data = imageData.str
+            logger.info("Successfully generated 1 image")
+            Right(GeneratedImage(
+              data = data,
+              format = ImageFormat.PNG,
+              size = options.size,
+              prompt = prompt,
+              seed = options.seed
+            ))
+          case None =>
+            Left(ValidationError("No image data in API response"))
+        }
+      }
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/StableDiffusionClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/StableDiffusionClient.scala
@@ -3,7 +3,10 @@ package org.llm4s.imagegeneration.provider
 import org.llm4s.imagegeneration._
 import org.slf4j.LoggerFactory
 import upickle.default._
+import java.nio.file.{Files, Path}
+import java.util.Base64
 import scala.util.Try
+import scala.concurrent.{Future, ExecutionContext}
 
 /**
  * Represents the JSON payload for the Stable Diffusion WebUI API's text-to-image endpoint.
@@ -24,6 +27,26 @@ case class StableDiffusionPayload(
 
 object StableDiffusionPayload {
   implicit val writer: Writer[StableDiffusionPayload] = macroW
+}
+
+case class StableDiffusionImg2ImgPayload(
+  init_images: Seq[String],
+  mask: Option[String],
+  prompt: String,
+  negative_prompt: String,
+  width: Int,
+  height: Int,
+  steps: Int,
+  cfg_scale: Double,
+  denoising_strength: Double,
+  batch_size: Int,
+  n_iter: Int,
+  seed: Long,
+  sampler_name: String = "Euler a"
+)
+
+object StableDiffusionImg2ImgPayload {
+    implicit val writer: Writer[StableDiffusionImg2ImgPayload] = macroW
 }
 
 /**
@@ -77,6 +100,99 @@ class StableDiffusionClient(config: StableDiffusionConfig) extends ImageGenerati
         .map(e => UnknownError(e))
       result <- parseResponse(response, prompt, options)
     } yield result
+
+  override def generateImageAsync(
+      prompt: String,
+      options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, GeneratedImage]] =
+    Future {
+      generateImage(prompt, options)
+    }
+
+  override def generateImagesAsync(
+      prompt: String,
+      count: Int,
+      options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      generateImages(prompt, count, options)
+    }
+
+  override def editImageAsync(
+      imagePath: Path,
+      prompt: String,
+      maskPath: Option[Path] = None,
+      options: ImageEditOptions = ImageEditOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      editImage(imagePath, prompt, maskPath, options)
+    }
+
+  override def editImage(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    options: ImageEditOptions = ImageEditOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+    // 1. Read files and convert to Base64
+    val imageBase64 = Try {
+      Base64.getEncoder.encodeToString(Files.readAllBytes(imagePath))
+    }.toEither.left.map(e => ValidationError(s"Failed to read input image: ${e.getMessage}"))
+
+    val maskBase64 = maskPath match {
+      case Some(path) =>
+        Try {
+          Some(Base64.getEncoder.encodeToString(Files.readAllBytes(path)))
+        }.toEither.left.map(e => ValidationError(s"Failed to read mask image: ${e.getMessage}"))
+      case None => Right(None)
+    }
+
+    // 2. Build payload and execute request
+    for {
+      img  <- imageBase64
+      mask <- maskBase64
+      // Convert ImageEditOptions to ImageGenerationOptions for response parsing
+      genOptions = ImageGenerationOptions(
+         size = options.size.getOrElse(ImageSize.Square512),
+         format = ImageFormat.PNG
+      )
+      payload = StableDiffusionImg2ImgPayload(
+        init_images = Seq(img),
+        mask = mask,
+        prompt = prompt,
+        negative_prompt = genOptions.negativePrompt.getOrElse(""),
+        width = genOptions.size.width,
+        height = genOptions.size.height,
+        steps = genOptions.inferenceSteps,
+        cfg_scale = genOptions.guidanceScale,
+        denoising_strength = options.strength.getOrElse(0.75),
+        batch_size = options.n,
+        n_iter = 1,
+        seed = genOptions.seed.getOrElse(-1L),
+        sampler_name = genOptions.samplerName.getOrElse("Euler a")
+      )
+      response <- Try(makeImg2ImgRequest(payload)).toEither.left.map(e => UnknownError(e))
+      result   <- parseResponse(response, prompt, genOptions)
+    } yield result
+  }
+
+  private def makeImg2ImgRequest(payload: StableDiffusionImg2ImgPayload): requests.Response = {
+    val url = s"${config.baseUrl}/sdapi/v1/img2img"
+    val headers = Map(
+      "Content-Type" -> "application/json"
+    ) ++ config.apiKey.map(key => "Authorization" -> s"Bearer $key").toMap
+
+    logger.debug(s"Making img2img request to: $url")
+    // logger.debug(s"Payload: ${write(payload, indent = 2)}") // Too large to log with base64 images
+
+    requests.post(
+      url = url,
+      data = write(payload),
+      headers = headers,
+      readTimeout = config.timeout,
+      connectTimeout = 10000
+    )
+  }
 
   override def health(): Either[ImageGenerationError, ServiceStatus] = Try {
     val url      = s"${config.baseUrl}/sdapi/v1/options"

--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/VertexAIClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/VertexAIClient.scala
@@ -1,0 +1,234 @@
+package org.llm4s.imagegeneration.provider
+
+import org.llm4s.imagegeneration._
+import org.slf4j.LoggerFactory
+import upickle.default._
+import java.nio.file.Path
+
+import scala.util.Try
+import scala.concurrent.{Future, ExecutionContext}
+
+/**
+ * Google Vertex AI Imagen client for image generation.
+ *
+ * This client connects to Google Cloud's Vertex AI Imagen API for text-to-image generation.
+ * It supports the Imagen 4.0 model and other Imagen variants.
+ *
+ * @param config Configuration containing project ID, location, model, and authentication settings
+ *
+ * @example
+ * {{{
+ * val config = VertexAIConfig(
+ *   projectId = "my-gcp-project",
+ *   location = "us-central1",
+ *   model = "imagen-4.0-generate-001"
+ * )
+ * val client = new VertexAIClient(config)
+ *
+ * client.generateImage("a beautiful landscape") match {
+ *   case Right(image) => println(s"Generated image: ${image.size}")
+ *   case Left(error) => println(s"Error: ${error.message}")
+ * }
+ * }}}
+ */
+class VertexAIClient(config: VertexAIConfig) extends ImageGenerationClient {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private def apiUrl: String =
+    s"https://${config.location}-aiplatform.googleapis.com/v1/projects/${config.projectId}/locations/${config.location}/publishers/google/models/${config.model}:predict"
+
+  override def generateImage(
+    prompt: String,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  ): Either[ImageGenerationError, GeneratedImage] =
+    generateImages(prompt, 1, options).map(_.head)
+
+  override def generateImages(
+    prompt: String,
+    count: Int,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+    for {
+      _        <- validatePrompt(prompt)
+      _        <- validateCount(count)
+      payload  <- Right(buildPayload(prompt, count, options))
+      response <- makeHttpRequest(payload)
+      images   <- parseResponse(response, prompt, options)
+    } yield images
+  }
+
+  override def editImage(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    options: ImageEditOptions = ImageEditOptions()
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] =
+    Left(ValidationError("Image editing is not yet supported for Vertex AI provider"))
+
+  override def generateImageAsync(
+    prompt: String,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, GeneratedImage]] =
+    Future {
+      generateImage(prompt, options)
+    }
+
+  override def generateImagesAsync(
+    prompt: String,
+    count: Int,
+    options: ImageGenerationOptions = ImageGenerationOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      generateImages(prompt, count, options)
+    }
+
+  override def editImageAsync(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path] = None,
+    options: ImageEditOptions = ImageEditOptions()
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+    Future {
+      editImage(imagePath, prompt, maskPath, options)
+    }
+
+  override def health(): Either[ImageGenerationError, ServiceStatus] = {
+    // Vertex AI doesn't have a dedicated health endpoint
+    // We'll try to make a minimal API call to check connectivity
+    Try {
+      val testPayload = ujson.Obj(
+        "instances" -> ujson.Arr(ujson.Obj("prompt" -> "test")),
+        "parameters" -> ujson.Obj("sampleCount" -> 1)
+      )
+
+      val headers = Map(
+        "Content-Type" -> "application/json"
+      ) ++ config.accessToken.map(token => "Authorization" -> s"Bearer $token").toMap
+
+      val response = requests.post(
+        url = apiUrl,
+        data = write(testPayload),
+        headers = headers,
+        readTimeout = 5000,
+        connectTimeout = 5000
+      )
+      response
+    }.toEither.left
+      .map(e => ServiceError(s"Health check failed: ${e.getMessage}", 0))
+      .flatMap { response =>
+        if (response.statusCode == 200 || response.statusCode == 400) {
+          // 400 is acceptable - means API is reachable but request was invalid (expected for test)
+          Right(ServiceStatus(HealthStatus.Healthy, "Vertex AI Imagen API is responding"))
+        } else if (response.statusCode == 401 || response.statusCode == 403) {
+          Right(ServiceStatus(HealthStatus.Degraded, s"Authentication issue: ${response.statusCode}"))
+        } else {
+          Right(ServiceStatus(HealthStatus.Degraded, s"Service returned status code: ${response.statusCode}"))
+        }
+      }
+  }
+
+  private def validatePrompt(prompt: String): Either[ImageGenerationError, String] =
+    Either.cond(prompt.trim.nonEmpty, prompt, ValidationError("Prompt cannot be empty"))
+
+  private def validateCount(count: Int): Either[ImageGenerationError, Int] =
+    Either.cond(count > 0 && count <= 8, count, ValidationError("Count must be between 1 and 8 for Vertex AI"))
+
+  private def buildPayload(prompt: String, count: Int, options: ImageGenerationOptions): ujson.Value = {
+    val instance = ujson.Obj("prompt" -> prompt)
+
+    // Add negative prompt if present
+    options.negativePrompt.foreach { negPrompt =>
+      instance("negativePrompt") = negPrompt
+    }
+
+    val parameters = ujson.Obj(
+      "sampleCount" -> count
+    )
+
+    // Map size to aspectRatio
+    val aspectRatio = options.size match {
+      case ImageSize.Square512 | ImageSize.Square1024 => "1:1"
+      case ImageSize.Landscape768x512 | ImageSize.Landscape1536x1024 => "16:9"
+      case ImageSize.Portrait512x768 | ImageSize.Portrait1024x1536 => "9:16"
+    }
+    parameters("aspectRatio") = aspectRatio
+
+    // Add seed if present
+    options.seed.foreach { seed =>
+      parameters("seed") = seed
+    }
+
+    ujson.Obj(
+      "instances" -> ujson.Arr(instance),
+      "parameters" -> parameters
+    )
+  }
+
+  private def makeHttpRequest(payload: ujson.Value): Either[ImageGenerationError, requests.Response] = {
+    val headers = Map(
+      "Content-Type" -> "application/json"
+    ) ++ config.accessToken.map(token => "Authorization" -> s"Bearer $token").toMap
+
+    logger.debug(s"Making request to: $apiUrl")
+    logger.debug(s"Payload: ${write(payload, indent = 2)}")
+
+    Try {
+      requests.post(
+        url = apiUrl,
+        data = write(payload),
+        headers = headers,
+        readTimeout = config.timeout,
+        connectTimeout = 10000
+      )
+    }.toEither.left.map(e => UnknownError(e))
+  }
+
+  private def parseResponse(
+    response: requests.Response,
+    prompt: String,
+    options: ImageGenerationOptions
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      return Left(AuthenticationError("Invalid or missing authentication credentials"))
+    }
+
+    if (response.statusCode != 200) {
+      val errorMsg = s"API request failed with status ${response.statusCode}: ${response.text()}"
+      logger.error(errorMsg)
+      return Left(ServiceError(errorMsg, response.statusCode))
+    }
+
+    Try {
+      val responseJson = read[ujson.Value](response.text())
+      val predictions = responseJson("predictions").arr
+      predictions
+    }.toEither.left
+      .map(e => UnknownError(e))
+      .flatMap { predictions =>
+        if (predictions.isEmpty) {
+          Left(ValidationError("No images returned from the API"))
+        } else {
+          val generatedImages = predictions.flatMap { prediction =>
+            // Vertex AI returns bytesBase64Encoded for each image
+            prediction.obj.get("bytesBase64Encoded").map { imageData =>
+              GeneratedImage(
+                data = imageData.str,
+                format = ImageFormat.PNG,
+                size = options.size,
+                prompt = prompt,
+                seed = options.seed
+              )
+            }
+          }.toSeq
+          
+          if (generatedImages.isEmpty) {
+            Left(ValidationError("No valid images in API response"))
+          } else {
+            logger.info(s"Successfully generated ${generatedImages.length} image(s)")
+            Right(generatedImages)
+          }
+        }
+      }
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/metrics/MetricsCollector.scala
+++ b/modules/core/src/main/scala/org/llm4s/metrics/MetricsCollector.scala
@@ -69,6 +69,25 @@ trait MetricsCollector {
     model: String,
     costUsd: Double
   ): Unit
+
+  /**
+   * Record an image generation request with its outcome and metrics.
+   *
+   * @param provider Provider name (e.g., "openai", "stability", "vertex")
+   * @param model Model name (e.g., "dall-e-3", "ultra")
+   * @param outcome Success or Error with error kind
+   * @param imageCount Number of images generated
+   * @param costUsd Estimated cost in USD
+   * @param duration Request duration
+   */
+  def recordImageGeneration(
+    provider: String,
+    model: String,
+    outcome: Outcome,
+    imageCount: Int,
+    costUsd: Double,
+    duration: FiniteDuration
+  ): Unit
 }
 
 object MetricsCollector {
@@ -96,6 +115,15 @@ object MetricsCollector {
       provider: String,
       model: String,
       costUsd: Double
+    ): Unit = ()
+
+    override def recordImageGeneration(
+      provider: String,
+      model: String,
+      outcome: Outcome,
+      imageCount: Int,
+      costUsd: Double,
+      duration: FiniteDuration
     ): Unit = ()
   }
 }

--- a/modules/core/src/main/scala/org/llm4s/metrics/PrometheusMetrics.scala
+++ b/modules/core/src/main/scala/org/llm4s/metrics/PrometheusMetrics.scala
@@ -144,6 +144,42 @@ final class PrometheusMetrics(
     }.recover { case e: Exception =>
       logger.warn(s"Failed to record cost metrics: ${e.getMessage}")
     }
+
+  /**
+   * Record an image generation request with its outcome and metrics.
+   *
+   * Safe: catches and logs any Prometheus errors without propagating.
+   */
+  override def recordImageGeneration(
+    provider: String,
+    model: String,
+    outcome: Outcome,
+    imageCount: Int,
+    costUsd: Double,
+    duration: FiniteDuration
+  ): Unit =
+    Try {
+      val status = outcome match {
+        case Outcome.Success          => "success"
+        case Outcome.Error(errorKind) =>
+          val kindStr   = errorKind.toString
+          val snakeCase = kindStr.replaceAll("([A-Z])", "_$1").toLowerCase.drop(1)
+          s"error_$snakeCase"
+      }
+
+      requestsTotal.labelValues(provider, model, status).inc()
+      requestDuration.labelValues(provider, model).observe(duration.toMillis / 1000.0)
+      costUsdTotal.labelValues(provider, model).inc(costUsd)
+
+      outcome match {
+        case Outcome.Error(errorKind) =>
+          val errorLabel = errorKind.toString.toLowerCase
+          errorsTotal.labelValues(provider, errorLabel).inc()
+        case _ => // Success - no additional action
+      }
+    }.recover { case e: Exception =>
+      logger.warn(s"Failed to record image generation metrics: ${e.getMessage}")
+    }
 }
 
 object PrometheusMetrics {

--- a/modules/core/src/main/scala/org/llm4s/trace/ConsoleTracing.scala
+++ b/modules/core/src/main/scala/org/llm4s/trace/ConsoleTracing.scala
@@ -174,6 +174,19 @@ class ConsoleTracing extends Tracing {
           e.llmCompletionTokens.foreach(t => println(s"${CYAN}LLM Completion Tokens: $t$RESET"))
           e.totalCostUsd.foreach(c => println(s"${CYAN}Total Cost (USD): $$${f"$c%.6f"}$RESET"))
           println()
+
+        case e: TraceEvent.ImageGenerationCostRecorded =>
+          println()
+          printSubHeader("IMAGE GENERATION COST", YELLOW)
+          println(s"${GRAY}Timestamp: ${e.timestamp}$RESET")
+          println(s"${YELLOW}Provider: ${e.provider}$RESET")
+          println(s"${YELLOW}Model: ${e.model}$RESET")
+          println(s"${YELLOW}Operation: ${e.operation}$RESET")
+          println(s"${YELLOW}Image Count: ${e.imageCount}$RESET")
+          println(s"${YELLOW}Image Size: ${e.imageSize}$RESET")
+          println(s"${YELLOW}Duration: ${e.durationMs}ms$RESET")
+          println(s"${YELLOW}Cost (USD): $$${f"${e.costUsd}%.6f"}$RESET")
+          println()
       }
     }.toEither.left.map(error => UnknownError(error.getMessage, error))
 

--- a/modules/core/src/main/scala/org/llm4s/trace/LangfuseTracing.scala
+++ b/modules/core/src/main/scala/org/llm4s/trace/LangfuseTracing.scala
@@ -450,6 +450,39 @@ class LangfuseTracing(
             "metadata" -> metadataObj
           )
         )
+
+      case e: TraceEvent.ImageGenerationCostRecorded =>
+        ujson.Obj(
+          "id"        -> uuid,
+          "timestamp" -> now,
+          "type"      -> "event-create",
+          "body" -> ujson.Obj(
+            "id"        -> uuid,
+            "timestamp" -> now,
+            "name"      -> s"Image Generation Cost - ${e.operation}",
+            "level"     -> "DEFAULT",
+            "input" -> ujson.Obj(
+              "provider"    -> e.provider,
+              "model"       -> e.model,
+              "operation"   -> e.operation,
+              "image_count" -> e.imageCount,
+              "image_size"  -> e.imageSize
+            ),
+            "output" -> ujson.Obj(
+              "cost_usd"    -> e.costUsd,
+              "duration_ms" -> e.durationMs
+            ),
+            "metadata" -> ujson.Obj(
+              "provider"    -> e.provider,
+              "model"       -> e.model,
+              "operation"   -> e.operation,
+              "image_count" -> e.imageCount,
+              "image_size"  -> e.imageSize,
+              "cost_usd"    -> e.costUsd,
+              "duration_ms" -> e.durationMs
+            )
+          )
+        )
     }
 
     batchEvents += langfuseEvent

--- a/modules/core/src/main/scala/org/llm4s/trace/TraceEvent.scala
+++ b/modules/core/src/main/scala/org/llm4s/trace/TraceEvent.scala
@@ -309,4 +309,39 @@ object TraceEvent {
     )
   }
 
+  /**
+   * Tracks image generation cost for billing and analytics.
+   *
+   * @param costUsd Estimated cost in US dollars
+   * @param provider Provider name (e.g., "openai", "stability", "vertex")
+   * @param model Model name used for generation
+   * @param operation Type of operation: "image_generation" or "image_edit"
+   * @param imageCount Number of images generated
+   * @param imageSize Size of generated images (e.g., "1024x1024")
+   * @param durationMs Request duration in milliseconds
+   */
+  case class ImageGenerationCostRecorded(
+    costUsd: Double,
+    provider: String,
+    model: String,
+    operation: String,
+    imageCount: Int,
+    imageSize: String,
+    durationMs: Long,
+    timestamp: Instant = Instant.now()
+  ) extends TraceEvent {
+    def eventType: String = "image_generation_cost_recorded"
+    def toJson: ujson.Value = ujson.Obj(
+      "event_type"  -> eventType,
+      "timestamp"   -> timestamp.toString,
+      "cost_usd"    -> costUsd,
+      "provider"    -> provider,
+      "model"       -> model,
+      "operation"   -> operation,
+      "image_count" -> imageCount,
+      "image_size"  -> imageSize,
+      "duration_ms" -> durationMs
+    )
+  }
+
 }

--- a/modules/core/src/test/scala/org/llm4s/imagegeneration/ImageGenerationTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/imagegeneration/ImageGenerationTest.scala
@@ -1,9 +1,12 @@
 package org.llm4s.imagegeneration
 
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.ExecutionContext.Implicits.global
 
-import java.nio.file.Files
+import java.nio.file.{Files, Path}
 import java.util.Base64
 
 /**
@@ -12,7 +15,7 @@ import java.util.Base64
  * Includes unit tests for models, integration tests for the factory,
  * and a mock implementation for testing without a real server.
  */
-class ImageGenerationTest extends AnyFunSuite with Matchers {
+class ImageGenerationTest extends AnyFunSuite with Matchers with ScalaFutures {
 
   // ===== MOCK CLIENT FOR TESTING =====
 
@@ -58,6 +61,26 @@ class ImageGenerationTest extends AnyFunSuite with Matchers {
       }
     }
 
+    override def editImage(
+      imagePath: Path,
+      prompt: String,
+      maskPath: Option[Path] = None,
+      options: ImageEditOptions = ImageEditOptions()
+    ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+      if (prompt.trim.isEmpty) return Left(ValidationError("Prompt cannot be empty"))
+      
+      // Return a mock edited image
+      Right(Seq(
+        GeneratedImage(
+          data = mockImageData,
+          format = ImageFormat.PNG,
+          size = options.size.getOrElse(ImageSize.Square512),
+          prompt = prompt,
+          seed = None
+        )
+      ))
+    }
+
     override def health(): Either[ImageGenerationError, ServiceStatus] =
       Right(
         ServiceStatus(
@@ -67,6 +90,27 @@ class ImageGenerationTest extends AnyFunSuite with Matchers {
           averageGenerationTime = Some(100)
         )
       )
+
+    override def generateImageAsync(
+        prompt: String,
+        options: ImageGenerationOptions = ImageGenerationOptions()
+    )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, GeneratedImage]] =
+      Future.successful(generateImage(prompt, options))
+
+    override def generateImagesAsync(
+        prompt: String,
+        count: Int,
+        options: ImageGenerationOptions = ImageGenerationOptions()
+    )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+      Future.successful(generateImages(prompt, count, options))
+
+    override def editImageAsync(
+        imagePath: Path,
+        prompt: String,
+        maskPath: Option[Path] = None,
+        options: ImageEditOptions = ImageEditOptions()
+    )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] =
+      Future.successful(editImage(imagePath, prompt, maskPath, options))
   }
 
   // ===== MODEL UNIT TESTS =====
@@ -79,6 +123,12 @@ class ImageGenerationTest extends AnyFunSuite with Matchers {
     ImageSize.Landscape768x512.width shouldBe 768
     ImageSize.Landscape768x512.height shouldBe 512
     ImageSize.Landscape768x512.description shouldBe "768x512"
+
+    ImageSize.Landscape1536x1024.width shouldBe 1536
+    ImageSize.Landscape1536x1024.height shouldBe 1024
+
+    ImageSize.Portrait1024x1536.width shouldBe 1024
+    ImageSize.Portrait1024x1536.height shouldBe 1536
   }
 
   test("ImageFormat provides correct metadata") {
@@ -98,6 +148,22 @@ class ImageGenerationTest extends AnyFunSuite with Matchers {
     options.guidanceScale shouldBe 7.5
     options.inferenceSteps shouldBe 20
     options.negativePrompt shouldBe None
+    
+    // New fields
+    options.quality shouldBe None
+    options.style shouldBe None
+    options.responseFormat shouldBe None
+    options.user shouldBe None
+  }
+
+  test("ImageEditOptions has sensible defaults") {
+    val options = ImageEditOptions()
+    options.size shouldBe None
+    options.n shouldBe 1
+    options.responseFormat shouldBe None
+    options.quality shouldBe None
+    options.strength shouldBe None
+    options.user shouldBe None
   }
 
   test("GeneratedImage decodes base64 data correctly") {
@@ -172,6 +238,11 @@ class ImageGenerationTest extends AnyFunSuite with Matchers {
     client shouldBe a[org.llm4s.imagegeneration.provider.HuggingFaceClient]
   }
 
+  test("openAIClient creates client with correct config") {
+    val client = ImageGeneration.openAIClient(apiKey = "test-key")
+    client shouldBe a[org.llm4s.imagegeneration.provider.OpenAIImageClient]
+  }
+
   test("Config objects have correct default values") {
     val sdConfig = StableDiffusionConfig()
     sdConfig.baseUrl shouldBe "http://localhost:7860"
@@ -183,6 +254,69 @@ class ImageGenerationTest extends AnyFunSuite with Matchers {
     hfConfig.model shouldBe "stabilityai/stable-diffusion-xl-base-1.0"
     hfConfig.timeout shouldBe 120000
     hfConfig.provider shouldBe ImageGenerationProvider.HuggingFace
+
+    val openAIConfig = OpenAIConfig(apiKey = "test-key")
+    openAIConfig.model shouldBe "gpt-image-1"
+    openAIConfig.provider shouldBe ImageGenerationProvider.DALLE
+
+    val vertexConfig = VertexAIConfig(projectId = "test-project")
+    vertexConfig.location shouldBe "us-central1"
+    vertexConfig.model shouldBe "imagen-4.0-generate-001"
+    vertexConfig.accessToken shouldBe None
+    vertexConfig.timeout shouldBe 120000
+    vertexConfig.provider shouldBe ImageGenerationProvider.VertexAI
+  }
+
+  test("ImageGeneration creates correct client for VertexAI config") {
+    val config = VertexAIConfig(projectId = "test-project")
+    val client = ImageGeneration.client(config)
+
+    client shouldBe a[org.llm4s.imagegeneration.provider.VertexAIClient]
+  }
+
+  test("ImageGeneration creates correct client for Bedrock config") {
+    val config = BedrockConfig()
+    val client = ImageGeneration.client(config)
+
+    client shouldBe a[org.llm4s.imagegeneration.provider.BedrockClient]
+  }
+
+  test("BedrockConfig has correct default values") {
+    val config = BedrockConfig()
+    config.region shouldBe "us-east-1"
+    config.model shouldBe "amazon.titan-image-generator-v1"
+    config.accessKeyId shouldBe None
+    config.secretAccessKey shouldBe None
+    config.timeout shouldBe 120000
+    config.provider shouldBe ImageGenerationProvider.Bedrock
+  }
+
+  test("ImageGeneration creates correct client for StabilityAI config") {
+    val config = StabilityAIConfig(apiKey = "test-key")
+    val client = ImageGeneration.client(config)
+
+    client shouldBe a[org.llm4s.imagegeneration.provider.StabilityAIClient]
+  }
+
+  test("StabilityAIConfig has correct default values") {
+    val config = StabilityAIConfig(apiKey = "test-key")
+    config.model shouldBe "ultra"
+    config.timeout shouldBe 120000
+    config.provider shouldBe ImageGenerationProvider.StabilityAI
+  }
+
+  test("ImageGeneration creates correct client for FalAI config") {
+    val config = FalAIConfig(apiKey = "test-key")
+    val client = ImageGeneration.client(config)
+
+    client shouldBe a[org.llm4s.imagegeneration.provider.FalAIClient]
+  }
+
+  test("FalAIConfig has correct default values") {
+    val config = FalAIConfig(apiKey = "test-key")
+    config.model shouldBe "fal-ai/flux/dev"
+    config.timeout shouldBe 120000
+    config.provider shouldBe ImageGenerationProvider.FalAI
   }
 
   test("Config objects can be customized") {
@@ -308,6 +442,24 @@ class ImageGenerationTest extends AnyFunSuite with Matchers {
     }
   }
 
+  test("Mock client edits image successfully") {
+    val tempFile = Files.createTempFile("test_input", ".png")
+    val result = mockClient.editImage(tempFile, "edited prompt")
+
+    try {
+      result match {
+        case Right(images) =>
+          images.head.prompt shouldBe "edited prompt"
+          images.head.size shouldBe ImageSize.Square512
+
+        case Left(error) =>
+          fail(s"Expected successful edit, but got error: $error")
+      }
+    } finally {
+      Files.deleteIfExists(tempFile)
+    }
+  }
+
   // ===== ERROR HANDLING TESTS =====
 
   test("Error types have correct messages") {
@@ -336,5 +488,74 @@ class ImageGenerationTest extends AnyFunSuite with Matchers {
       case Left(_)      => succeed
       case Right(value) => fail(s"Expected failure but got: $value")
     }
+  }
+
+  // ===== ASYNC TESTS =====
+
+  test("generateImageAsync returns Future[Either]") {
+    val futureResult = mockClient.generateImageAsync("Async test")
+
+    whenReady(futureResult) { result =>
+      result shouldBe a[Right[?, ?]]
+      result.map { image =>
+        image.prompt shouldBe "Async test"
+        image.size shouldBe ImageSize.Square512
+      }
+    }
+  }
+
+  test("generateImagesAsync returns Future[Either]") {
+    val futureResult = mockClient.generateImagesAsync("Async multiple", 2)
+
+    whenReady(futureResult) { result =>
+      result shouldBe a[Right[?, ?]]
+      result.map { images =>
+        images should have length 2
+        images.head.prompt shouldBe "Async multiple"
+      }
+    }
+  }
+
+  test("editImageAsync returns Future[Either]") {
+    val tempFile = Files.createTempFile("async_edit", ".png")
+    try {
+      val futureResult = mockClient.editImageAsync(tempFile, "Async edit")
+
+      whenReady(futureResult) { result =>
+        result shouldBe a[Right[?, ?]]
+        result.map { images =>
+          images.head.prompt shouldBe "Async edit"
+        }
+      }
+    } finally {
+      Files.deleteIfExists(tempFile)
+    }
+  }
+
+  // ===== Image Pricing Registry Tests =====
+
+  test("ImagePricingRegistry returns correct cost for OpenAI DALL-E 3") {
+    val cost = ImagePricingRegistry.getCostPerImage("openai", "dall-e-3", "1024x1024", Some("standard"))
+    cost shouldBe 0.040
+  }
+
+  test("ImagePricingRegistry returns correct cost for Stability AI") {
+    val cost = ImagePricingRegistry.getCostPerImage("stability", "ultra", "1024x1024")
+    cost shouldBe 0.080
+  }
+
+  test("ImagePricingRegistry estimates total cost correctly") {
+    val cost = ImagePricingRegistry.estimateCost("openai", "dall-e-3", 5, "1024x1024", Some("standard"))
+    cost shouldBe 0.200
+  }
+
+  test("ImagePricingRegistry returns default for unknown model") {
+    val cost = ImagePricingRegistry.getCostPerImage("unknown", "unknown-model", "1024x1024")
+    cost shouldBe 0.020 // default fallback
+  }
+
+  test("ImagePricingRegistry getCostForProvider works with enum") {
+    val cost = ImagePricingRegistry.getCostForProvider(ImageGenerationProvider.StabilityAI, "ultra")
+    cost shouldBe 0.080
   }
 }

--- a/modules/core/src/test/scala/org/llm4s/metrics/MockMetricsCollector.scala
+++ b/modules/core/src/test/scala/org/llm4s/metrics/MockMetricsCollector.scala
@@ -9,9 +9,11 @@ import scala.concurrent.duration.FiniteDuration
  */
 class MockMetricsCollector extends MetricsCollector {
   // Track all calls to metrics methods
-  val requestCalls: mutable.Buffer[(String, String, Outcome, FiniteDuration)] = mutable.Buffer.empty
-  val tokenCalls: mutable.Buffer[(String, String, Long, Long)]                = mutable.Buffer.empty
-  val costCalls: mutable.Buffer[(String, String, Double)]                     = mutable.Buffer.empty
+  val requestCalls: mutable.Buffer[(String, String, Outcome, FiniteDuration)]          = mutable.Buffer.empty
+  val tokenCalls: mutable.Buffer[(String, String, Long, Long)]                         = mutable.Buffer.empty
+  val costCalls: mutable.Buffer[(String, String, Double)]                              = mutable.Buffer.empty
+  val imageGenerationCalls: mutable.Buffer[(String, String, Outcome, Int, Double, FiniteDuration)] =
+    mutable.Buffer.empty
 
   override def observeRequest(
     provider: String,
@@ -36,11 +38,22 @@ class MockMetricsCollector extends MetricsCollector {
   ): Unit =
     costCalls += ((provider, model, costUsd))
 
+  override def recordImageGeneration(
+    provider: String,
+    model: String,
+    outcome: Outcome,
+    imageCount: Int,
+    costUsd: Double,
+    duration: FiniteDuration
+  ): Unit =
+    imageGenerationCalls += ((provider, model, outcome, imageCount, costUsd, duration))
+
   // Helper methods for test assertions
   def clearAll(): Unit = {
     requestCalls.clear()
     tokenCalls.clear()
     costCalls.clear()
+    imageGenerationCalls.clear()
   }
 
   def hasSuccessRequest(provider: String, model: String): Boolean =
@@ -55,7 +68,8 @@ class MockMetricsCollector extends MetricsCollector {
       case _                              => false
     }
 
-  def totalRequests: Int   = requestCalls.size
-  def totalTokenCalls: Int = tokenCalls.size
-  def totalCostCalls: Int  = costCalls.size
+  def totalRequests: Int            = requestCalls.size
+  def totalTokenCalls: Int          = tokenCalls.size
+  def totalCostCalls: Int           = costCalls.size
+  def totalImageGenerationCalls: Int = imageGenerationCalls.size
 }

--- a/modules/trace-opentelemetry/src/main/scala/org/llm4s/trace/OpenTelemetryTracing.scala
+++ b/modules/trace-opentelemetry/src/main/scala/org/llm4s/trace/OpenTelemetryTracing.scala
@@ -265,6 +265,22 @@ class OpenTelemetryTracing(
             .put("timestamp", e.timestamp.toString)
             .build()
         )
+
+      case e: TraceEvent.ImageGenerationCostRecorded =>
+        (
+          "Image Generation Cost - " + e.operation,
+          Attributes
+            .builder()
+            .put(TraceAttributes.EventType, "image-generation-cost")
+            .put("provider", e.provider)
+            .put("gen_ai.request.model", e.model)
+            .put("operation", e.operation)
+            .put("image_count", e.imageCount.toLong)
+            .put("image_size", e.imageSize)
+            .put("duration_ms", e.durationMs)
+            .put("cost.usd", e.costUsd)
+            .build()
+        )
     }
   }
 


### PR DESCRIPTION
##Issue: #502  


## Summary
Complete implementation of the Image Generation module for llm4s, enabling text-to-image generation and image editing across multiple cloud providers.
## Issues Resolved
- #497: Core text-to-image support
- #498: Image editing support
- #499: Async API variants
- #500: Additional cloud provider support
- #501: Cost tracking and metrics integration
## Changes
### New Files (5)
- [ImagePricingRegistry.scala](cci:7://file:///c:/Users/singh/Documents/GitHub/llm4ss/modules/core/src/main/scala/org/llm4s/imagegeneration/ImagePricingRegistry.scala:0:0-0:0) - Pricing data for all supported image providers
- `VertexAIClient.scala` - Google Vertex AI Imagen support
- `BedrockClient.scala` - AWS Bedrock Titan Image Generator support
- [StabilityAIClient.scala](cci:7://file:///c:/Users/singh/Documents/GitHub/llm4ss/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/StabilityAIClient.scala:0:0-0:0) - Stability AI Direct API support
- [FalAIClient.scala](cci:7://file:///c:/Users/singh/Documents/GitHub/llm4ss/modules/core/src/main/scala/org/llm4s/imagegeneration/provider/FalAIClient.scala:0:0-0:0) - Fal AI (Flux/SDXL) support
### Modified Files (12)
- [ImageGeneration.scala](cci:7://file:///c:/Users/singh/Documents/GitHub/llm4ss/modules/core/src/main/scala/org/llm4s/imagegeneration/ImageGeneration.scala:0:0-0:0) - Added provider enums, configs, and factory methods
- `StableDiffusionClient.scala`, `HuggingFaceClient.scala`, `OpenAIImageClient.scala` - Enhanced with async support
- [TraceEvent.scala](cci:7://file:///c:/Users/singh/Documents/GitHub/llm4ss/modules/core/src/main/scala/org/llm4s/trace/TraceEvent.scala:0:0-0:0) - Added `ImageGenerationCostRecorded` event
- [MetricsCollector.scala](cci:7://file:///c:/Users/singh/Documents/GitHub/llm4ss/modules/core/src/main/scala/org/llm4s/metrics/MetricsCollector.scala:0:0-0:0), [PrometheusMetrics.scala](cci:7://file:///c:/Users/singh/Documents/GitHub/llm4ss/modules/core/src/main/scala/org/llm4s/metrics/PrometheusMetrics.scala:0:0-0:0) - Added `recordImageGeneration()` method
- [ConsoleTracing.scala](cci:7://file:///c:/Users/singh/Documents/GitHub/llm4ss/modules/core/src/main/scala/org/llm4s/trace/ConsoleTracing.scala:0:0-0:0), [LangfuseTracing.scala](cci:7://file:///c:/Users/singh/Documents/GitHub/llm4ss/modules/core/src/main/scala/org/llm4s/trace/LangfuseTracing.scala:0:0-0:0), [OpenTelemetryTracing.scala](cci:7://file:///c:/Users/singh/Documents/GitHub/llm4ss/modules/trace-opentelemetry/src/main/scala/org/llm4s/trace/OpenTelemetryTracing.scala:0:0-0:0) - Handle new trace events
- [MockMetricsCollector.scala](cci:7://file:///c:/Users/singh/Documents/GitHub/llm4ss/modules/core/src/test/scala/org/llm4s/metrics/MockMetricsCollector.scala:0:0-0:0), [ImageGenerationTest.scala](cci:7://file:///c:/Users/singh/Documents/GitHub/llm4ss/modules/core/src/test/scala/org/llm4s/imagegeneration/ImageGenerationTest.scala:0:0-0:0) - Updated tests
## Features
- **6 Providers**: OpenAI, StableDiffusion, HuggingFace, VertexAI, Bedrock, StabilityAI, FalAI
- **Async APIs**: `generateImageAsync()`, `generateImagesAsync()`, `editImageAsync()`
- **Cost Tracking**: `ImagePricingRegistry` with per-image pricing for all providers
- **Metrics**: Prometheus-compatible metrics for image generation operations
## Testing
- **37 tests passing**
- Unit tests for all configs, factory methods, and pricing lookups
- 
<img width="1194" height="984" alt="Screenshot 2026-02-09 174618" src="https://github.com/user-attachments/assets/491fbcdb-1c40-4140-8977-3a6053f6d8a8" />

