### PR TITLE
test: add unit tests for MemoryStats.empty default contract

### DIFF
--- a/modules/core/src/test/scala/org/llm4s/agent/memory/MemoryStatsSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/memory/MemoryStatsSpec.scala
@@ -1,0 +1,23 @@
+package org.llm4s.agent.memory
+
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+
+class MemoryStatsSpec extends AnyWordSpec with Matchers {
+
+  "MemoryStats.empty" should {
+
+    "return the zero/default state" in {
+      val stats = MemoryStats.empty
+
+      stats.totalMemories shouldBe 0L
+      stats.byType shouldBe Map.empty
+      stats.entityCount shouldBe 0L
+      stats.conversationCount shouldBe 0L
+      stats.embeddedCount shouldBe 0L
+      stats.oldestMemory shouldBe None
+      stats.newestMemory shouldBe None
+    }
+
+  }
+}


### PR DESCRIPTION
Closes #613

### Summary
Adds a focused unit test for `MemoryStats.empty` to verify the zero/default state.

### What’s included
- Asserts all default fields:
  - `totalMemories == 0`
  - `byType == Map.empty`
  - `entityCount == 0`
  - `conversationCount == 0`
  - `embeddedCount == 0`
  - `oldestMemory == None`
  - `newestMemory == None`

### Why
This locks in the expected baseline behaviour and protects against accidental regressions in callers that rely on the empty stats contract.

### Scope
Test-only change. No production code modified.

### Notes
Follows the structure and style used in the existing memory manager specs.

### Local verification

Full test suite run after adding the spec:

![Test run output]
<img width="1918" height="1011" alt="image" src="https://github.com/user-attachments/assets/b99997aa-02a3-445d-8713-657c85d40eb7" />

