### PR TITLE
chore: Update Discord community link in GSoC 2026 documentation

### DIFF
--- a/Google Summer of Code/Project Ideas/2026.md
+++ b/Google Summer of Code/Project Ideas/2026.md
@@ -48,7 +48,7 @@ However, here are some rules that we'd like to emphasize since they are not visi
 
 ## Stepwise Instructions to prepare for GSoC 2026 with LLM4S
 
-1. [Join our Discord community.](https://discord.gg/YXSmPjDp)
+1. [Join our Discord community.](https://lnkd.in/e2ifVzPc)
 2. Introduce yourself in the `#introduce-yourself` Discord channel.
 3. [Add your details to the GSoC 2026 Aspirants spreadsheet](https://docs.google.com/spreadsheets/d/1GzQDQaFCp4iJz8WIMwiooVDk0JWPh6hvODWRzEZRHxY/edit?gid=0#gid=0) so that every mentor knows you.
 4. Attend LLM4S Dev Hour:


### PR DESCRIPTION
## What does this PR do?
- Updated the Discord community invitation link in step 1 of the "Stepwise Instructions to prepare for GSoC 2026 with LLM4S" section.

## Related issue
- Fixes #593 

## How was this tested?
- Tests not required

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt +test` — tests pass on both Scala 2.13 and 3.x
- [x] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"