### PR TITLE
docs: Update Google Gemini provider status to Complete

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -297,7 +297,7 @@ Explore **69 working examples** covering all features:
 | **Anthropic** | ✅ Complete | Claude 3.5, Claude 3 |
 | **Azure OpenAI** | ✅ Complete | All Azure-hosted models |
 | **Ollama** | ✅ Complete | Llama, Mistral, local models |
-| **Google Gemini** | 🚧 Planned | Coming soon |
+| **Google Gemini** | ✅ Complete | Gemini 2.0, 1.5 Pro/Flash |
 | **Cohere** | 🚧 Planned | Coming soon |
 
 ---


### PR DESCRIPTION
## What does this PR do?
Change the main documentation page that incorrectly shows Google Gemini as "🚧 Planned | Coming soon" despite being fully implemented.
- Update provider comparison table to show Gemini as "✅ Complete | Gemini 2.0, 1.5 Pro/Flash".


## Related issue
https://github.com/llm4s/llm4s/issues/690

## How was this tested?
-  [configuration.md](docs/getting-started/configuration.md) has complete Gemini setup examples
-  [roadmap.md](docs/roadmap.md) shows Gemini as "✅ Complete"
-  GeminiClient.scala fully implemented with all features

## Note
Cohere intentionally kept as "Planned" - CohereClient is marked as "Minimal" (basic chat only, no streaming/tools/embeddings/multimodal)

## Checklist

- [X ] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [X ] PR is small and focused — one change, one reason
- [X ] `sbt scalafmtAll` — code is formatted
- [X ] `sbt +test` — tests pass on both Scala 2.13 and 3.x
- [ ] New code includes tests
- [X ] No unrelated changes included (branched from `main`, not from another PR)
- [X ] Commit messages explain the "why"
