### PR TITLE
fix: pass optional user and password to pgvector config

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/vectorstore/VectorStoreFactory.scala
+++ b/modules/core/src/main/scala/org/llm4s/vectorstore/VectorStoreFactory.scala
@@ -114,20 +114,23 @@ object VectorStoreFactory {
      * @param connectionString JDBC connection string (jdbc:postgresql://...)
      * @param tableName Optional table name (default: "vectors")
      */
-    def pgvector(connectionString: String,
-                 tableName: String = "vectors",
-                 user: Option[String] = None,
-                 password: Option[String] = None): Config ={
+    def pgvector(
+      connectionString: String,
+      tableName: String = "vectors",
+      user: Option[String] = None,
+      password: Option[String] = None
+    ): Config = {
       val baseOptions = Map("tableName" -> tableName)
-  
+
       // ++ appends to the map.
       // .map transforms the Option into a key-value pair IF it exists.
-      val finalOptions = baseOptions ++ 
-        user.map("user" -> _) ++ 
+      val finalOptions = baseOptions ++
+        user.map("user" -> _) ++
         password.map("password" -> _)
-    
+
       Config(Backend.PgVector, Some(connectionString), options = finalOptions)
-      }
+    }
+
     /**
      * Configuration for local Qdrant.
      *


### PR DESCRIPTION
What does this PR do?

Updates the VectorStoreFactory.Config.pgvector helper method to accept optional user and password parameters.
Why is this necessary?

Currently, there is a gap between the Config helper and the actual PgVectorStore creation. If a user uses the Config.pgvector() method, the options map is hardcoded to only contain the tableName.

Later, when create(config) is called, it attempts to read user and password from config.options. Because they were never added by the helper method, it falls back to the defaults (postgres and ""), effectively locking users out of connecting to a remote Postgres database that requires a password.
How was this fixed?

Added the parameters to the helper method and used .map with map concatenation (++) to dynamically append the credentials to the options map if they are provided, keeping the configuration strictly immutable.
Testing

Ran a full sbt clean compile test. All 3959 tests passed locally.