### PR TITLE
docs: Update GSoC 2026 spreadsheet link

### DIFF
--- a/Google Summer of Code/Project Ideas/2026.md
+++ b/Google Summer of Code/Project Ideas/2026.md
@@ -8,7 +8,7 @@ for [Google Summer of Code 2026](https://summerofcode.withgoogle.com/).
 | **Total Projects**    | 77                                                                                                                       |
 | **Community Members** | 300+                                                                                                                      |
 | **Mentors**           | 50+ (from 10+ countries)                                                                                                  |
-| **GSoC Aspirants**    | 30+ (and growing!) · [Aspirants Spreadsheet](https://docs.google.com/spreadsheets/d/1GzQDQaFCp4iJz8WIMwiooVDk0JWPh6hvODWRzEZRHxY/edit?usp=sharing)  |
+| **GSoC Aspirants**    | 30+ (and growing!) · [Aspirants Spreadsheet](https://docs.google.com/spreadsheets/d/1TBjYy1P64dPe_6Am4C0AmBFzOp45XBpgIyRDrxqat7E/edit?usp=sharing)  |
 | **Focus Areas**       | AI Agents, RAG, Data Pipelines, Hardware Design, Developer Tools                                                          |
 | **LLM4S Foundation**  | [llm4s.org/foundation](https://llm4s.org/foundation/)                                                                        |
 
@@ -16,7 +16,7 @@ For a detailed overview of all projects, mentors, and statistics, see the **[GSo
 
 ### Join Our Growing Community!
 
-Interested contributors from around the world are already preparing for GSoC 2026 with LLM4S. Check out the **[GSoC 2026 Aspirants Spreadsheet](https://docs.google.com/spreadsheets/d/1GzQDQaFCp4iJz8WIMwiooVDk0JWPh6hvODWRzEZRHxY/edit?usp=sharing)** to add your name and connect with fellow aspirants from India, USA, UK, Poland, Egypt, Indonesia, Switzerland, and more!
+Interested contributors from around the world are already preparing for GSoC 2026 with LLM4S. Check out the **[GSoC 2026 Aspirants Spreadsheet](https://docs.google.com/spreadsheets/d/1TBjYy1P64dPe_6Am4C0AmBFzOp45XBpgIyRDrxqat7E/edit?usp=sharing)** to add your name and connect with fellow aspirants from India, USA, UK, Poland, Egypt, Indonesia, Switzerland, and more!
 
 ---
 
@@ -56,7 +56,7 @@ However, here are some rules that we'd like to emphasize since they are not visi
 
 1. [Join our Discord community.](https://lnkd.in/e2ifVzPc)
 2. Introduce yourself in the `#introduce-yourself` Discord channel.
-3. [Add your details to the GSoC 2026 Aspirants spreadsheet](https://docs.google.com/spreadsheets/d/1GzQDQaFCp4iJz8WIMwiooVDk0JWPh6hvODWRzEZRHxY/edit?gid=0#gid=0) so that every mentor knows you.
+3. [Add your details to the GSoC 2026 Aspirants spreadsheet](https://docs.google.com/spreadsheets/d/1TBjYy1P64dPe_6Am4C0AmBFzOp45XBpgIyRDrxqat7E/edit?usp=sharing) so that every mentor knows you.
 4. Attend LLM4S Dev Hour:
    - We meet every Sunday 9am London time! (Weekly changing link for [LLM4S Dev Hours](https://luma.com/calendar/cal-Zd9BLb5jbZewxLA))
    - [Subscribe to add all 2026 Dev Hour events to your Google Calendar.](https://api2.luma.com/ics/get?entity=calendar&id=cal-Zd9BLb5jbZewxLA)


### PR DESCRIPTION
## What does this PR do?
This PR updates the embedded spreadsheet link in the GSoC 2026 documentation to ensure contributors and aspirants are directed to the most current tracking sheet. 

## Related issue
Relates to GSoC 2026 Aspirant Tracking

## How was this tested?
- **Link Verification:** Clicked the newly added spreadsheet link in the markdown preview to confirm it successfully routes to the correct destination with the appropriate viewing permissions.

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted (N/A - Docs only)
- [x] `sbt +test` — tests pass on both Scala 2.13 and 3.x (N/A - No code changes)
- [x] New code includes tests (N/A)
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"