### PR TITLE
Fix: Close BufferedReaders in startContainer to prevent file descriptor leak

### DIFF
--- a/modules/workspace/workspaceClient/src/main/scala/org/llm4s/workspace/ContainerisedWorkspace.scala
+++ b/modules/workspace/workspaceClient/src/main/scala/org/llm4s/workspace/ContainerisedWorkspace.scala
@@ -12,6 +12,10 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 import java.util.concurrent.{ CompletableFuture, ConcurrentHashMap, Executors, ScheduledExecutorService, TimeUnit }
 import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success, Try }
+import scala.util.Using
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ Future, Await }
+import scala.concurrent.duration._
 
 /**
  * WebSocket-based implementation of ContainerisedWorkspace that communicates with
@@ -170,27 +174,26 @@ class ContainerisedWorkspace(
         s"$workspaceDir:/workspace",
         imageName
       )
-      val process  = pb.start()
+      val process = pb.start()
+
+      // Capture stdout and stderr while process is running(before waitFor)
+      val stdoutF = Future {
+        Using.resource(new BufferedReader(new InputStreamReader(process.getInputStream))) { reader =>
+          Iterator.continually(reader.readLine()).takeWhile(_ != null).mkString("\n")
+        }
+      }
+
+      val stderrF = Future {
+        Using.resource(new BufferedReader(new InputStreamReader(process.getErrorStream))) { reader =>
+          Iterator.continually(reader.readLine()).takeWhile(_ != null).mkString("\n")
+        }
+      }
+
       val exitCode = process.waitFor()
+      val stdout   = Await.result(stdoutF, 30.seconds)
+      val stderr   = Await.result(stderrF, 30.seconds)
 
-      // Capture and log stdout
-      val stdoutReader = new BufferedReader(new InputStreamReader(process.getInputStream))
-      val stdout = try {
-        Iterator.continually(stdoutReader.readLine()).takeWhile(_ != null).mkString("\n")
-      } 
-      finally {
-        stdoutReader.close()
-      }
       if (stdout.nonEmpty) logger.info(s"Docker stdout: $stdout")
-
-      // Capture and log stderr
-      val stderrReader = new BufferedReader(new InputStreamReader(process.getErrorStream))
-      val stderr = try {
-        Iterator.continually(stderrReader.readLine()).takeWhile(_ != null).mkString("\n")
-      } 
-      finally {
-        stderrReader.close()
-      }
       if (stderr.nonEmpty) logger.warn(s"Docker stderr: $stderr")
 
       (exitCode, stdout, stderr)


### PR DESCRIPTION
## Related issue
Fixes #560 

## What does this PR do?
Fixes a small resource leak in ContainerisedWorkspace.startContainer().
The BufferedReader instances used to read Docker process stdout and stderr were not explicitly closed. This could lead to file descriptor exhaustion (java.io.IOException: Too many open files) during repeated container starts in long-running environments.
This PR wraps both readers in try-finally blocks to ensure proper resource cleanup without changing existing behavior.


Before Change Code ->
<img width="1056" height="264" alt="image" src="https://github.com/user-attachments/assets/001923d5-cb67-420d-a427-74ba24238f25" />

After Change Code ->
<img width="930" height="467" alt="image" src="https://github.com/user-attachments/assets/0d9ee3d0-c709-4cc2-9bf7-9d99ee761cf8" />