### PR TITLE
test: add missing ContextWindowResolver and provider fallback coverage

### DIFF
--- a/modules/core/src/test/scala/org/llm4s/llmconnect/config/ProviderConfigFallbackSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/config/ProviderConfigFallbackSpec.scala
@@ -135,4 +135,58 @@ class ProviderConfigFallbackSpec extends AnyFlatSpec with Matchers {
     cfg.contextWindow shouldBe 128000
     cfg.reserveCompletion shouldBe 8192
   }
+
+  "OllamaConfig fallback" should "return 4096 for llama2-like model" in {
+    val cfg = OllamaConfig.fromValues("patch-cov-llama2", baseUrl)
+    cfg.contextWindow shouldBe 4096
+    cfg.reserveCompletion shouldBe 4096
+  }
+
+  it should "return 8192 for llama3-like model" in {
+    val cfg = OllamaConfig.fromValues("patch-cov-llama3", baseUrl)
+    cfg.contextWindow shouldBe 8192
+    cfg.reserveCompletion shouldBe 4096
+  }
+
+  it should "return 16384 for codellama-like model" in {
+    val cfg = OllamaConfig.fromValues("patch-cov-codellama", baseUrl)
+    cfg.contextWindow shouldBe 16384
+    cfg.reserveCompletion shouldBe 4096
+  }
+
+  it should "return 32768 for mistral-like model" in {
+    val cfg = OllamaConfig.fromValues("patch-cov-mistral", baseUrl)
+    cfg.contextWindow shouldBe 32768
+    cfg.reserveCompletion shouldBe 4096
+  }
+
+  it should "return 8192 for unknown model" in {
+    val cfg = OllamaConfig.fromValues("patch-cov-unknown", baseUrl)
+    cfg.contextWindow shouldBe 8192
+    cfg.reserveCompletion shouldBe 4096
+  }
+
+  "ZaiConfig fallback" should "return 128000 for GLM-4.7-like model" in {
+    val cfg = ZaiConfig.fromValues("patch-cov-GLM-4.7", apiKey, baseUrl)
+    cfg.contextWindow shouldBe 128000
+    cfg.reserveCompletion shouldBe 4096
+  }
+
+  it should "return 32000 for GLM-4.5-like model" in {
+    val cfg = ZaiConfig.fromValues("patch-cov-GLM-4.5", apiKey, baseUrl)
+    cfg.contextWindow shouldBe 32000
+    cfg.reserveCompletion shouldBe 4096
+  }
+
+  it should "return 128000 for unknown model" in {
+    val cfg = ZaiConfig.fromValues("patch-cov-unknown", apiKey, baseUrl)
+    cfg.contextWindow shouldBe 128000
+    cfg.reserveCompletion shouldBe 4096
+  }
+
+  "CohereConfig fallback" should "return 128000 for any unregistered model" in {
+    val cfg = CohereConfig.fromValues("patch-cov-unknown", apiKey, baseUrl)
+    cfg.contextWindow shouldBe 128000
+    cfg.reserveCompletion shouldBe 4096
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #682 (Centralize Provider Context-Window Resolution), addressing the test coverage gaps noted in the review.

- **`ContextWindowResolverSpec`**: added registry *hit path* tests — one where the registered model has token data (expects that data to be used) and one where it has no token data (expects `defaultContextWindow`/`defaultReserve` to be used). Added `BeforeAndAfterEach` with `ModelRegistry.reset()` for test isolation.
- **`ProviderConfigFallbackSpec`**: added missing fallback tests for the three providers that were untested:
  - `OllamaConfig` — llama2 (4096), llama3 (8192), codellama (16384), mistral (32768), unknown (8192)
  - `ZaiConfig` — GLM-4.7 (128000), GLM-4.5 (32000), unknown (128000)
  - `CohereConfig` — unknown → default 128000

## Test plan

- [x] `sbt "core/testOnly org.llm4s.llmconnect.config.ContextWindowResolverSpec org.llm4s.llmconnect.config.ProviderConfigFallbackSpec"` — all 34 tests pass
- [x] Full `sbt +test` (pre-commit hook) — 3665 tests pass, 0 failures