### PR TITLE
Add reviewdoc support to Claude CI workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,6 @@ jobs:
           set -euo pipefail
 
           trigger_text="$(jq -r '
-            def nonempty: select(. != null and . != "");
             [
               .comment.body?,
               .review.body?,
@@ -67,7 +66,7 @@ jobs:
             exit 1
           fi
 
-          if [[ "$review_doc" == *".."* ]]; then
+          if [[ "$review_doc" == *"/../"* ]] || [[ "$review_doc" == "../"* ]] || [[ "$review_doc" == *"/.." ]]; then
             echo "Path traversal is not allowed for --reviewdoc: $review_doc" >&2
             exit 1
           fi


### PR DESCRIPTION
Validate reviewdoc path and parse trigger text safely Build enforced prompt from selected guideline file

## What does this PR do?
<!-- Brief description of the change and WHY it's needed -->

## Related issue
<!-- Link the issue this addresses: Fixes #XXX or Relates to #XXX -->

## How was this tested?
<!-- Describe what you tested and how. Include relevant commands or test names. -->

## Checklist

- [ ] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [ ] PR is small and focused — one change, one reason
- [ ] `sbt scalafmtAll` — code is formatted
- [ ] `sbt +test` — tests pass on both Scala 2.13 and 3.x
- [ ] New code includes tests
- [ ] No unrelated changes included (branched from `main`, not from another PR)
- [ ] Commit messages explain the "why"
