### PR TITLE
test: add concurrent execution tests for CircuitBreaker functionality

### DIFF
--- a/modules/core/src/test/scala/org/llm4s/error/ErrorRecoverySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/error/ErrorRecoverySpec.scala
@@ -4,11 +4,9 @@ import org.llm4s.Result
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.util.concurrent.{ CyclicBarrier, CountDownLatch, Executors, TimeUnit }
-import java.util.concurrent.atomic.AtomicInteger
-import scala.concurrent.duration._
 import java.util.concurrent.{ CountDownLatch, CyclicBarrier, Executors, TimeUnit }
 import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.duration._
 
 /**
  * Tests for ErrorRecovery utilities: backoff retry logic and CircuitBreaker pattern


### PR DESCRIPTION
## What does this PR do?
Add 11 new tests:
- "CircuitBreaker under concurrent load" — 4 tests
- "CircuitBreaker HalfOpen re-open" — 3 tests
- "CircuitBreaker timeout boundary" — 4 tests

## Related issue
https://github.com/llm4s/llm4s/issues/738

## How was this tested?
- sbt scalafmtAll
- sbt "core/testOnly org.llm4s.error.ErrorRecoverySpec"

All 29 tests pass (18 existing + 11 new)

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt +test` — tests pass on both Scala 2.13 and 3.x
- [x] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"
