### PR TITLE
Fix broken documentation links

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -19,10 +19,9 @@ The **[Scaladoc](/scaladoc/)** provides comprehensive, auto-generated API docume
 
 | Document | Description |
 |----------|-------------|
-| [LLM4S API Spec](/reference/llm4s-api-spec) | Complete API specification |
-| [Tool Calling API Design](/design/tool-calling-api-design) | Tool calling interface design |
-
-|[Workspace Agent Protocol](/workspace-agent-protocol)| Standardized interface for LLM workspace interaction |
+| [LLM4S API Spec](../llm4s-api-spec) | Complete API specification |
+| [Tool Calling API Design](../tool-calling-api-design) | Tool calling interface design |
+| [Workspace Agent Protocol](../workspace-agent-protocol) | Standardized interface for LLM workspace interaction |
 
 ## API Design Principles
 

--- a/docs/llm4s-api-spec.md
+++ b/docs/llm4s-api-spec.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: LLM4S API Specification
+parent: API Reference
+---
+
 # LLM4S API Specification
 
 ## Overview

--- a/docs/tool-calling-api-design.md
+++ b/docs/tool-calling-api-design.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Tool Calling API Design
+parent: API Reference
+---
+
 # Scala Tool Calling API Design
 
 This document outlines the design for a type-safe Scala API for defining, validating, and executing tool calls for LLMs. It provides a clean, functional approach to tool function definitions with JSON Schema validation.


### PR DESCRIPTION
- Add jekyll front matter
- Update links

## What does this PR do?
This PR fixes broken documentation links in the API documentation pages. It adds missing Jekyll front matter to documentation files and updates broken internal links, ensuring proper navigation in the generated documentation site.
## Related issue
#701 

## How was this tested?
- Verified the documentation builds successfully with Jekyll
- Manually checked that all updated links resolve correctly
- Confirmed the following files now display properly:
  - docs/api/index.md
  - docs/llm4s-api-spec.md
  - docs/tool-calling-api-design.md
## Checklist

- [X ] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [X ] PR is small and focused — one change, one reason
- [X ] `sbt scalafmtAll` — code is formatted
- [X ] `sbt +test` — tests pass on both Scala 2.13 and 3.x
- [ ] New code includes tests
- [X ] No unrelated changes included (branched from `main`, not from another PR)
- [X ] Commit messages explain the "why"
