### PR TITLE
build: remove duplicate sbt-scalafmt plugin declaration

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,6 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.0")
 addSbtPlugin("com.github.sbt" % "sbt-dynver"     % "5.1.1")
 // Cross-compilation support
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 // Dependency updates
 addSbtPlugin("org.jmotor.sbt" % "sbt-dependency-updates" % "1.2.9")
 


### PR DESCRIPTION
## What does this PR do?
Removes a duplicate declaration of sbt-scalafmt in project/plugins.sbt.
Keeps the latest version (2.5.4) and removes the older one.
## Related issue
N/A (build configuration cleanup)
## How was this tested?

- sbt clean compile — success
- sbt scalafmtCheckAll — success
- sbt test — success
- No functional changes.

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt +test` — tests pass on both Scala 2.13 and 3.x
- [x] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"
