### PR TITLE
docs: Add Java 16+ .jvmopts fix for sbt-dotenv InaccessibleObjectException

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -145,6 +145,9 @@ sbt run
 
 **Option 2: Use sbt-dotenv plugin**
 
+{: .warning }
+**Java 16+ Compatibility Issue:** The sbt-dotenv plugin can cause a `java.lang.reflect.InaccessibleObjectException` at startup on Java 16+ due to module system restrictions. Use **Option 1** or **Option 3** as alternatives, or apply the fix below.
+
 Add to `project/plugins.sbt`:
 
 ```scala
@@ -152,6 +155,15 @@ addSbtPlugin("au.com.onegeek" %% "sbt-dotenv" % "2.1.233")
 ```
 
 Variables automatically load when SBT starts!
+
+**Java 16+ Fix:** If you see `InaccessibleObjectException`, create (or add to) `.jvmopts` in your project root:
+
+```
+--add-opens=java.base/java.lang=ALL-UNNAMED
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+```
+
+Restart sbt after adding this file. This grants the plugin the reflective access it needs and works on all platforms.
 
 **Option 3: IntelliJ IDEA**
 


### PR DESCRIPTION
## What does this PR do?
- Add warning about java.lang.reflect.InaccessibleObjectException on Java 16+
- Document .jvmopts fix as primary cross-platform solution under Option 2

## Related issue
Replaces PR#688, addresses maintainer feedback


## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt +test` — tests pass on both Scala 2.13 and 3.x
- [ ] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"
