### PR TITLE
Fix file descriptor leaks in stopContainer

### DIFF
--- a/modules/workspace/workspaceClient/src/main/scala/org/llm4s/workspace/ContainerisedWorkspace.scala
+++ b/modules/workspace/workspaceClient/src/main/scala/org/llm4s/workspace/ContainerisedWorkspace.scala
@@ -314,18 +314,24 @@ class ContainerisedWorkspace(
 
     // Execute stop and remove as separate commands
     val stopResult = Try {
-      val process  = Runtime.getRuntime.exec(Array("docker", "stop", containerName))
+      val process = Runtime.getRuntime.exec(Array("docker", "stop", containerName))
+
+      val stderr =
+        Using(scala.io.Source.fromInputStream(process.getErrorStream))(source => source.mkString.trim).getOrElse("")
+
       val exitCode = process.waitFor()
-      val stderr   = scala.io.Source.fromInputStream(process.getErrorStream).mkString.trim
       (exitCode, stderr)
     }
 
     val rmResult = stopResult match {
       case Success((0, _)) =>
         Try {
-          val process  = Runtime.getRuntime.exec(Array("docker", "rm", containerName))
+          val process = Runtime.getRuntime.exec(Array("docker", "rm", containerName))
+
+          val stderr = Using(scala.io.Source.fromInputStream(process.getErrorStream))(source => source.mkString.trim)
+            .getOrElse("")
+
           val exitCode = process.waitFor()
-          val stderr   = scala.io.Source.fromInputStream(process.getErrorStream).mkString.trim
           (exitCode, stderr)
         }
       case Success((_, stderr)) =>


### PR DESCRIPTION
Fixes #595 
## What does this PR do?
This PR fixes a resource leak in the `stopContainer` method where `process.getErrorStream` was being read using `scala.io.Source` without being explicitly closed.

## Changes
Wrapped the stderr reading logic for `docker stop` and `docker rm` in `scala.util.Using` blocks.
- Ensures the underlying input streams are closed immediately after reading.
- Prevents "Too many open files" errors during repeated container operations.
- Ensures stream reading happens before `process.waitFor()` to prevent potential deadlocks.
  
## Location
`modules/workspace/workspaceClient/src/main/scala/org/llm4s/workspace/ContainerisedWorkspace.scala`

## Previous Code 
`val stderr   = scala.io.Source.fromInputStream(process.getErrorStream).mkString.trim`

## Code After Change 
`val stderr = Using(scala.io.Source.fromInputStream(process.getErrorStream))(source => source.mkString.trim)
            .getOrElse("")`

## Image for Reference 
Line 319 - 320 
<img width="922" height="62" alt="image" src="https://github.com/user-attachments/assets/04c97dc9-bf59-4f9c-97b5-65b1a4646d68" />
Line 331 - 332
<img width="922" height="62" alt="image" src="https://github.com/user-attachments/assets/04c97dc9-bf59-4f9c-97b5-65b1a4646d68" />
