### PR TITLE
docs: Add new mentors and GSoC aspirant sheets to 2026.md

### DIFF
--- a/Google Summer of Code/GSOC-2026-SUMMARY.md
+++ b/Google Summer of Code/GSOC-2026-SUMMARY.md
@@ -18,7 +18,7 @@ Welcome to the **LLM4S Google Summer of Code 2026** program! We're excited to of
 ## Summary Statistics
 
 - **Total Projects**: 75
-- **Total Mentors**: 35
+- **Total Mentors**: 37
 - **Community Members**: 300+
 - **Project Sizes**:
   - Large (350 hours): 64 projects
@@ -327,6 +327,18 @@ Our mentors are experienced developers and researchers passionate about LLMs, Sc
 35. **Anand Joshi**
 
     - LinkedIn: [linkedin.com/in/anandjoshi1](https://www.linkedin.com/in/anandjoshi1/)
+    - Location: US 🇺🇸
+    - Focus: Scala, LLM systems
+36. **Ullas Bangalore Suresh**
+
+    - LinkedIn: [linkedin.com/in/bsullas](https://www.linkedin.com/in/bsullas/)
+    - Email: bsullas@gmail.com
+    - Location: US 🇺🇸
+    - Focus: Scala, LLM systems
+37. **Abhinav Gupta**
+
+    - LinkedIn: [linkedin.com/in/abhinav-22](https://www.linkedin.com/in/abhinav-22/)
+    - Email: abhinavgupta2206@gmail.com
     - Location: US 🇺🇸
     - Focus: Scala, LLM systems
 

--- a/Google Summer of Code/Project Ideas/2026.md
+++ b/Google Summer of Code/Project Ideas/2026.md
@@ -9,10 +9,15 @@ for [Google Summer of Code 2026](https://summerofcode.withgoogle.com/).
 | --------------------------- | ------------------------------------------------------------------------------- |
 | **Total Projects**    | 75                                                                              |
 | **Community Members** | 300+                                                                            |
-| **Mentors**           | 35+                                                                             |
+| **Mentors**           | 37                                                                              |
+| **GSoC Aspirants**    | 30+ (and growing!)                                                              |
 | **Focus Areas**       | AI Agents, RAG, Data Pipelines, Hardware Design, Travel Planning, Screenwriting |
 
 For a detailed overview of all projects, mentors, and statistics, see the **[GSoC 2026 Summary](../GSOC-2026-SUMMARY.md)**.
+
+### Join Our Growing Community!
+
+Interested contributors from around the world are already preparing for GSoC 2026 with LLM4S. Check out the **[GSoC 2026 Aspirants Spreadsheet](https://docs.google.com/spreadsheets/d/1GzQDQaFCp4iJz8WIMwiooVDk0JWPh6hvODWRzEZRHxY/edit?usp=sharing)** to add your name and connect with fellow aspirants from India, USA, UK, Poland, Egypt, Indonesia, Switzerland, and more!
 
 ---
 
@@ -369,7 +374,7 @@ Looking forward to your contributions to LLM4S!
 | Title                    | LLM Change-data-capture (CDC) for prompts/models                                                                                                                                                                                                                                                                                                                                                                  |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Link to Project          | https://github.com/llm4s/llm4s                                                                                                                                                                                                                                                                                                                                                                                    |
-| Brief Description        | Git-like diff/provenance for prompts/tool schemas/model versions; replay historical runs to detect regressions. A**"git for prompts/models/tools":** capture every change with who/when, show diffs, and replay past runs on new versions to spot regressions.                                                                                                                                              |
+| Brief Description        | Git-like diff/provenance for prompts/tool schemas/model versions; replay historical runs to detect regressions. A**"git for prompts/models/tools":** capture every change with who/when, show diffs, and replay past runs on new versions to spot regressions.                                                                                                                                                    |
 | Expected Outcome         | Versioned store, diff CLI/GUI, replay runner for saved runs/golden sets, regression reports, and trace metadata linking runs to versions. CDC store, diff CLI, replay runner, regression report, integration with agent traces.                                                                                                                                                                                   |
 | Prerequisites            | Scala, git/diff concepts, storage design.                                                                                                                                                                                                                                                                                                                                                                         |
 | Expected Difficulty      | Hard                                                                                                                                                                                                                                                                                                                                                                                                              |


### PR DESCRIPTION
## Description
This PR updates `2026.md` to expand the mentorship team and provide necessary resources for GSoC aspirants.

## Changes
- **Mentors:** Added 2 new mentors to the team roster for the 2026 program.
- **Aspirant Resources:** Integrated the "GSoC Aspirant Sheets" to guide potential contributors and track participation.
- **Formatting:** Updated the personnel section to maintain consistent styling with existing mentor profiles.

## Checklist
- [x] Mentor details (names/contact) are correctly added.
- [x] Aspirant sheets are clearly linked/displayed.
- [x] Formatting checks passed.