### PR TITLE
fix: include parentPath in InvalidNesting JSON error payload

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/toolapi/ToolParameterError.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/ToolParameterError.scala
@@ -204,7 +204,8 @@ object ToolCallErrorJson {
         "parameterName" -> name,
         "kind"          -> "invalid_nesting",
         "expectedType"  -> "object",
-        "receivedType"  -> parentType
+        "receivedType"  -> parentType,
+        "parentPath" -> parentPath
       )
 
     case ToolParameterError.MultipleErrors(errors) =>

--- a/modules/core/src/test/scala/org/llm4s/agent/AgentToolFailureTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/AgentToolFailureTest.scala
@@ -598,6 +598,7 @@ class AgentToolFailureTest extends AnyFlatSpec with Matchers with MockFactory {
     pe("kind").str shouldBe "invalid_nesting"
     pe("expectedType").str shouldBe "object"
     pe("receivedType").str shouldBe "array"
+    pe("parentPath").str shouldBe "parent"
   }
 
   // ============================================================================


### PR DESCRIPTION
Adds the parentPath field to the InvalidNesting structured JSON error payload
and updates the corresponding test to verify it.

Fixes #556
