### PR TITLE
fix(providers): extract StreamingToolArgumentParser and normalize ujson.Null boundaries (#504)

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
@@ -239,7 +239,7 @@ curl https://api.anthropic.com/v1/messages \
                       val chunk = StreamedChunk(
                         id = currentMessageId.getOrElse(""),
                         content = None,
-                        toolCall = Some(ToolCall(id = toolUse.id(), name = toolUse.name(), arguments = ujson.Null)),
+                        toolCall = Some(ToolCall(id = toolUse.id(), name = toolUse.name(), arguments = ujson.Obj())),
                         finishReason = None
                       )
                       accumulator.addChunk(chunk)

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/DeepSeekClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/DeepSeekClient.scala
@@ -3,7 +3,7 @@ package org.llm4s.llmconnect.provider
 import org.llm4s.llmconnect.LLMClient
 import org.llm4s.llmconnect.config.DeepSeekConfig
 import org.llm4s.llmconnect.model._
-import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator }
+import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator, StreamingToolArgumentParser }
 import org.llm4s.metrics.MetricsCollector
 import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.types.Result
@@ -176,7 +176,7 @@ class DeepSeekClient(
           ToolCall(
             id = call.obj.get("id").flatMap(_.strOpt).getOrElse(""),
             name = function.obj.get("name").flatMap(_.strOpt).getOrElse(""),
-            arguments = parseStreamingArguments(rawArgs)
+            arguments = StreamingToolArgumentParser.parse(rawArgs)
           )
       }
 
@@ -214,16 +214,6 @@ class DeepSeekClient(
       Seq.empty
     }
   }
-
-  /**
-   * Parse argument JSON from a string, returning the raw string if parsing fails.
-   * This avoids null semantics in Scala code by using an Option-compatible pattern.
-   *
-   * @param raw Raw JSON string to parse
-   * @return Parsed JSON, or raw string if parsing fails
-   */
-  private def parseStreamingArguments(raw: String): ujson.Value =
-    if (raw.isEmpty) ujson.Obj() else scala.util.Try(ujson.read(raw)).getOrElse(ujson.Str(raw))
 
   private[provider] def createRequestBody(conversation: Conversation, options: CompletionOptions): ujson.Obj = {
     val messages = conversation.messages.map {

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenAIClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenAIClient.scala
@@ -444,21 +444,11 @@ class OpenAIClient private (
           ToolCall(
             id = ftc.getId,
             name = function.map(_.getName).getOrElse(""),
-            arguments = parseStreamingArguments(rawArgs)
+            arguments = StreamingToolArgumentParser.parse(rawArgs)
           )
         }
       )
       .getOrElse(Seq.empty)
-
-  /**
-   * Parse argument JSON from a string, returning the raw string if parsing fails.
-   * This avoids null semantics in Scala code by using an Option-compatible pattern.
-   *
-   * @param raw Raw JSON string to parse
-   * @return Parsed JSON, or raw string if parsing fails
-   */
-  private def parseStreamingArguments(raw: String): ujson.Value =
-    if (raw.isEmpty) ujson.Obj() else Try(ujson.read(raw)).getOrElse(ujson.Str(raw))
 
   /**
    * Converts llm4s Conversation to OpenAI ChatRequestMessage format.

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenRouterClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenRouterClient.scala
@@ -4,7 +4,7 @@ import org.llm4s.llmconnect.LLMClient
 import org.llm4s.llmconnect.config.OpenAIConfig
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.serialization.OpenRouterToolCallDeserializer
-import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator }
+import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator, StreamingToolArgumentParser }
 import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.types.Result
 import org.llm4s.error.{ AuthenticationError, ConfigurationError, RateLimitError, ServiceError }
@@ -170,7 +170,7 @@ class OpenRouterClient(
           ToolCall(
             id = call.obj.get("id").flatMap(_.strOpt).getOrElse(""),
             name = function.obj.get("name").flatMap(_.strOpt).getOrElse(""),
-            arguments = parseStreamingArguments(rawArgs)
+            arguments = StreamingToolArgumentParser.parse(rawArgs)
           )
       }
 
@@ -208,16 +208,6 @@ class OpenRouterClient(
       Seq.empty
     }
   }
-
-  /**
-   * Parse argument JSON from a string, returning the raw string if parsing fails.
-   * This avoids null semantics in Scala code by using an Option-compatible pattern.
-   *
-   * @param raw Raw JSON string to parse
-   * @return Parsed JSON, or raw string if parsing fails
-   */
-  private def parseStreamingArguments(raw: String): ujson.Value =
-    if (raw.isEmpty) ujson.Obj() else scala.util.Try(ujson.read(raw)).getOrElse(ujson.Str(raw))
 
   /**
    * Test-visible seam for request serialization; intentionally scoped to provider package to avoid broader API surface.

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/ZaiClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/ZaiClient.scala
@@ -4,7 +4,7 @@ import org.llm4s.util.Redaction
 import org.llm4s.llmconnect.LLMClient
 import org.llm4s.llmconnect.config.ZaiConfig
 import org.llm4s.llmconnect.model._
-import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator }
+import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator, StreamingToolArgumentParser }
 import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.types.Result
 import org.llm4s.error.{ AuthenticationError, ConfigurationError, RateLimitError, ServiceError }
@@ -183,7 +183,7 @@ class ZaiClient(
           ToolCall(
             id = call.obj.get("id").flatMap(_.strOpt).getOrElse(""),
             name = function.obj.get("name").flatMap(_.strOpt).getOrElse(""),
-            arguments = parseStreamingArguments(rawArgs)
+            arguments = StreamingToolArgumentParser.parse(rawArgs)
           )
       }
 
@@ -221,16 +221,6 @@ class ZaiClient(
       Seq.empty
     }
   }
-
-  /**
-   * Parse argument JSON from a string, returning the raw string if parsing fails.
-   * This avoids null semantics in Scala code by using an Option-compatible pattern.
-   *
-   * @param raw Raw JSON string to parse
-   * @return Parsed JSON, or raw string if parsing fails
-   */
-  private[provider] def parseStreamingArguments(raw: String): ujson.Value =
-    if (raw.isEmpty) ujson.Obj() else scala.util.Try(ujson.read(raw)).getOrElse(ujson.Str(raw))
 
   /**
    * Test-visible seam for request serialization; intentionally scoped to provider package to avoid broader API surface.

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/streaming/StreamingAccumulator.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/streaming/StreamingAccumulator.scala
@@ -57,8 +57,10 @@ class StreamingAccumulator {
         toolCall.arguments match {
           case ujson.Str(raw) if raw.nonEmpty =>
             partial.argumentsBuilder.append(raw)
-          case args if args != ujson.Null && args != ujson.Obj() =>
-            partial.argumentsBuilder.append(args.render())
+          case obj: ujson.Obj if obj.obj.nonEmpty =>
+            partial.argumentsBuilder.append(obj.render())
+          case arr: ujson.Arr =>
+            partial.argumentsBuilder.append(arr.render())
           case _ =>
         }
       }

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/streaming/StreamingResponseHandler.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/streaming/StreamingResponseHandler.scala
@@ -132,7 +132,7 @@ class OpenAIStreamingHandler extends BaseStreamingResponseHandler {
             ToolCall(
               id = call.obj.get("id").flatMap(_.strOpt).getOrElse(""),
               name = function.obj.get("name").flatMap(_.strOpt).getOrElse(""),
-              arguments = parseStreamingArguments(rawArgs)
+              arguments = StreamingToolArgumentParser.parse(rawArgs)
             )
         }
 
@@ -173,15 +173,6 @@ class OpenAIStreamingHandler extends BaseStreamingResponseHandler {
       }
     }.getOrElse(Seq.empty)
 
-  /**
-   * Parse argument JSON from a string, returning the raw string if parsing fails.
-   * This avoids null semantics in Scala code by using an Option-compatible pattern.
-   *
-   * @param raw Raw JSON string to parse
-   * @return Parsed JSON, or raw string if parsing fails
-   */
-  private def parseStreamingArguments(raw: String): ujson.Value =
-    if (raw.isEmpty) ujson.Obj() else Try(ujson.read(raw)).getOrElse(ujson.Str(raw))
 }
 
 /**

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/streaming/StreamingToolArgumentParser.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/streaming/StreamingToolArgumentParser.scala
@@ -1,0 +1,16 @@
+package org.llm4s.llmconnect.streaming
+
+import scala.util.Try
+
+/**
+ * Shared boundary parser for streaming tool-call arguments.
+ *
+ * - Empty input yields an empty object sentinel for accumulators.
+ * - Valid JSON is parsed as-is.
+ * - Invalid/partial JSON is preserved as a raw string for later assembly.
+ */
+object StreamingToolArgumentParser {
+
+  def parse(raw: String): ujson.Value =
+    if (raw.isEmpty) ujson.Obj() else Try(ujson.read(raw)).getOrElse(ujson.Str(raw))
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/ZaiClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/ZaiClientSpec.scala
@@ -706,7 +706,7 @@ class ZaiClientTestHelper(config: ZaiConfig) extends ZaiClient(config) {
   }
 
   def testParseStreamingArguments(raw: String): ujson.Value =
-    parseStreamingArguments(raw)
+    org.llm4s.llmconnect.streaming.StreamingToolArgumentParser.parse(raw)
 }
 
 // ============ Metrics Tests ============

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/streaming/StreamingToolArgumentParserTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/streaming/StreamingToolArgumentParserTest.scala
@@ -1,0 +1,26 @@
+package org.llm4s.llmconnect.streaming
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class StreamingToolArgumentParserTest extends AnyFunSuite with Matchers {
+
+  test("empty input returns empty Obj sentinel") {
+    StreamingToolArgumentParser.parse("") shouldBe ujson.Obj()
+  }
+
+  test("valid JSON is parsed as-is") {
+    val result = StreamingToolArgumentParser.parse("""{"location":"SF"}""")
+    result("location").str shouldBe "SF"
+  }
+
+  test("partial/invalid JSON is preserved as raw Str") {
+    val result = StreamingToolArgumentParser.parse("""{"location":""")
+    result shouldBe ujson.Str("""{"location":""")
+  }
+
+  test("valid JSON array is parsed correctly") {
+    val result = StreamingToolArgumentParser.parse("""[1,2,3]""")
+    result.arr.map(_.num.toInt) shouldBe Seq(1, 2, 3)
+  }
+}


### PR DESCRIPTION
## Summary
- Extract shared `StreamingToolArgumentParser.parse()` to deduplicate 5 identical `parseStreamingArguments` methods across provider clients
- Fix `AnthropicClient` returning `ujson.Null` at tool-use content-block-start boundary → `ujson.Obj()`
- Improve `StreamingAccumulator` argument guard to use type-safe pattern matching instead of negative equality checks against `ujson.Null`
- Add unit tests for `StreamingToolArgumentParser` and new accumulator sentinel/fragment tests

## Why
Returning `ujson.Null` introduces null-like semantics into Scala code. Since tool-call arguments are expected to be JSON objects, an empty `ujson.Obj()` is the safer and more consistent sentinel. The 5 identical `parseStreamingArguments` methods across providers were a maintenance burden — extracting them to a shared utility reduces duplication and ensures consistent behavior.

## Changes

### Production code
| File | Change |
|------|--------|
| `StreamingToolArgumentParser.scala` | **New** — shared boundary parser for streaming tool-call arguments |
| `OpenAIClient.scala` | Use shared parser, remove private method |
| `OpenRouterClient.scala` | Use shared parser, remove private method |
| `DeepSeekClient.scala` | Use shared parser, remove private method |
| `ZaiClient.scala` | Use shared parser, remove `private[provider]` method |
| `StreamingResponseHandler.scala` | Use shared parser, remove private method |
| `AnthropicClient.scala` | Fix `ujson.Null` → `ujson.Obj()` at tool-use boundary |
| `StreamingAccumulator.scala` | Type-safe pattern matching for argument accumulation |

### Test code
| File | Change |
|------|--------|
| `StreamingToolArgumentParserTest.scala` | **New** — tests for empty, valid, partial, and array inputs |
| `StreamingAccumulatorTest.scala` | Fix sentinel value, add sentinel-filtering and raw-fragment tests |
| `ZaiClientSpec.scala` | Update test helper to delegate to shared parser |

## Test plan
- [x] All 3452 core tests pass
- [x] `StreamingToolArgumentParser` unit tests pass (4 tests)
- [x] `StreamingAccumulator` tests pass including 2 new tests
- [x] `ZaiClientSpec` parseStreamingArguments helper tests pass
- [x] `sbt scalafmtAll` clean

Closes #504