### PR TITLE
test: cover provider-prefixed O-series model names

### DIFF
--- a/modules/core/src/test/scala/org/llm4s/model/RequestTransformerSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/model/RequestTransformerSpec.scala
@@ -281,6 +281,7 @@ class RequestTransformerSpec extends AnyFunSuite with Matchers with EitherValues
       ("o1-mini", true),
       ("o3", true),
       ("openai/o1", true),
+      ("openai/o3", true),
       // GPT-5 family requires max_completion_tokens
       ("gpt-5", true),
       ("gpt5", true),


### PR DESCRIPTION
## What does this PR do?

This PR adds a missing unit test case for provider-prefixed O-series model identifiers (e.g. `openai/o1`) in `requiresMaxCompletionTokens`.

This is a small follow up to the review feedback on the earlier PR.

---

## Related issue

Relates to the review comment on PR #537 (follow up coverage improvement).
---
## How was this tested?

- Updated the existing table driven unit test to include `openai/o1`
- Ran the full test suite locally:
```bash
sbt +test
