### PR TITLE
fix: add safe embedding validation to embedBatch with provider context

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/rag/RAG.scala
+++ b/modules/core/src/main/scala/org/llm4s/rag/RAG.scala
@@ -950,7 +950,27 @@ final class RAG private (
 
   private def embedBatch(texts: Seq[String]): Result[Seq[Array[Float]]] = {
     val request = EmbeddingRequest(texts, embeddingModelConfig)
-    tracedEmbeddingClient.embed(request).map(_.embeddings.map(_.map(_.toFloat).toArray))
+    tracedEmbeddingClient.embed(request).flatMap { response =>
+      if (response.embeddings.isEmpty) {
+        Left(
+          EmbeddingError(
+            None,
+            "Embedding provider returned empty embeddings list",
+            embeddingModelConfig.name
+          )
+        )
+      } else if (response.embeddings.length != texts.length) {
+        Left(
+          EmbeddingError(
+            None,
+            s"Embedding provider returned ${response.embeddings.length} embeddings for batch of ${texts.length} texts",
+            embeddingModelConfig.name
+          )
+        )
+      } else {
+        Right(response.embeddings.map(_.map(_.toFloat).toArray))
+      }
+    }
   }
 
   private def searchWithStrategy(

--- a/modules/core/src/test/scala/org/llm4s/rag/RAGWithMocksSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/rag/RAGWithMocksSpec.scala
@@ -285,6 +285,36 @@ class RAGWithMocksSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach
     }
   }
 
+  /**
+   * Mock EmbeddingProvider that returns empty embeddings list.
+   * Used to test empty embeddings error handling.
+   */
+  class EmptyEmbeddingProvider extends EmbeddingProvider {
+    override def embed(request: EmbeddingRequest): Result[EmbeddingResponse] =
+      Right(
+        EmbeddingResponse(
+          embeddings = Seq.empty,
+          usage = Some(EmbeddingUsage(0, 0))
+        )
+      )
+  }
+
+  /**
+   * Mock EmbeddingProvider that returns mismatched embeddings count.
+   * Used to test cardinality validation.
+   */
+  class MismatchedEmbeddingProvider(returnCount: Int) extends EmbeddingProvider {
+    override def embed(request: EmbeddingRequest): Result[EmbeddingResponse] = {
+      val embeddings = (0 until returnCount).map(i => (0 until 3).map(j => ((i + j) % 100) / 100.0).toSeq)
+      Right(
+        EmbeddingResponse(
+          embeddings = embeddings,
+          usage = Some(EmbeddingUsage(request.input.map(_.length).sum, request.input.map(_.length).sum))
+        )
+      )
+    }
+  }
+
   // ==========================================================================
   // Test Fixtures
   // ==========================================================================
@@ -563,6 +593,72 @@ class RAGWithMocksSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach
     result.isRight shouldBe true
     val results = result.toOption.get
     results.size should be <= 3
+  }
+
+  // ==========================================================================
+  // Embedding Batch Tests
+  // ==========================================================================
+
+  "RAG.embedBatch" should "return EmbeddingError when provider returns empty embeddings list" in {
+    val emptyProvider   = new EmptyEmbeddingProvider()
+    val embeddingClient = new EmbeddingClient(emptyProvider)
+
+    val config = RAGConfig.default
+    val rag    = RAG.buildWithClient(config, embeddingClient).toOption.get
+
+    // embedBatch is private, so we test it through ingestText with a provider that returns empty
+    val result = rag.ingestText("Test content", "doc1")
+
+    result.fold(
+      error => {
+        error shouldBe an[EmbeddingError]
+        error.message should include("empty embeddings")
+        val embError = error.asInstanceOf[EmbeddingError]
+        embError.provider should not be "unknown"
+        embError.provider shouldBe "text-embedding-3-small"
+      },
+      _ => fail("Expected EmbeddingError for empty embeddings")
+    )
+  }
+
+  it should "return EmbeddingError when embeddings count doesn't match batch size" in {
+    val mismatchedProvider = new MismatchedEmbeddingProvider(returnCount = 1)
+    val embeddingClient    = new EmbeddingClient(mismatchedProvider)
+
+    val config = RAGConfig.default
+    val rag    = RAG.buildWithClient(config, embeddingClient).toOption.get
+
+    // Try to ingest multiple chunks but provider only returns 1 embedding
+    val result = rag.ingestChunks(
+      "doc1",
+      Seq("Chunk 1", "Chunk 2")
+    )
+
+    result.fold(
+      error => {
+        error shouldBe an[EmbeddingError]
+        error.message should include("2 texts")
+        error.message should include("1 embedding")
+        val embError = error.asInstanceOf[EmbeddingError]
+        embError.provider should not be "unknown"
+        embError.provider shouldBe "text-embedding-3-small"
+      },
+      _ => fail("Expected EmbeddingError for mismatched embeddings count")
+    )
+  }
+
+  it should "succeed when embeddings count matches batch size" in {
+    val rag = createMockRAG().toOption.get
+
+    val result = rag.ingestChunks(
+      "doc1",
+      Seq("Chunk 1", "Chunk 2", "Chunk 3")
+    )
+
+    result.fold(
+      error => fail(s"Expected success but got error: ${error.message}"),
+      count => count shouldBe 3
+    )
   }
 
   "RAG.queryWithAnswer" should "fail without LLM client" in {


### PR DESCRIPTION


## What does this PR do?
Fixes unsafe `.map()` operation in `RAG.embedBatch` that could silently fail if embedding provider returns empty or mismatched embeddings list.

**Changes:**
- Replace unsafe `.map(_.embeddings.map(...))` with proper validation in `embedBatch`
- Validate embeddings list is non-empty → return typed `EmbeddingError` instead of silent failure
- Validate embeddings count matches batch size → catch provider mismatches early
- Include provider/model context in error messages for production observability (not hardcoded "unknown")
- Use `flatMap` with explicit `Left`/`Right` handling for Result type consistency

**Why it's needed:**
This fix addresses a data integrity issue where embedding provider failures could go undetected during document ingestion. If a provider returns fewer embeddings than texts (or an empty list), the current code silently produces wrong data. The fix ensures:
- **Type safety**: Proper `Result[Seq[Array[Float]]]` with error context
- **Observability**: Error messages include provider model name for triaging in production
- **Consistency**: Aligns with similar fixes already applied to `embedQuery` and `RAGPipeline.search`

## Related issue
#740 
## How was this tested?
**Unit Tests Added (3 new tests in RAGWithMocksSpec):**
1. `RAG.embedBatch should "return EmbeddingError when provider returns empty embeddings list"`
   - Uses `EmptyEmbeddingProvider` mock
   - Asserts `EmbeddingError` with error message includes "empty embeddings"
   - Asserts provider field equals "text-embedding-3-small" (not "unknown")

2. `should "return EmbeddingError when embeddings count doesn't match batch size"`
   - Uses `MismatchedEmbeddingProvider` (returns 1 embedding for 2 texts)
   - Tests through `ingestChunks` operation
   - Asserts error message includes both requested count (2) and returned count (1)
   - Asserts provider field correctly identifies the model

3. `should "succeed when embeddings count matches batch size"`
   - Tests success path with 3 chunks
   - Asserts proper ingestion when everything is correct
## Checklist

- [X ] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [ X] PR is small and focused — one change, one reason
- [X ] `sbt scalafmtAll` — code is formatted
- [X ] `sbt +test` — tests pass on both Scala 2.13 and 3.x
- [X ] New code includes tests
- [X ] No unrelated changes included (branched from `main`, not from another PR)
- [ X] Commit messages explain the "why"
