### PR TITLE
[BUG] : Fix swapped parameters in ToolMessage pattern match in TraceHelper.scala

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/model/TraceHelper.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/model/TraceHelper.scala
@@ -130,7 +130,7 @@ object TraceHelper {
         )
       )
 
-    case tm @ ToolMessage(toolCallId, content) =>
+    case tm @ ToolMessage(content, toolCallId) =>
       val toolCallName = tm.findToolCallName(contextMessages)
       wrapper(
         uuid,


### PR DESCRIPTION
Fixes : #667 
## What does this PR do?
`TraceHelper.scala` has the same swapped-parameter bug that was fixed in PR #646 for OpenRouterClient and ZaiClient.
The `ToolMessage` case class is defined as `ToolMessage(content, toolCallId)`, but the pattern match at line 133 destructures it as `ToolMessage(toolCallId, content)` — parameters are in the wrong order.
 
Related with :
- Fixed for OpenRouter/ZaiClient in PR #646: "BUG: Fix tool message serialization for OpenRouter and Z.ai clients"

## Current (incorrect):
- `case tm @ ToolMessage(content, toolCallId) =>`

## Fixed :
- `case tm @ ToolMessage(toolCallId,content) =>`

<img width="533" height="25" alt="image" src="https://github.com/user-attachments/assets/25c0073a-2f61-473e-8073-d53fbc7dc4cd" />