### PR TITLE
refactor: remove deprecated throwing APIs and migrate callers to Safe variants

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/agent/Agent.scala
+++ b/modules/core/src/main/scala/org/llm4s/agent/Agent.scala
@@ -198,30 +198,6 @@ class Agent(client: LLMClient) {
   }
 
   /**
-   * Initializes a new agent state with the given query.
-   *
-   * @param query The user query to process
-   * @param tools The registry of available tools
-   * @param handoffs Available handoffs (default: none)
-   * @param systemPromptAddition Optional additional text to append to the default system prompt
-   * @param completionOptions Optional completion options for LLM calls (temperature, maxTokens, etc.)
-   * @return A new AgentState initialized with the query and tools
-   * @throws IllegalStateException if initialization fails
-   */
-  @deprecated("Use initializeSafe() which returns Result[AgentState] for safe error handling", "0.2.9")
-  def initialize(
-    query: String,
-    tools: ToolRegistry,
-    handoffs: Seq[Handoff] = Seq.empty,
-    systemPromptAddition: Option[String] = None,
-    completionOptions: CompletionOptions = CompletionOptions()
-  ): AgentState =
-    initializeSafe(query, tools, handoffs, systemPromptAddition, completionOptions) match {
-      case Right(state) => state
-      case Left(e)      => throw new IllegalStateException(s"Agent.initialize failed: ${e.formatted}")
-    }
-
-  /**
    * Runs a single step of the agent's reasoning process
    */
   def runStep(state: AgentState, context: AgentContext = AgentContext.Default): Result[AgentState] =
@@ -1150,7 +1126,8 @@ class Agent(client: LLMClient) {
    * val result = for {
    *   providerCfg <- /* load provider config */
    *   client      <- org.llm4s.llmconnect.LLMConnect.getClient(providerCfg)
-   *   tools       = new ToolRegistry(Seq(WeatherTool.tool))
+   *   tool        <- WeatherTool.toolSafe
+   *   tools       = new ToolRegistry(Seq(tool))
    *   agent       = new Agent(client)
    *   state1     <- agent.run("What's the weather in Paris?", tools)
    *   state2     <- agent.continueConversation(state1, "And in London?")

--- a/modules/core/src/main/scala/org/llm4s/toolapi/AzureToolHelper.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/AzureToolHelper.scala
@@ -34,7 +34,7 @@ object AzureToolHelper {
   def convertToolRegistryToAzureTools(
     toolRegistry: ToolRegistry
   ): java.util.List[ChatCompletionsToolDefinition] = {
-    val toolsJson = toolRegistry.getToolDefinitions("openai")
+    val toolsJson = toolRegistry.getToolDefinitionsSafe("openai").getOrElse(ujson.Arr())
 
     val tools = new java.util.ArrayList[ChatCompletionsToolDefinition]()
     for (toolObj <- toolsJson.arr) {

--- a/modules/core/src/main/scala/org/llm4s/toolapi/ToolFunction.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/ToolFunction.scala
@@ -119,16 +119,6 @@ class ToolBuilder[T, R: ReadWriter] private (
     case None    => Left(ValidationError("handler", "must be defined before calling build()"))
   }
 
-  /**
-   * Build the tool function, throwing on failure.
-   *
-   * @throws IllegalStateException if handler is not defined
-   */
-  @deprecated("Use buildSafe() which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  def build(): ToolFunction[T, R] = handler match {
-    case Some(h) => ToolFunction(name, description, schema, h)
-    case None    => throw new IllegalStateException("Handler not defined")
-  }
 }
 
 object ToolBuilder {

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/BuiltinTools.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/BuiltinTools.scala
@@ -23,12 +23,12 @@ import org.llm4s.types.Result
  *
  * // Safe tools for production use
  * for {
- *   tools <- BuiltinTools.safe()
+ *   tools <- BuiltinTools.withHttpSafe()
  * } yield new ToolRegistry(tools)
  *
  * // Development tools with file and shell access
  * for {
- *   tools <- BuiltinTools.development(
+ *   tools <- BuiltinTools.developmentSafe(
  *     workingDirectory = Some("/home/user/project")
  *   )
  * } yield new ToolRegistry(tools)
@@ -54,18 +54,6 @@ object BuiltinTools {
   } yield Seq(dateTime, calculator, uuid, json)
 
   /**
-   * Core utility tools (always safe, no external dependencies).
-   *
-   * @throws IllegalStateException if any tool initialization fails
-   */
-  @deprecated("Use coreSafe which returns Result[Seq[ToolFunction]] for safe error handling", "0.2.9")
-  def core: Seq[ToolFunction[_, _]] =
-    coreSafe match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"BuiltinTools.core failed: ${e.formatted}")
-    }
-
-  /**
    * Safe tools for production use, returning a Result for safe error handling.
    *
    * Includes:
@@ -81,18 +69,6 @@ object BuiltinTools {
     coreTools <- coreSafe
     httpTool  <- HTTPTool.createSafe(httpConfig)
   } yield coreTools :+ httpTool
-
-  /**
-   * Safe tools for production use.
-   *
-   * @throws IllegalStateException if any tool initialization fails
-   */
-  @deprecated("Use withHttpSafe() which returns Result[Seq[ToolFunction]] for safe error handling", "0.2.9")
-  def safe(httpConfig: HttpConfig = HttpConfig.readOnly()): Seq[ToolFunction[_, _]] =
-    withHttpSafe(httpConfig) match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"BuiltinTools.safe failed: ${e.formatted}")
-    }
 
   /**
    * Safe tools plus read-only file system access,
@@ -115,21 +91,6 @@ object BuiltinTools {
     listDir   <- ListDirectoryTool.createSafe(fileConfig)
     fileInfo  <- FileInfoTool.createSafe(fileConfig)
   } yield safeTools ++ Seq(readFile, listDir, fileInfo)
-
-  /**
-   * Safe tools plus read-only file system access.
-   *
-   * @throws IllegalStateException if any tool initialization fails
-   */
-  @deprecated("Use withFilesSafe() which returns Result[Seq[ToolFunction]] for safe error handling", "0.2.9")
-  def withFiles(
-    fileConfig: FileConfig = FileConfig(),
-    httpConfig: HttpConfig = HttpConfig.readOnly()
-  ): Seq[ToolFunction[_, _]] =
-    withFilesSafe(fileConfig, httpConfig) match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"BuiltinTools.withFiles failed: ${e.formatted}")
-    }
 
   /**
    * Development tools with full read/write and shell access,
@@ -170,26 +131,6 @@ object BuiltinTools {
       shell     <- ShellTool.createSafe(shellConfig)
     } yield coreTools ++ Seq(httpTool, readFile, listDir, fileInfo, writeFile, shell)
   }
-
-  /**
-   * Development tools with full read/write and shell access.
-   *
-   * WARNING: These tools have significant access to the system.
-   * Use only in trusted development environments.
-   *
-   * @param workingDirectory Optional working directory for file/shell operations
-   * @param fileAllowedPaths Allowed paths for file write operations
-   * @throws IllegalStateException if any tool initialization fails
-   */
-  @deprecated("Use developmentSafe() which returns Result[Seq[ToolFunction]] for safe error handling", "0.2.9")
-  def development(
-    workingDirectory: Option[String] = None,
-    fileAllowedPaths: Seq[String] = Seq("/tmp")
-  ): Seq[ToolFunction[_, _]] =
-    developmentSafe(workingDirectory, fileAllowedPaths) match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"BuiltinTools.development failed: ${e.formatted}")
-    }
 
   /**
    * Custom tool set with full configuration control,
@@ -237,24 +178,4 @@ object BuiltinTools {
     } yield coreTools ++ httpTools ++ fileTools ++ writeTools ++ shellTools
   }
 
-  /**
-   * Custom tool set with full configuration control.
-   *
-   * @param fileConfig Configuration for read operations
-   * @param writeConfig Optional write configuration (if None, write tool is not included)
-   * @param httpConfig HTTP configuration
-   * @param shellConfig Optional shell configuration (if None, shell tool is not included)
-   * @throws IllegalStateException if any tool initialization fails
-   */
-  @deprecated("Use customSafe() which returns Result[Seq[ToolFunction]] for safe error handling", "0.2.9")
-  def custom(
-    fileConfig: Option[FileConfig] = None,
-    writeConfig: Option[WriteConfig] = None,
-    httpConfig: Option[HttpConfig] = None,
-    shellConfig: Option[ShellConfig] = None
-  ): Seq[ToolFunction[_, _]] =
-    customSafe(fileConfig, writeConfig, httpConfig, shellConfig) match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"BuiltinTools.custom failed: ${e.formatted}")
-    }
 }

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/core/CalculatorTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/core/CalculatorTool.scala
@@ -80,18 +80,6 @@ object CalculatorTool {
       } yield result
     }.buildSafe()
 
-  /**
-   * The calculator tool instance.
-   *
-   * @throws IllegalStateException if tool initialization fails
-   */
-  @deprecated("Use toolSafe which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  lazy val tool: ToolFunction[Map[String, Any], CalculatorResult] =
-    toolSafe match {
-      case Right(t) => t
-      case Left(e) => throw new IllegalStateException(s"CalculatorTool.tool lazy initialization failed: ${e.formatted}")
-    }
-
   private def calculate(operation: String, a: Double, bOpt: Option[Double]): Either[String, CalculatorResult] = {
     def requireB: Either[String, Double] =
       bOpt.toRight(s"Operation '$operation' requires two operands (a and b)")

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/core/DateTimeTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/core/DateTimeTool.scala
@@ -117,18 +117,6 @@ object DateTimeTool {
     }.buildSafe()
 
   /**
-   * The date/time tool instance.
-   *
-   * @throws IllegalStateException if tool initialization fails
-   */
-  @deprecated("Use toolSafe which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  lazy val tool: ToolFunction[Map[String, Any], DateTimeResult] =
-    toolSafe match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"DateTimeTool.tool lazy initialization failed: ${e.formatted}")
-    }
-
-  /**
    * Get list of common timezone identifiers.
    */
   val commonTimezones: Seq[String] = Seq(

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/core/JSONTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/core/JSONTool.scala
@@ -86,18 +86,6 @@ object JSONTool {
       } yield result
     }.buildSafe()
 
-  /**
-   * The JSON tool instance.
-   *
-   * @throws IllegalStateException if tool initialization fails
-   */
-  @deprecated("Use toolSafe which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  lazy val tool: ToolFunction[Map[String, Any], JSONResult] =
-    toolSafe match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"JSONTool.tool lazy initialization failed: ${e.formatted}")
-    }
-
   private def processJSON(
     operation: String,
     jsonStr: String,

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/core/UUIDTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/core/UUIDTool.scala
@@ -96,15 +96,4 @@ object UUIDTool {
       Right(UUIDsResult(uuids))
     }.buildSafe()
 
-  /**
-   * The UUID generator tool instance.
-   *
-   * @throws IllegalStateException if tool initialization fails
-   */
-  @deprecated("Use toolSafe which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  lazy val tool: ToolFunction[Map[String, Any], UUIDsResult] =
-    toolSafe match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"UUIDTool.tool lazy initialization failed: ${e.formatted}")
-    }
 }

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/core/package.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/core/package.scala
@@ -39,12 +39,4 @@ package object core {
     json       <- JSONTool.toolSafe
   } yield Seq(dateTime, calculator, uuid, json)
 
-  /**
-   * All core utility tools combined into a sequence.
-   *
-   * @throws IllegalStateException if any tool initialization fails
-   */
-  @deprecated("Use allToolsSafe which returns Result[Seq[ToolFunction]] for safe error handling", "0.2.9")
-  lazy val allTools: Seq[org.llm4s.toolapi.ToolFunction[_, _]] =
-    Seq(DateTimeTool.tool, CalculatorTool.tool, UUIDTool.tool, JSONTool.tool)
 }

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/filesystem/FileInfoTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/filesystem/FileInfoTool.scala
@@ -89,30 +89,6 @@ object FileInfoTool {
    */
   val toolSafe: Result[ToolFunction[Map[String, Any], FileInfoResult]] = createSafe()
 
-  /**
-   * Create a file info tool with the given configuration.
-   *
-   * @throws IllegalStateException if tool creation fails
-   */
-  @deprecated("Use createSafe() which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  def create(config: FileConfig = FileConfig()): ToolFunction[Map[String, Any], FileInfoResult] =
-    createSafe(config) match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"FileInfoTool.create failed: ${e.formatted}")
-    }
-
-  /**
-   * Default file info tool with standard configuration.
-   *
-   * @throws IllegalStateException if tool initialization fails
-   */
-  @deprecated("Use toolSafe which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  lazy val tool: ToolFunction[Map[String, Any], FileInfoResult] =
-    toolSafe match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"FileInfoTool.tool lazy initialization failed: ${e.formatted}")
-    }
-
   private def getFileInfo(
     pathStr: String,
     config: FileConfig

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/filesystem/ListDirectoryTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/filesystem/ListDirectoryTool.scala
@@ -112,31 +112,6 @@ object ListDirectoryTool {
    */
   val toolSafe: Result[ToolFunction[Map[String, Any], ListDirectoryResult]] = createSafe()
 
-  /**
-   * Create a list directory tool with the given configuration.
-   *
-   * @throws IllegalStateException if tool creation fails
-   */
-  @deprecated("Use createSafe() which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  def create(config: FileConfig = FileConfig()): ToolFunction[Map[String, Any], ListDirectoryResult] =
-    createSafe(config) match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"ListDirectoryTool.create failed: ${e.formatted}")
-    }
-
-  /**
-   * Default list directory tool with standard configuration.
-   *
-   * @throws IllegalStateException if tool initialization fails
-   */
-  @deprecated("Use toolSafe which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  lazy val tool: ToolFunction[Map[String, Any], ListDirectoryResult] =
-    toolSafe match {
-      case Right(t) => t
-      case Left(e) =>
-        throw new IllegalStateException(s"ListDirectoryTool.tool lazy initialization failed: ${e.formatted}")
-    }
-
   private def listDirectory(
     pathStr: String,
     maxEntries: Int,

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/filesystem/ReadFileTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/filesystem/ReadFileTool.scala
@@ -93,30 +93,6 @@ object ReadFileTool {
    */
   val toolSafe: Result[ToolFunction[Map[String, Any], ReadFileResult]] = createSafe()
 
-  /**
-   * Create a read file tool with the given configuration.
-   *
-   * @throws IllegalStateException if tool creation fails
-   */
-  @deprecated("Use createSafe() which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  def create(config: FileConfig = FileConfig()): ToolFunction[Map[String, Any], ReadFileResult] =
-    createSafe(config) match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"ReadFileTool.create failed: ${e.formatted}")
-    }
-
-  /**
-   * Default read file tool with standard configuration.
-   *
-   * @throws IllegalStateException if tool initialization fails
-   */
-  @deprecated("Use toolSafe which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  lazy val tool: ToolFunction[Map[String, Any], ReadFileResult] =
-    toolSafe match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"ReadFileTool.tool lazy initialization failed: ${e.formatted}")
-    }
-
   private def readFile(
     pathStr: String,
     maxLines: Option[Int],

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/filesystem/WriteFileTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/filesystem/WriteFileTool.scala
@@ -99,19 +99,6 @@ object WriteFileTool {
       } yield result
     }.buildSafe()
 
-  /**
-   * Create a write file tool with the given configuration.
-   *
-   * @param config Write configuration with required allowedPaths
-   * @throws IllegalStateException if tool creation fails
-   */
-  @deprecated("Use createSafe() which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  def create(config: WriteConfig): ToolFunction[Map[String, Any], WriteFileResult] =
-    createSafe(config) match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"WriteFileTool.create failed: ${e.formatted}")
-    }
-
   private def writeFile(
     pathStr: String,
     content: String,

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/filesystem/package.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/filesystem/package.scala
@@ -71,12 +71,4 @@ package object filesystem {
     fileInfo <- FileInfoTool.toolSafe
   } yield Seq(readFile, listDir, fileInfo)
 
-  /**
-   * All file system tools with default configuration (read-only, excludes write).
-   *
-   * @throws IllegalStateException if any tool initialization fails
-   */
-  @deprecated("Use readOnlyToolsSafe which returns Result[Seq[ToolFunction]] for safe error handling", "0.2.9")
-  lazy val readOnlyTools: Seq[org.llm4s.toolapi.ToolFunction[_, _]] =
-    Seq(ReadFileTool.tool, ListDirectoryTool.tool, FileInfoTool.tool)
 }

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/http/HTTPTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/http/HTTPTool.scala
@@ -125,30 +125,6 @@ object HTTPTool {
    */
   val toolSafe: Result[ToolFunction[Map[String, Any], HTTPResult]] = createSafe()
 
-  /**
-   * Create an HTTP tool with the given configuration.
-   *
-   * @throws IllegalStateException if tool creation fails
-   */
-  @deprecated("Use createSafe() which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  def create(config: HttpConfig = HttpConfig()): ToolFunction[Map[String, Any], HTTPResult] =
-    createSafe(config) match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"HTTPTool.create failed: ${e.formatted}")
-    }
-
-  /**
-   * Default HTTP tool with standard configuration.
-   *
-   * @throws IllegalStateException if tool initialization fails
-   */
-  @deprecated("Use toolSafe which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  lazy val tool: ToolFunction[Map[String, Any], HTTPResult] =
-    toolSafe match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"HTTPTool.tool lazy initialization failed: ${e.formatted}")
-    }
-
   private def makeRequest(
     urlStr: String,
     method: String,

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/http/package.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/http/package.scala
@@ -53,12 +53,4 @@ package object http {
   val allToolsSafe: org.llm4s.types.Result[Seq[org.llm4s.toolapi.ToolFunction[_, _]]] =
     HTTPTool.toolSafe.map(Seq(_))
 
-  /**
-   * All HTTP tools with default configuration.
-   *
-   * @throws IllegalStateException if any tool initialization fails
-   */
-  @deprecated("Use allToolsSafe which returns Result[Seq[ToolFunction]] for safe error handling", "0.2.9")
-  lazy val allTools: Seq[org.llm4s.toolapi.ToolFunction[_, _]] =
-    Seq(HTTPTool.tool)
 }

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/package.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/package.scala
@@ -78,7 +78,7 @@ package org.llm4s.toolapi
  * import org.llm4s.toolapi.builtin.BuiltinTools
  *
  * // Get all safe tools (no shell, restricted filesystem)
- * val tools = BuiltinTools.safe()
+ * val tools = BuiltinTools.withHttpSafe()
  *
  * // Get all tools with custom config
  * val allTools = BuiltinTools.all(

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/shell/ShellTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/shell/ShellTool.scala
@@ -84,19 +84,6 @@ object ShellTool {
       } yield result
     }.buildSafe()
 
-  /**
-   * Create a shell tool with the given configuration.
-   *
-   * @param config Shell configuration with required allowedCommands
-   * @throws IllegalStateException if tool creation fails
-   */
-  @deprecated("Use createSafe() which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  def create(config: ShellConfig): ToolFunction[Map[String, Any], ShellResult] =
-    createSafe(config) match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"ShellTool.create failed: ${e.formatted}")
-    }
-
   private def executeCommand(
     command: String,
     config: ShellConfig

--- a/modules/core/src/main/scala/org/llm4s/toolapi/tools/WeatherTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/tools/WeatherTool.scala
@@ -63,15 +63,4 @@ object WeatherTool {
     weatherParamsSchema
   ).withHandler(weatherHandler).buildSafe()
 
-  /**
-   * The weather tool instance.
-   *
-   * @throws IllegalStateException if tool initialization fails
-   */
-  @deprecated("Use toolSafe which returns Result[ToolFunction] for safe error handling", "0.2.9")
-  lazy val tool: ToolFunction[Map[String, Any], WeatherResult] =
-    toolSafe match {
-      case Right(t) => t
-      case Left(e)  => throw new IllegalStateException(s"WeatherTool.tool lazy initialization failed: ${e.formatted}")
-    }
 }

--- a/modules/core/src/test/scala/org/llm4s/agent/AgentSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/AgentSpec.scala
@@ -839,30 +839,4 @@ class AgentSpec extends AnyFlatSpec with Matchers {
     mockClient.getContextBudget(HeadroomPercent.Standard) shouldBe 7360
   }
 
-  // ============ Deprecated API tests ============
-
-  "Agent.initialize (deprecated)" should "initialize agent state successfully" in {
-    val completion = createCompletion("Test response")
-    val mockClient = new MockLLMClient(Seq(Right(completion)))
-    val agent      = new Agent(mockClient)
-
-    testTools.fold(
-      e => fail(s"Tool creation failed: ${e.formatted}"),
-      tools => {
-        @scala.annotation.nowarn("cat=deprecation")
-        val state = agent.initialize(
-          query = "Test query",
-          tools = tools,
-          handoffs = Seq.empty,
-          systemPromptAddition = None,
-          completionOptions = CompletionOptions()
-        )
-
-        state.initialQuery shouldBe Some("Test query")
-        state.status shouldBe AgentStatus.InProgress
-        state.conversation.messages.size shouldBe 1
-        state.tools.tools.map(_.name) shouldBe tools.tools.map(_.name)
-      }
-    )
-  }
 }

--- a/modules/core/src/test/scala/org/llm4s/toolapi/ToolFunctionSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/ToolFunctionSpec.scala
@@ -1,7 +1,5 @@
 package org.llm4s.toolapi
 
-import scala.annotation.nowarn
-
 import org.llm4s.types.Result
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -284,36 +282,6 @@ class ToolFunctionSpec extends AnyFlatSpec with Matchers {
 
     val result = builder.buildSafe()
     result.isLeft shouldBe true
-  }
-
-  it should "build a tool via deprecated build() when handler is defined" in {
-    val schema = Schema.`object`[Map[String, Any]]("Params")
-
-    @nowarn("cat=deprecation")
-    val tool = ToolBuilder[Map[String, Any], EmptyResult](
-      "test",
-      "Test",
-      schema
-    ).withHandler(_ => Right(EmptyResult(success = true)))
-      .build()
-
-    tool.name shouldBe "test"
-  }
-
-  it should "throw IllegalStateException via deprecated build() when handler is not defined" in {
-    val schema = Schema.`object`[Map[String, Any]]("Params")
-
-    @nowarn("cat=deprecation")
-    val result = scala.util.Try {
-      ToolBuilder[Map[String, Any], EmptyResult](
-        "no_handler",
-        "No handler defined",
-        schema
-      ).build()
-    }
-
-    result.isFailure shouldBe true
-    result.failed.get shouldBe a[IllegalStateException]
   }
 
   it should "allow replacing handler with withHandler" in {

--- a/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
@@ -343,12 +343,12 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
     )
   }
 
-  "ToolRegistry.getToolDefinitions" should "return OpenAI format for openai provider" in {
+  "ToolRegistry.getToolDefinitionsSafe" should "return OpenAI format for openai provider" in {
     createAddTool().fold(
       e => fail(s"Tool creation failed: ${e.formatted}"),
       addTool => {
         val registry = new ToolRegistry(Seq(addTool))
-        val tools    = registry.getToolDefinitions("openai")
+        val tools    = registry.getToolDefinitionsSafe("openai").getOrElse(fail("getToolDefinitionsSafe failed"))
         tools shouldBe a[ujson.Arr]
         tools.arr should have size 1
       }
@@ -360,7 +360,7 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
       e => fail(s"Tool creation failed: ${e.formatted}"),
       addTool => {
         val registry = new ToolRegistry(Seq(addTool))
-        val tools    = registry.getToolDefinitions("anthropic")
+        val tools    = registry.getToolDefinitionsSafe("anthropic").getOrElse(fail("getToolDefinitionsSafe failed"))
         tools shouldBe a[ujson.Arr]
       }
     )
@@ -371,20 +371,18 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
       e => fail(s"Tool creation failed: ${e.formatted}"),
       addTool => {
         val registry = new ToolRegistry(Seq(addTool))
-        val tools    = registry.getToolDefinitions("gemini")
+        val tools    = registry.getToolDefinitionsSafe("gemini").getOrElse(fail("getToolDefinitionsSafe failed"))
         tools shouldBe a[ujson.Arr]
       }
     )
   }
 
-  it should "throw exception for unsupported provider" in {
+  it should "return Left for unsupported provider" in {
     createAddTool().fold(
       e => fail(s"Tool creation failed: ${e.formatted}"),
       addTool => {
         val registry = new ToolRegistry(Seq(addTool))
-        an[IllegalArgumentException] should be thrownBy {
-          registry.getToolDefinitions("unsupported_provider")
-        }
+        registry.getToolDefinitionsSafe("unsupported_provider") shouldBe a[Left[_, _]]
       }
     )
   }

--- a/modules/core/src/test/scala/org/llm4s/toolapi/builtin/BuiltinToolsSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/builtin/BuiltinToolsSpec.scala
@@ -1,7 +1,5 @@
 package org.llm4s.toolapi.builtin
 
-import scala.annotation.nowarn
-
 import org.llm4s.toolapi.tools.WeatherTool
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -174,58 +172,10 @@ class BuiltinToolsSpec extends AnyFlatSpec with Matchers {
       )
   }
 
-  // ============ Deprecated API tests ============
-
-  "BuiltinTools.core (deprecated)" should "return 4 core tools" in {
-    @nowarn("cat=deprecation") val tools = BuiltinTools.core
-    tools.size shouldBe 4
-    val names = tools.map(_.name).toSet
-    names should contain("get_current_datetime")
-    names should contain("calculator")
-    names should contain("generate_uuid")
-    names should contain("json_tool")
-  }
-
-  "BuiltinTools.safe() (deprecated)" should "return 5 tools" in {
-    @nowarn("cat=deprecation") val tools = BuiltinTools.safe()
-    tools.size shouldBe 5
-    val names = tools.map(_.name).toSet
-    names should contain("http_request")
-    names should contain("get_current_datetime")
-  }
-
-  "BuiltinTools.withFiles() (deprecated)" should "return 8 tools" in {
-    @nowarn("cat=deprecation") val tools = BuiltinTools.withFiles()
-    tools.size shouldBe 8
-    val names = tools.map(_.name).toSet
-    names should contain("read_file")
-    names should contain("list_directory")
-    names should contain("file_info")
-    names should contain("http_request")
-  }
-
-  "BuiltinTools.development() (deprecated)" should "return 10 tools" in {
-    @nowarn("cat=deprecation") val tools = BuiltinTools.development()
-    tools.size shouldBe 10
-    val names = tools.map(_.name).toSet
-    names should contain("shell_command")
-    names should contain("write_file")
-    names should contain("read_file")
-    names should contain("http_request")
-  }
-
-  "BuiltinTools.custom() (deprecated)" should "return tools matching configuration" in {
-    @nowarn("cat=deprecation") val tools = BuiltinTools.custom(shellConfig = Some(shell.ShellConfig.readOnly()))
-    val names                            = tools.map(_.name).toSet
-    names should contain("shell_command")
-    names should contain("get_current_datetime")
-    names should contain("calculator")
-    (names should not).contain("read_file")
-    (names should not).contain("http_request")
-  }
-
-  "WeatherTool.tool (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = WeatherTool.tool
-    tool.name shouldBe "get_weather"
+  "WeatherTool.toolSafe" should "return a valid tool" in {
+    WeatherTool.toolSafe.fold(
+      e => fail(s"Tool creation failed: ${e.formatted}"),
+      tool => tool.name shouldBe "get_weather"
+    )
   }
 }

--- a/modules/core/src/test/scala/org/llm4s/toolapi/builtin/CoreToolsSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/builtin/CoreToolsSpec.scala
@@ -1,7 +1,5 @@
 package org.llm4s.toolapi.builtin
 
-import scala.annotation.nowarn
-
 import org.llm4s.toolapi.SafeParameterExtractor
 import org.llm4s.toolapi.builtin.core._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -383,35 +381,4 @@ class CoreToolsSpec extends AnyFlatSpec with Matchers {
     )
   }
 
-  // ============ Deprecated API tests ============
-
-  "DateTimeTool.tool (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = DateTimeTool.tool
-    tool.name shouldBe "get_current_datetime"
-  }
-
-  "CalculatorTool.tool (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = CalculatorTool.tool
-    tool.name shouldBe "calculator"
-  }
-
-  "UUIDTool.tool (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = UUIDTool.tool
-    tool.name shouldBe "generate_uuid"
-  }
-
-  "JSONTool.tool (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = JSONTool.tool
-    tool.name shouldBe "json_tool"
-  }
-
-  "core.allTools (deprecated)" should "return all 4 core tools" in {
-    @nowarn("cat=deprecation") val tools = core.allTools
-    tools.size shouldBe 4
-    val names = tools.map(_.name).toSet
-    names should contain("get_current_datetime")
-    names should contain("calculator")
-    names should contain("generate_uuid")
-    names should contain("json_tool")
-  }
 }

--- a/modules/core/src/test/scala/org/llm4s/toolapi/builtin/FileSystemToolsSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/builtin/FileSystemToolsSpec.scala
@@ -1,7 +1,5 @@
 package org.llm4s.toolapi.builtin
 
-import scala.annotation.nowarn
-
 import org.llm4s.toolapi.SafeParameterExtractor
 import org.llm4s.toolapi.builtin.filesystem._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -368,39 +366,4 @@ class FileSystemToolsSpec extends AnyFlatSpec with Matchers {
       )
   }
 
-  // ============ Deprecated API tests ============
-
-  "ReadFileTool.create() (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = ReadFileTool.create()
-    tool.name shouldBe "read_file"
-  }
-
-  "ReadFileTool.tool (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = ReadFileTool.tool
-    tool.name shouldBe "read_file"
-  }
-
-  "ListDirectoryTool.create() (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = ListDirectoryTool.create()
-    tool.name shouldBe "list_directory"
-  }
-
-  "FileInfoTool.create() (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = FileInfoTool.create()
-    tool.name shouldBe "file_info"
-  }
-
-  "WriteFileTool.create() (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = WriteFileTool.create(WriteConfig(allowedPaths = Seq("/tmp")))
-    tool.name shouldBe "write_file"
-  }
-
-  "filesystem.readOnlyTools (deprecated)" should "return 3 read-only tools" in {
-    @nowarn("cat=deprecation") val tools = readOnlyTools
-    tools.size shouldBe 3
-    val names = tools.map(_.name).toSet
-    names should contain("read_file")
-    names should contain("list_directory")
-    names should contain("file_info")
-  }
 }

--- a/modules/core/src/test/scala/org/llm4s/toolapi/builtin/HttpToolsSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/builtin/HttpToolsSpec.scala
@@ -1,7 +1,5 @@
 package org.llm4s.toolapi.builtin
 
-import scala.annotation.nowarn
-
 import org.llm4s.toolapi.SafeParameterExtractor
 import org.llm4s.toolapi.builtin.http._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -174,21 +172,4 @@ class HttpToolsSpec extends AnyFlatSpec with Matchers {
     config.isDomainAllowed("other.com") shouldBe false
   }
 
-  // ============ Deprecated API tests ============
-
-  "HTTPTool.create() (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = HTTPTool.create()
-    tool.name shouldBe "http_request"
-  }
-
-  "HTTPTool.tool (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = HTTPTool.tool
-    tool.name shouldBe "http_request"
-  }
-
-  "http.allTools (deprecated)" should "contain http_request" in {
-    @nowarn("cat=deprecation") val tools = http.allTools
-    tools.size shouldBe 1
-    tools.head.name shouldBe "http_request"
-  }
 }

--- a/modules/core/src/test/scala/org/llm4s/toolapi/builtin/ShellToolsSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/builtin/ShellToolsSpec.scala
@@ -1,7 +1,5 @@
 package org.llm4s.toolapi.builtin
 
-import scala.annotation.nowarn
-
 import org.llm4s.toolapi.SafeParameterExtractor
 import org.llm4s.toolapi.builtin.shell._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -215,10 +213,4 @@ class ShellToolsSpec extends AnyFlatSpec with Matchers {
       )
   }
 
-  // ============ Deprecated API tests ============
-
-  "ShellTool.create() (deprecated)" should "return a valid tool" in {
-    @nowarn("cat=deprecation") val tool = ShellTool.create(ShellConfig.readOnly())
-    tool.name shouldBe "shell_command"
-  }
 }

--- a/modules/crossTest/scala2/src/test/scala/org/llm4s/sc2/AgentToolIntegrationCrossTest.scala
+++ b/modules/crossTest/scala2/src/test/scala/org/llm4s/sc2/AgentToolIntegrationCrossTest.scala
@@ -2,7 +2,7 @@ package org.llm4s.sc2
 
 /**
  * Cross-version test for Agent and ToolRegistry integration.
- * Verifies that Agent.initialize with builtin tools produces consistent state across Scala 2.13 and 3.x.
+ * Verifies that Agent.initializeSafe with builtin tools produces consistent state across Scala 2.13 and 3.x.
  * No network: uses a stub LLMClient that never performs real completion.
 */
 class AgentToolIntegrationCrossTest
@@ -27,10 +27,10 @@ class AgentToolIntegrationCrossTest
     override def getReserveCompletion(): Int = 4096
   }
 
-  "Agent.initialize" should "return state with conversation containing user message" in {
+  "Agent.initializeSafe" should "return state with conversation containing user message" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
-    val state = agent.initialize("Hello, world", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val state = agent.initializeSafe("Hello, world", tools).getOrElse(fail("initializeSafe failed"))
     state.conversation.messages should not be empty
     state.conversation.messages.head shouldBe a[org.llm4s.llmconnect.model.UserMessage]
     state.conversation.messages.head.asInstanceOf[org.llm4s.llmconnect.model.UserMessage].content shouldBe "Hello, world"
@@ -38,8 +38,8 @@ class AgentToolIntegrationCrossTest
 
   it should "return state with tools registry containing builtin core tools" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
-    val state = agent.initialize("Query", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val state = agent.initializeSafe("Query", tools).getOrElse(fail("initializeSafe failed"))
     state.tools.tools should not be empty
     state.tools.tools.map(_.name).toSet should contain("get_current_datetime")
     state.tools.tools.map(_.name).toSet should contain("calculator")
@@ -47,39 +47,39 @@ class AgentToolIntegrationCrossTest
 
   it should "return state with InProgress status" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
-    val state = agent.initialize("Query", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val state = agent.initializeSafe("Query", tools).getOrElse(fail("initializeSafe failed"))
     state.status shouldBe org.llm4s.agent.AgentStatus.InProgress
   }
 
   it should "return state with initialQuery set" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
-    val state = agent.initialize("My query", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val state = agent.initializeSafe("My query", tools).getOrElse(fail("initializeSafe failed"))
     state.initialQuery shouldBe Some("My query")
   }
 
   it should "return state with systemMessage set" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
-    val state = agent.initialize("Query", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val state = agent.initializeSafe("Query", tools).getOrElse(fail("initializeSafe failed"))
     state.systemMessage shouldBe defined
     state.systemMessage.get.content should include("assistant")
   }
 
   it should "expose tool definitions via state.tools.getOpenAITools" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
-    val state = agent.initialize("Query", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val state = agent.initializeSafe("Query", tools).getOrElse(fail("initializeSafe failed"))
     val defs = state.tools.getOpenAITools(strict = true)
     defs.arr should not be empty
     defs.arr.map(_.obj("function").obj("name").str) should contain("get_current_datetime")
   }
 
-  it should "work with safe() tools as well" in {
+  it should "work with withHttpSafe() tools as well" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.safe())
-    val state = agent.initialize("Query", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.withHttpSafe().getOrElse(fail("withHttpSafe failed")))
+    val state = agent.initializeSafe("Query", tools).getOrElse(fail("initializeSafe failed"))
     state.tools.tools.map(_.name) should contain("http_request")
     state.tools.tools.map(_.name) should contain("calculator")
   }

--- a/modules/crossTest/scala2/src/test/scala/org/llm4s/sc2/BuiltinToolsCrossTest.scala
+++ b/modules/crossTest/scala2/src/test/scala/org/llm4s/sc2/BuiltinToolsCrossTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 
 /**
  * Cross-version test for BuiltinTools factory methods and tool set composition.
- * Verifies that core, safe(), withFiles(), and development() behave identically in Scala 2.13 and 3.x.
+ * Verifies that coreSafe, withHttpSafe(), withFilesSafe(), and developmentSafe() behave identically in Scala 2.13 and 3.x.
  * No network, no filesystem I/O — construction and discovery only.
  * Same logic as sc3.BuiltinToolsCrossTest; positive assertions only (no negative cases for factory methods).
  */
@@ -15,87 +15,89 @@ class BuiltinToolsCrossTest extends AnyFlatSpec with Matchers {
   val coreToolNames = Set("get_current_datetime", "calculator", "generate_uuid", "json_tool")
   val fileReadNames = Set("read_file", "list_directory", "file_info")
 
-  "BuiltinTools.core" should "return a non-empty sequence of tools" in {
-    val tools = BuiltinTools.core
+  "BuiltinTools.coreSafe" should "return a non-empty sequence of tools" in {
+    val tools = BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed"))
     tools should not be empty
   }
 
   it should "include expected core tool names" in {
-    val names = BuiltinTools.core.map(_.name).toSet
+    val names = BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")).map(_.name).toSet
     coreToolNames.foreach { name =>
       names should contain(name)
     }
   }
 
   it should "have exactly four tools" in {
-    BuiltinTools.core.size shouldBe 4
+    BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")).size shouldBe 4
   }
 
-  "BuiltinTools.safe()" should "include all core tools" in {
-    val names = BuiltinTools.safe().map(_.name).toSet
+  "BuiltinTools.withHttpSafe()" should "include all core tools" in {
+    val names = BuiltinTools.withHttpSafe().getOrElse(fail("withHttpSafe failed")).map(_.name).toSet
     coreToolNames.foreach { name =>
       names should contain(name)
     }
   }
 
   it should "include http_request" in {
-    val names = BuiltinTools.safe().map(_.name).toSet
+    val names = BuiltinTools.withHttpSafe().getOrElse(fail("withHttpSafe failed")).map(_.name).toSet
     names should contain("http_request")
   }
 
   it should "not include write_file or shell_command" in {
-    val names = BuiltinTools.safe().map(_.name).toSet
+    val names = BuiltinTools.withHttpSafe().getOrElse(fail("withHttpSafe failed")).map(_.name).toSet
     names should not contain "write_file"
     names should not contain "shell_command"
   }
 
-  it should "have more tools than core" in {
-    BuiltinTools.safe().size should be > BuiltinTools.core.size
+  it should "have more tools than coreSafe" in {
+    val coreSize = BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")).size
+    val safeSize = BuiltinTools.withHttpSafe().getOrElse(fail("withHttpSafe failed")).size
+    safeSize should be > coreSize
   }
 
-  "BuiltinTools.withFiles()" should "include all safe tools" in {
-    val safeNames = BuiltinTools.safe().map(_.name).toSet
-    val withFilesNames = BuiltinTools.withFiles().map(_.name).toSet
+  "BuiltinTools.withFilesSafe()" should "include all withHttpSafe tools" in {
+    val safeNames      = BuiltinTools.withHttpSafe().getOrElse(fail("withHttpSafe failed")).map(_.name).toSet
+    val withFilesNames = BuiltinTools.withFilesSafe().getOrElse(fail("withFilesSafe failed")).map(_.name).toSet
     safeNames.foreach { name =>
       withFilesNames should contain(name)
     }
   }
 
   it should "include read-only file tools" in {
-    val names = BuiltinTools.withFiles().map(_.name).toSet
+    val names = BuiltinTools.withFilesSafe().getOrElse(fail("withFilesSafe failed")).map(_.name).toSet
     fileReadNames.foreach { name =>
       names should contain(name)
     }
   }
 
   it should "not include write_file or shell_command" in {
-    val names = BuiltinTools.withFiles().map(_.name).toSet
+    val names = BuiltinTools.withFilesSafe().getOrElse(fail("withFilesSafe failed")).map(_.name).toSet
     names should not contain "write_file"
     names should not contain "shell_command"
   }
 
-  "BuiltinTools.development()" should "include core tools" in {
-    val names = BuiltinTools.development().map(_.name).toSet
+  "BuiltinTools.developmentSafe()" should "include core tools" in {
+    val names = BuiltinTools.developmentSafe().getOrElse(fail("developmentSafe failed")).map(_.name).toSet
     coreToolNames.foreach { name =>
       names should contain(name)
     }
   }
 
   it should "include write_file and shell_command" in {
-    val names = BuiltinTools.development().map(_.name).toSet
+    val names = BuiltinTools.developmentSafe().getOrElse(fail("developmentSafe failed")).map(_.name).toSet
     names should contain("write_file")
     names should contain("shell_command")
   }
 
   it should "include read-only file tools" in {
-    val names = BuiltinTools.development().map(_.name).toSet
+    val names = BuiltinTools.developmentSafe().getOrElse(fail("developmentSafe failed")).map(_.name).toSet
     fileReadNames.foreach { name =>
       names should contain(name)
     }
   }
 
   "Each tool" should "have a non-empty name and description" in {
-    BuiltinTools.core.foreach { tool =>
+    BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")).foreach { tool =>
       tool.name should not be empty
       tool.description should not be empty
     }

--- a/modules/crossTest/scala2/src/test/scala/org/llm4s/sc2/SchemaCrossTest.scala
+++ b/modules/crossTest/scala2/src/test/scala/org/llm4s/sc2/SchemaCrossTest.scala
@@ -81,7 +81,7 @@ class SchemaCrossTest extends AnyFlatSpec with Matchers {
   }
 
   "Builtin tool toOpenAITool" should "produce function object with name, description, parameters" in {
-    val reg  = new ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
+    val reg  = new ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val arr  = reg.getOpenAITools(strict = true)
     val first = arr.arr.head
     first.obj("type") shouldBe ujson.Str("function")
@@ -94,7 +94,7 @@ class SchemaCrossTest extends AnyFlatSpec with Matchers {
   }
 
   it should "preserve tool name in serialized schema" in {
-    val reg = new ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
+    val reg = new ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val arr = reg.getOpenAITools(strict = true)
     val names = arr.arr.map(_.obj("function").obj("name").str)
     names should contain("get_current_datetime")

--- a/modules/crossTest/scala2/src/test/scala/org/llm4s/sc2/ToolRegistryCrossTest.scala
+++ b/modules/crossTest/scala2/src/test/scala/org/llm4s/sc2/ToolRegistryCrossTest.scala
@@ -13,29 +13,30 @@ import scala.concurrent.Await
  * Cross-version test for ToolRegistry: registration, discovery, sync execute, and schema output.
  * Verifies behavior is identical in Scala 2.13 and 3.x (same logic as sc3.ToolRegistryCrossTest).
  * Uses only core builtin tools; no network or filesystem.
- * Includes positive (valid execute, getToolDefinitions) and negative (UnknownFunction, unsupported provider) cases.
+ * Includes positive (valid execute, getToolDefinitionsSafe) and negative (UnknownFunction, unsupported provider) cases.
  */
 class ToolRegistryCrossTest extends AnyFlatSpec with Matchers {
 
   "ToolRegistry" should "accept a sequence of tools and expose them" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val coreTools = BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed"))
+    val reg = new ToolRegistry(coreTools)
     reg.tools should not be empty
-    reg.tools.size shouldBe BuiltinTools.core.size
+    reg.tools.size shouldBe coreTools.size
   }
 
   it should "return None for unknown tool name" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     reg.getTool("nonexistent_tool") shouldBe None
   }
 
   it should "return Some(tool) for existing tool name" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     reg.getTool("get_current_datetime") shouldBe defined
     reg.getTool("get_current_datetime").get.name shouldBe "get_current_datetime"
   }
 
   it should "execute get_current_datetime with empty object and return Right" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val result = reg.execute(ToolCallRequest("get_current_datetime", ujson.Obj()))
     result shouldBe a[Right[_, _]]
     result.foreach { json =>
@@ -45,7 +46,7 @@ class ToolRegistryCrossTest extends AnyFlatSpec with Matchers {
   }
 
   it should "execute calculator with valid args and return result" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val args = ujson.Obj("operation" -> "add", "a" -> 2, "b" -> 3)
     val result = reg.execute(ToolCallRequest("calculator", args))
     result shouldBe a[Right[_, _]]
@@ -55,13 +56,13 @@ class ToolRegistryCrossTest extends AnyFlatSpec with Matchers {
   }
 
   it should "return Left(UnknownFunction) for unknown tool name" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val result = reg.execute(ToolCallRequest("unknown_tool", ujson.Obj()))
     result shouldBe Left(ToolCallError.UnknownFunction("unknown_tool"))
   }
 
   it should "getOpenAITools return a non-empty array with function entries" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val arr = reg.getOpenAITools(strict = true)
     arr shouldBe a[ujson.Arr]
     arr.arr should not be empty
@@ -73,29 +74,27 @@ class ToolRegistryCrossTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "getToolDefinitions(openai) return same shape as getOpenAITools" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
-    val openai = reg.getToolDefinitions("openai")
+  it should "getToolDefinitionsSafe(openai) return same shape as getOpenAITools" in {
+    val reg    = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val openai = reg.getToolDefinitionsSafe("openai").getOrElse(fail("getToolDefinitionsSafe failed"))
     openai shouldBe a[ujson.Arr]
     openai.arr should not be empty
   }
 
-  it should "getToolDefinitions(anthropic) return non-empty array" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
-    val anthropic = reg.getToolDefinitions("anthropic")
+  it should "getToolDefinitionsSafe(anthropic) return non-empty array" in {
+    val reg      = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val anthropic = reg.getToolDefinitionsSafe("anthropic").getOrElse(fail("getToolDefinitionsSafe failed"))
     anthropic shouldBe a[ujson.Arr]
     anthropic.arr should not be empty
   }
 
-  it should "throw for unsupported provider in getToolDefinitions" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
-    intercept[IllegalArgumentException] {
-      reg.getToolDefinitions("unsupported_provider")
-    }.getMessage should include("Unsupported")
+  it should "return Left for unsupported provider in getToolDefinitionsSafe" in {
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    reg.getToolDefinitionsSafe("unsupported_provider") shouldBe a[Left[_, _]]
   }
 
   it should "executeAll Sequential return results in order" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val reqs = Seq(
       ToolCallRequest("get_current_datetime", ujson.Obj()),
       ToolCallRequest("generate_uuid", ujson.Obj())

--- a/modules/crossTest/scala3/src/test/scala/org/llm4s/sc3/AgentToolIntegrationCrossTest.scala
+++ b/modules/crossTest/scala3/src/test/scala/org/llm4s/sc3/AgentToolIntegrationCrossTest.scala
@@ -2,7 +2,7 @@ package org.llm4s.sc3
 
 /**
  * Cross-version test for Agent and ToolRegistry integration.
- * Verifies that Agent.initialize with builtin tools produces consistent state across Scala 2.13 and 3.x.
+ * Verifies that Agent.initializeSafe with builtin tools produces consistent state across Scala 2.13 and 3.x.
  * No network: uses a stub LLMClient that never performs real completion.
 */
 class AgentToolIntegrationCrossTest
@@ -27,10 +27,10 @@ class AgentToolIntegrationCrossTest
     override def getReserveCompletion(): Int = 4096
   }
 
-  "Agent.initialize" should "return state with conversation containing user message" in {
+  "Agent.initializeSafe" should "return state with conversation containing user message" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
-    val state = agent.initialize("Hello, world", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val state = agent.initializeSafe("Hello, world", tools).getOrElse(fail("initializeSafe failed"))
     state.conversation.messages should not be empty
     state.conversation.messages.head shouldBe a[org.llm4s.llmconnect.model.UserMessage]
     state.conversation.messages.head.asInstanceOf[org.llm4s.llmconnect.model.UserMessage].content shouldBe "Hello, world"
@@ -38,8 +38,8 @@ class AgentToolIntegrationCrossTest
 
   it should "return state with tools registry containing builtin core tools" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
-    val state = agent.initialize("Query", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val state = agent.initializeSafe("Query", tools).getOrElse(fail("initializeSafe failed"))
     state.tools.tools should not be empty
     state.tools.tools.map(_.name).toSet should contain("get_current_datetime")
     state.tools.tools.map(_.name).toSet should contain("calculator")
@@ -47,39 +47,39 @@ class AgentToolIntegrationCrossTest
 
   it should "return state with InProgress status" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
-    val state = agent.initialize("Query", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val state = agent.initializeSafe("Query", tools).getOrElse(fail("initializeSafe failed"))
     state.status shouldBe org.llm4s.agent.AgentStatus.InProgress
   }
 
   it should "return state with initialQuery set" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
-    val state = agent.initialize("My query", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val state = agent.initializeSafe("My query", tools).getOrElse(fail("initializeSafe failed"))
     state.initialQuery shouldBe Some("My query")
   }
 
   it should "return state with systemMessage set" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
-    val state = agent.initialize("Query", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val state = agent.initializeSafe("Query", tools).getOrElse(fail("initializeSafe failed"))
     state.systemMessage shouldBe defined
     state.systemMessage.get.content should include("assistant")
   }
 
   it should "expose tool definitions via state.tools.getOpenAITools" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
-    val state = agent.initialize("Query", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val state = agent.initializeSafe("Query", tools).getOrElse(fail("initializeSafe failed"))
     val defs = state.tools.getOpenAITools(strict = true)
     defs.arr should not be empty
     defs.arr.map(_.obj("function").obj("name").str) should contain("get_current_datetime")
   }
 
-  it should "work with safe() tools as well" in {
+  it should "work with withHttpSafe() tools as well" in {
     val agent = new org.llm4s.agent.Agent(stubClient)
-    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.safe())
-    val state = agent.initialize("Query", tools)
+    val tools = new org.llm4s.toolapi.ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.withHttpSafe().getOrElse(fail("withHttpSafe failed")))
+    val state = agent.initializeSafe("Query", tools).getOrElse(fail("initializeSafe failed"))
     state.tools.tools.map(_.name) should contain("http_request")
     state.tools.tools.map(_.name) should contain("calculator")
   }

--- a/modules/crossTest/scala3/src/test/scala/org/llm4s/sc3/BuiltinToolsCrossTest.scala
+++ b/modules/crossTest/scala3/src/test/scala/org/llm4s/sc3/BuiltinToolsCrossTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 
 /**
  * Cross-version test for BuiltinTools factory methods and tool set composition.
- * Verifies that core, safe(), withFiles(), and development() behave identically in Scala 2.13 and 3.x.
+ * Verifies that coreSafe, withHttpSafe(), withFilesSafe(), and developmentSafe() behave identically in Scala 2.13 and 3.x.
  * No network, no filesystem I/O — construction and discovery only.
  * Same logic as sc2.BuiltinToolsCrossTest; positive assertions only (no negative cases for factory methods).
  */
@@ -15,87 +15,89 @@ class BuiltinToolsCrossTest extends AnyFlatSpec with Matchers {
   val coreToolNames = Set("get_current_datetime", "calculator", "generate_uuid", "json_tool")
   val fileReadNames = Set("read_file", "list_directory", "file_info")
 
-  "BuiltinTools.core" should "return a non-empty sequence of tools" in {
-    val tools = BuiltinTools.core
+  "BuiltinTools.coreSafe" should "return a non-empty sequence of tools" in {
+    val tools = BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed"))
     tools should not be empty
   }
 
   it should "include expected core tool names" in {
-    val names = BuiltinTools.core.map(_.name).toSet
+    val names = BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")).map(_.name).toSet
     coreToolNames.foreach { name =>
       names should contain(name)
     }
   }
 
   it should "have exactly four tools" in {
-    BuiltinTools.core.size shouldBe 4
+    BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")).size shouldBe 4
   }
 
-  "BuiltinTools.safe()" should "include all core tools" in {
-    val names = BuiltinTools.safe().map(_.name).toSet
+  "BuiltinTools.withHttpSafe()" should "include all core tools" in {
+    val names = BuiltinTools.withHttpSafe().getOrElse(fail("withHttpSafe failed")).map(_.name).toSet
     coreToolNames.foreach { name =>
       names should contain(name)
     }
   }
 
   it should "include http_request" in {
-    val names = BuiltinTools.safe().map(_.name).toSet
+    val names = BuiltinTools.withHttpSafe().getOrElse(fail("withHttpSafe failed")).map(_.name).toSet
     names should contain("http_request")
   }
 
   it should "not include write_file or shell_command" in {
-    val names = BuiltinTools.safe().map(_.name).toSet
+    val names = BuiltinTools.withHttpSafe().getOrElse(fail("withHttpSafe failed")).map(_.name).toSet
     names should not contain "write_file"
     names should not contain "shell_command"
   }
 
-  it should "have more tools than core" in {
-    BuiltinTools.safe().size should be > BuiltinTools.core.size
+  it should "have more tools than coreSafe" in {
+    val coreSize = BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")).size
+    val safeSize = BuiltinTools.withHttpSafe().getOrElse(fail("withHttpSafe failed")).size
+    safeSize should be > coreSize
   }
 
-  "BuiltinTools.withFiles()" should "include all safe tools" in {
-    val safeNames = BuiltinTools.safe().map(_.name).toSet
-    val withFilesNames = BuiltinTools.withFiles().map(_.name).toSet
+  "BuiltinTools.withFilesSafe()" should "include all withHttpSafe tools" in {
+    val safeNames      = BuiltinTools.withHttpSafe().getOrElse(fail("withHttpSafe failed")).map(_.name).toSet
+    val withFilesNames = BuiltinTools.withFilesSafe().getOrElse(fail("withFilesSafe failed")).map(_.name).toSet
     safeNames.foreach { name =>
       withFilesNames should contain(name)
     }
   }
 
   it should "include read-only file tools" in {
-    val names = BuiltinTools.withFiles().map(_.name).toSet
+    val names = BuiltinTools.withFilesSafe().getOrElse(fail("withFilesSafe failed")).map(_.name).toSet
     fileReadNames.foreach { name =>
       names should contain(name)
     }
   }
 
   it should "not include write_file or shell_command" in {
-    val names = BuiltinTools.withFiles().map(_.name).toSet
+    val names = BuiltinTools.withFilesSafe().getOrElse(fail("withFilesSafe failed")).map(_.name).toSet
     names should not contain "write_file"
     names should not contain "shell_command"
   }
 
-  "BuiltinTools.development()" should "include core tools" in {
-    val names = BuiltinTools.development().map(_.name).toSet
+  "BuiltinTools.developmentSafe()" should "include core tools" in {
+    val names = BuiltinTools.developmentSafe().getOrElse(fail("developmentSafe failed")).map(_.name).toSet
     coreToolNames.foreach { name =>
       names should contain(name)
     }
   }
 
   it should "include write_file and shell_command" in {
-    val names = BuiltinTools.development().map(_.name).toSet
+    val names = BuiltinTools.developmentSafe().getOrElse(fail("developmentSafe failed")).map(_.name).toSet
     names should contain("write_file")
     names should contain("shell_command")
   }
 
   it should "include read-only file tools" in {
-    val names = BuiltinTools.development().map(_.name).toSet
+    val names = BuiltinTools.developmentSafe().getOrElse(fail("developmentSafe failed")).map(_.name).toSet
     fileReadNames.foreach { name =>
       names should contain(name)
     }
   }
 
   "Each tool" should "have a non-empty name and description" in {
-    BuiltinTools.core.foreach { tool =>
+    BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")).foreach { tool =>
       tool.name should not be empty
       tool.description should not be empty
     }

--- a/modules/crossTest/scala3/src/test/scala/org/llm4s/sc3/SchemaCrossTest.scala
+++ b/modules/crossTest/scala3/src/test/scala/org/llm4s/sc3/SchemaCrossTest.scala
@@ -81,7 +81,7 @@ class SchemaCrossTest extends AnyFlatSpec with Matchers {
   }
 
   "Builtin tool toOpenAITool" should "produce function object with name, description, parameters" in {
-    val reg  = new ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
+    val reg  = new ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val arr  = reg.getOpenAITools(strict = true)
     val first = arr.arr.head
     first.obj("type") shouldBe ujson.Str("function")
@@ -94,7 +94,7 @@ class SchemaCrossTest extends AnyFlatSpec with Matchers {
   }
 
   it should "preserve tool name in serialized schema" in {
-    val reg = new ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.core)
+    val reg = new ToolRegistry(org.llm4s.toolapi.builtin.BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val arr = reg.getOpenAITools(strict = true)
     val names = arr.arr.map(_.obj("function").obj("name").str)
     names should contain("get_current_datetime")

--- a/modules/crossTest/scala3/src/test/scala/org/llm4s/sc3/ToolRegistryCrossTest.scala
+++ b/modules/crossTest/scala3/src/test/scala/org/llm4s/sc3/ToolRegistryCrossTest.scala
@@ -13,29 +13,30 @@ import scala.concurrent.Await
  * Cross-version test for ToolRegistry: registration, discovery, sync execute, and schema output.
  * Verifies behavior is identical in Scala 2.13 and 3.x (same logic as sc2.ToolRegistryCrossTest).
  * Uses only core builtin tools; no network or filesystem.
- * Includes positive (valid execute, getToolDefinitions) and negative (UnknownFunction, unsupported provider) cases.
+ * Includes positive (valid execute, getToolDefinitionsSafe) and negative (UnknownFunction, unsupported provider) cases.
  */
 class ToolRegistryCrossTest extends AnyFlatSpec with Matchers {
 
   "ToolRegistry" should "accept a sequence of tools and expose them" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val coreTools = BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed"))
+    val reg = new ToolRegistry(coreTools)
     reg.tools should not be empty
-    reg.tools.size shouldBe BuiltinTools.core.size
+    reg.tools.size shouldBe coreTools.size
   }
 
   it should "return None for unknown tool name" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     reg.getTool("nonexistent_tool") shouldBe None
   }
 
   it should "return Some(tool) for existing tool name" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     reg.getTool("get_current_datetime") shouldBe defined
     reg.getTool("get_current_datetime").get.name shouldBe "get_current_datetime"
   }
 
   it should "execute get_current_datetime with empty object and return Right" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val result = reg.execute(ToolCallRequest("get_current_datetime", ujson.Obj()))
     result shouldBe a[Right[_, _]]
     result.foreach { json =>
@@ -45,7 +46,7 @@ class ToolRegistryCrossTest extends AnyFlatSpec with Matchers {
   }
 
   it should "execute calculator with valid args and return result" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val args = ujson.Obj("operation" -> "add", "a" -> 2, "b" -> 3)
     val result = reg.execute(ToolCallRequest("calculator", args))
     result shouldBe a[Right[_, _]]
@@ -55,13 +56,13 @@ class ToolRegistryCrossTest extends AnyFlatSpec with Matchers {
   }
 
   it should "return Left(UnknownFunction) for unknown tool name" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val result = reg.execute(ToolCallRequest("unknown_tool", ujson.Obj()))
     result shouldBe Left(ToolCallError.UnknownFunction("unknown_tool"))
   }
 
   it should "getOpenAITools return a non-empty array with function entries" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val arr = reg.getOpenAITools(strict = true)
     arr shouldBe a[ujson.Arr]
     arr.arr should not be empty
@@ -73,29 +74,27 @@ class ToolRegistryCrossTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "getToolDefinitions(openai) return same shape as getOpenAITools" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
-    val openai = reg.getToolDefinitions("openai")
+  it should "getToolDefinitionsSafe(openai) return same shape as getOpenAITools" in {
+    val reg    = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val openai = reg.getToolDefinitionsSafe("openai").getOrElse(fail("getToolDefinitionsSafe failed"))
     openai shouldBe a[ujson.Arr]
     openai.arr should not be empty
   }
 
-  it should "getToolDefinitions(anthropic) return non-empty array" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
-    val anthropic = reg.getToolDefinitions("anthropic")
+  it should "getToolDefinitionsSafe(anthropic) return non-empty array" in {
+    val reg       = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    val anthropic = reg.getToolDefinitionsSafe("anthropic").getOrElse(fail("getToolDefinitionsSafe failed"))
     anthropic shouldBe a[ujson.Arr]
     anthropic.arr should not be empty
   }
 
-  it should "throw for unsupported provider in getToolDefinitions" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
-    intercept[IllegalArgumentException] {
-      reg.getToolDefinitions("unsupported_provider")
-    }.getMessage should include("Unsupported")
+  it should "return Left for unsupported provider in getToolDefinitionsSafe" in {
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
+    reg.getToolDefinitionsSafe("unsupported_provider") shouldBe a[Left[_, _]]
   }
 
   it should "executeAll Sequential return results in order" in {
-    val reg = new ToolRegistry(BuiltinTools.core)
+    val reg = new ToolRegistry(BuiltinTools.coreSafe.getOrElse(fail("coreSafe failed")))
     val reqs = Seq(
       ToolCallRequest("get_current_datetime", ujson.Obj()),
       ToolCallRequest("generate_uuid", ujson.Obj())

--- a/modules/samples/src/main/scala/org/llm4s/samples/toolapi/BuiltinToolsExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/toolapi/BuiltinToolsExample.scala
@@ -18,10 +18,10 @@ import org.slf4j.LoggerFactory
  * - Search: Web search via DuckDuckGo
  *
  * Tools come in pre-configured bundles:
- * - `BuiltinTools.core` - Just the core utilities (always safe)
- * - `BuiltinTools.safe()` - Core + network (web search, HTTP)
- * - `BuiltinTools.withFiles()` - Safe + read-only file access
- * - `BuiltinTools.development()` - All tools for development environments
+ * - `BuiltinTools.coreSafe` - Just the core utilities (always safe)
+ * - `BuiltinTools.withHttpSafe()` - Core + network (web search, HTTP)
+ * - `BuiltinTools.withFilesSafe()` - Safe + read-only file access
+ * - `BuiltinTools.developmentSafe()` - All tools for development environments
  *
  * @example
  * {{{

--- a/modules/samples/src/main/scala/org/llm4s/samples/toolapi/MultiToolExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/toolapi/MultiToolExample.scala
@@ -145,7 +145,12 @@ object MultiToolExample {
 
       // Generate OpenAI tool definitions
       logger.info("Tool definitions for OpenAI:")
-      logger.info(toolRegistry.getToolDefinitions("openai").render(indent = 2))
+      toolRegistry
+        .getToolDefinitionsSafe("openai")
+        .fold(
+          err => logger.error("Failed to get tool definitions: {}", err.formatted),
+          defs => logger.info(defs.render(indent = 2))
+        )
     }
 
     result.left.foreach(err => logger.error("Failed to build tools: {}", err.formatted))

--- a/modules/samples/src/main/scala/org/llm4s/samples/toolapi/WeatherToolExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/toolapi/WeatherToolExample.scala
@@ -33,10 +33,15 @@ object WeatherToolExample {
       }
 
       // Generate tool definitions for OpenAI
-      val openaiTools = toolRegistry.getToolDefinitions("openai")
-
-      logger.info("OpenAI tool definition:")
-      logger.info("{}", openaiTools.render(indent = 2))
+      toolRegistry
+        .getToolDefinitionsSafe("openai")
+        .fold(
+          err => logger.error("Failed to get tool definitions: {}", err.formatted),
+          openaiTools => {
+            logger.info("OpenAI tool definition:")
+            logger.info("{}", openaiTools.render(indent = 2))
+          }
+        )
     }
 
     result.left.foreach(err => logger.error("Failed to load weather tool: {}", err.formatted))


### PR DESCRIPTION
## Summary

Systematically removes all deprecated methods that wrapped `Result`-returning Safe variants and threw exceptions on `Left`, replacing call sites throughout the codebase with idiomatic `Result`-based error handling.

This is a follow-up to the existing deprecation work (methods already marked `@deprecated` since 0.2.9) — we now remove the deprecated wrappers entirely.

### Changes

**Source removals (deprecated throwing wrappers):**
- `BuiltinTools.core/safe/withFiles/development/custom` — replaced by `coreSafe`, `withHttpSafe`, `withFilesSafe`, `developmentSafe`, `customSafe`
- `lazy val tool` on `CalculatorTool`, `DateTimeTool`, `JSONTool`, `UUIDTool` — replaced by `toolSafe`
- `lazy val tool / create()` on `ReadFileTool`, `WriteFileTool`, `ListDirectoryTool`, `FileInfoTool`, `HTTPTool`, `ShellTool` — replaced by `createSafe()`
- `lazy val allTools` on `core`, `filesystem`, `http` packages — replaced by `allToolsSafe`
- `WeatherTool.tool` — replaced by `toolSafe`
- `Agent.initialize()` — replaced by `initializeSafe()`
- `ToolBuilder.build()` — replaced by `buildSafe()`

**New safe API:**
- `ToolRegistry.getToolDefinitionsSafe(provider: String): Result[ujson.Value]` — returns `Left(ValidationError)` for unknown providers instead of throwing
- `ToolRegistry.getToolDefinitions` deprecated as a wrapper

**Updated callers:**
- `AzureToolHelper`: uses `getToolDefinitionsSafe("openai")`
- Samples (`MultiToolExample`, `WeatherToolExample`, `BuiltinToolsExample`): use safe variants

**Test changes:**
- Removed all `@nowarn("cat=deprecation")` test sections testing deprecated APIs
- Updated `ToolRegistrySpec` to assert `Left` for unknown provider (instead of `intercept[IllegalArgumentException]`)
- Updated all `crossTest` files (sc2/sc3) to use Safe variants with `.getOrElse(fail(...))`

## Test plan

- [x] `sbt "core/test"` — 4267 tests pass
- [x] `sbt "crossTestScala3/test"` — 90 tests pass
- [x] `sbt "crossTestScala2/test"` — 87 tests pass (1 pre-existing `SchemaCrossTest` abort unrelated to this change)
- [x] Pre-commit hook (scalafmt + full test suite) passes