### PR TITLE
feat: improve provider test coverage via Llm4sHttpClient injection

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VoyageAIEmbeddingProvider.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VoyageAIEmbeddingProvider.scala
@@ -1,75 +1,79 @@
 package org.llm4s.llmconnect.provider
 
+import org.llm4s.http.{ HttpResponse => Llm4sHttpResponse, Llm4sHttpClient }
 import org.llm4s.llmconnect.config.EmbeddingProviderConfig
 import org.llm4s.llmconnect.model._
 import org.llm4s.util.Redaction
 import org.slf4j.LoggerFactory
-import ujson.{ Arr, Obj, read }
+import ujson.{ Arr, Obj }
 
-import java.net.URI
-import java.net.http.{ HttpClient, HttpRequest, HttpResponse }
-import java.nio.charset.StandardCharsets
-import java.time.Duration
 import scala.util.Try
 import scala.util.control.NonFatal
 
 object VoyageAIEmbeddingProvider {
 
-  def fromConfig(cfg: EmbeddingProviderConfig): EmbeddingProvider = new EmbeddingProvider {
-    private val httpClient = HttpClient.newHttpClient()
-    private val logger     = LoggerFactory.getLogger(getClass)
+  def fromConfig(cfg: EmbeddingProviderConfig): EmbeddingProvider =
+    create(cfg, Llm4sHttpClient.create())
 
-    override def embed(request: EmbeddingRequest): Either[EmbeddingError, EmbeddingResponse] = {
-      val model = request.model.name
-      val input = request.input
-      val payload = Obj(
-        "input" -> Arr.from(input),
-        "model" -> model
-      )
+  private[provider] def forTest(cfg: EmbeddingProviderConfig, httpClient: Llm4sHttpClient): EmbeddingProvider =
+    create(cfg, httpClient)
 
-      val url = s"${cfg.baseUrl}/v1/embeddings"
-      logger.debug(s"[VoyageAIEmbeddingProvider] POST $url model=$model inputs=${input.size}")
+  private def create(cfg: EmbeddingProviderConfig, httpClient: Llm4sHttpClient): EmbeddingProvider =
+    new EmbeddingProvider {
+      private val logger = LoggerFactory.getLogger(getClass)
 
-      val httpRequest = HttpRequest
-        .newBuilder()
-        .uri(URI.create(url))
-        .header("Authorization", s"Bearer ${cfg.apiKey}")
-        .header("Content-Type", "application/json")
-        .timeout(Duration.ofMinutes(2))
-        .POST(HttpRequest.BodyPublishers.ofString(payload.render()))
-        .build()
+      override def embed(request: EmbeddingRequest): Either[EmbeddingError, EmbeddingResponse] = {
+        val model = request.model.name
+        val input = request.input
+        val payload = Obj(
+          "input" -> Arr.from(input),
+          "model" -> model
+        )
 
-      val respEither: Either[EmbeddingError, HttpResponse[String]] =
-        try Right(httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)))
-        catch {
-          case e: InterruptedException =>
-            Thread.currentThread().interrupt()
-            Left(
-              EmbeddingError(code = None, message = s"HTTP request interrupted: ${e.getMessage}", provider = "voyage")
-            )
-          case NonFatal(e) =>
-            Left(EmbeddingError(code = None, message = s"HTTP request failed: ${e.getMessage}", provider = "voyage"))
-        }
+        val url = s"${cfg.baseUrl}/v1/embeddings"
+        logger.debug(s"[VoyageAIEmbeddingProvider] POST $url model=$model inputs=${input.size}")
 
-      respEither.flatMap { response =>
-        response.statusCode() match {
-          case 200 =>
-            Try {
-              val json     = read(response.body())
-              val vectors  = json("data").arr.map(r => r("embedding").arr.map(_.num).toVector).toSeq
-              val metadata = Map("provider" -> "voyage", "model" -> model, "count" -> input.size.toString)
-              EmbeddingResponse(embeddings = vectors, metadata = metadata)
-            }.toEither.left
-              .map { ex =>
-                logger.error(s"[VoyageAIEmbeddingProvider] Parse error: ${ex.getMessage}")
-                EmbeddingError(code = None, message = s"Parsing error: ${ex.getMessage}", provider = "voyage")
-              }
-          case status =>
-            val body = Redaction.truncateForLog(response.body())
-            logger.error(s"[VoyageAIEmbeddingProvider] HTTP error: $body")
-            Left(EmbeddingError(code = Some(status.toString), message = body, provider = "voyage"))
+        val headers = Map(
+          "Authorization" -> s"Bearer ${cfg.apiKey}",
+          "Content-Type"  -> "application/json"
+        )
+
+        val respEither: Either[EmbeddingError, Llm4sHttpResponse] =
+          try Right(httpClient.post(url, headers, payload.render(), timeout = 120000))
+          catch {
+            case e: InterruptedException =>
+              Thread.currentThread().interrupt()
+              Left(
+                EmbeddingError(
+                  code = None,
+                  message = s"HTTP request interrupted: ${e.getMessage}",
+                  provider = "voyage"
+                )
+              )
+            case NonFatal(e) =>
+              Left(EmbeddingError(code = None, message = s"HTTP request failed: ${e.getMessage}", provider = "voyage"))
+          }
+
+        respEither.flatMap { response =>
+          response.statusCode match {
+            case 200 =>
+              Try {
+                val json    = ujson.read(response.body)
+                val vectors = json("data").arr.map(r => r("embedding").arr.map(_.num).toVector).toSeq
+                val metadata =
+                  Map("provider" -> "voyage", "model" -> model, "count" -> input.size.toString)
+                EmbeddingResponse(embeddings = vectors, metadata = metadata)
+              }.toEither.left
+                .map { ex =>
+                  logger.error(s"[VoyageAIEmbeddingProvider] Parse error: ${ex.getMessage}")
+                  EmbeddingError(code = None, message = s"Parsing error: ${ex.getMessage}", provider = "voyage")
+                }
+            case status =>
+              val body = Redaction.truncateForLog(response.body)
+              logger.error(s"[VoyageAIEmbeddingProvider] HTTP error: $body")
+              Left(EmbeddingError(code = Some(status.toString), message = body, provider = "voyage"))
+          }
         }
       }
     }
-  }
 }

--- a/modules/core/src/test/scala/org/llm4s/http/MockHttpClient.scala
+++ b/modules/core/src/test/scala/org/llm4s/http/MockHttpClient.scala
@@ -83,6 +83,16 @@ final class MockHttpClient(response: HttpResponse) extends Llm4sHttpClient {
     record(url, headers, None, Some(body), timeout, countPost = true)
     HttpRawResponse(response.statusCode, response.body.getBytes())
   }
+
+  override def postStream(
+    url: String,
+    headers: Map[String, String],
+    body: String,
+    timeout: Int
+  ): StreamingHttpResponse = {
+    record(url, headers, None, Some(body), timeout, countPost = true)
+    StreamingHttpResponse(response.statusCode, new java.io.ByteArrayInputStream(response.body.getBytes()))
+  }
 }
 
 final class FailingHttpClient(exception: Throwable) extends Llm4sHttpClient {
@@ -135,4 +145,11 @@ final class FailingHttpClient(exception: Throwable) extends Llm4sHttpClient {
     body: String,
     timeout: Int
   ): HttpRawResponse = fail
+
+  override def postStream(
+    url: String,
+    headers: Map[String, String],
+    body: String,
+    timeout: Int
+  ): StreamingHttpResponse = fail
 }

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/GeminiClientHttpSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/GeminiClientHttpSpec.scala
@@ -1,0 +1,237 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.http.{ HttpResponse, Llm4sHttpClient, StreamingHttpResponse }
+import org.llm4s.llmconnect.config.GeminiConfig
+import org.llm4s.llmconnect.model._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+class GeminiClientHttpSpec extends AnyFlatSpec with Matchers with MockFactory {
+
+  private val testConfig = GeminiConfig(
+    apiKey = "test-key",
+    model = "gemini-2.0-flash",
+    baseUrl = "https://generativelanguage.googleapis.com/v1beta",
+    contextWindow = 1048576,
+    reserveCompletion = 8192
+  )
+
+  private def mkClient(mockHttp: Llm4sHttpClient): GeminiClient =
+    new GeminiClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, mockHttp)
+
+  private def httpOk(body: String): HttpResponse = HttpResponse(200, body, Map.empty)
+  private def httpErr(status: Int): HttpResponse = HttpResponse(status, s"Error $status", Map.empty)
+  private def conversation(text: String): Conversation =
+    Conversation(messages = Seq(UserMessage(text)))
+
+  private val successBody =
+    """|{"candidates":[{"content":{"parts":[{"text":"Hello!"}],"role":"model"},"finishReason":"STOP"}],
+       | "usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}""".stripMargin
+
+  // ============================================================
+  // complete() tests
+  // ============================================================
+
+  "GeminiClient.complete()" should "parse text content from a 200 response" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(httpOk(successBody))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.content shouldBe "Hello!"
+  }
+
+  it should "parse token usage from the response" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(httpOk(successBody))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isRight shouldBe true
+    val usage = result.toOption.get.usage.get
+    usage.promptTokens shouldBe 10
+    usage.completionTokens shouldBe 5
+    usage.totalTokens shouldBe 15
+  }
+
+  it should "parse a tool call response" in {
+    val toolCallBody =
+      """{"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","args":{"location":"London"}}}],"role":"model"}}]}"""
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(httpOk(toolCallBody))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("What's the weather?"), CompletionOptions())
+
+    result.isRight shouldBe true
+    val completion = result.toOption.get
+    completion.toolCalls should have size 1
+    completion.toolCalls.head.name shouldBe "get_weather"
+  }
+
+  it should "return AuthenticationError on HTTP 401" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(httpErr(401))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.AuthenticationError]
+  }
+
+  it should "return AuthenticationError on HTTP 403" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(httpErr(403))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.AuthenticationError]
+  }
+
+  it should "return RateLimitError on HTTP 429" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(httpErr(429))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.RateLimitError]
+  }
+
+  it should "return ValidationError on HTTP 400" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(httpErr(400))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.ValidationError]
+  }
+
+  it should "return ServiceError on HTTP 500" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(httpErr(500))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.ServiceError]
+  }
+
+  // ============================================================
+  // streamComplete() tests
+  // ============================================================
+
+  "GeminiClient.streamComplete()" should "parse SSE lines and accumulate into a Completion" in {
+    val sseData =
+      "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}]}}]}\n" +
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" world\"}]}}]," +
+        "\"usageMetadata\":{\"promptTokenCount\":5,\"candidatesTokenCount\":2,\"totalTokenCount\":7}}\n"
+    val inputStream = new ByteArrayInputStream(sseData.getBytes(StandardCharsets.UTF_8))
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(200, inputStream))
+
+    val chunks = scala.collection.mutable.Buffer[StreamedChunk]()
+    val client = mkClient(mockHttp)
+    val result = client.streamComplete(conversation("Hi"), CompletionOptions(), chunk => chunks += chunk)
+
+    result.isRight shouldBe true
+    result.toOption.get.content should include("Hello")
+    result.toOption.get.content should include("world")
+    chunks should have size 2
+  }
+
+  it should "parse token usage from the final SSE chunk" in {
+    val sseData =
+      "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Done\"}]}}]," +
+        "\"usageMetadata\":{\"promptTokenCount\":5,\"candidatesTokenCount\":2,\"totalTokenCount\":7}}\n"
+    val inputStream = new ByteArrayInputStream(sseData.getBytes(StandardCharsets.UTF_8))
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(200, inputStream))
+
+    val client = mkClient(mockHttp)
+    val result = client.streamComplete(conversation("Hi"), CompletionOptions(), _ => ())
+
+    result.isRight shouldBe true
+    val usage = result.toOption.get.usage.get
+    usage.promptTokens shouldBe 5
+    usage.completionTokens shouldBe 2
+  }
+
+  it should "return an error for non-200 status before reading the body" in {
+    val errorBody   = """{"error":{"message":"API key missing","status":"UNAUTHENTICATED"}}"""
+    val inputStream = new ByteArrayInputStream(errorBody.getBytes(StandardCharsets.UTF_8))
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(401, inputStream))
+
+    val client = mkClient(mockHttp)
+    val result = client.streamComplete(conversation("Hi"), CompletionOptions(), _ => ())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.AuthenticationError]
+  }
+
+  // ============================================================
+  // Schema conversion tests (convertToolToGeminiFormat)
+  // ============================================================
+
+  "GeminiClient.convertToolToGeminiFormat()" should "strip 'strict' and 'additionalProperties' from schema" in {
+    import org.llm4s.toolapi.{ Schema, ToolBuilder }
+
+    val schema = Schema
+      .`object`[Map[String, Any]]("Input")
+      .withProperty(Schema.property("q", Schema.string("query")))
+
+    val toolResult = ToolBuilder[Map[String, Any], String]("search", "Search tool", schema)
+      .withHandler(_ => Right("ok"))
+      .buildSafe()
+
+    val client = mkClient(stub[Llm4sHttpClient])
+    toolResult match {
+      case Right(tool) =>
+        val geminiTool = client.convertToolToGeminiFormat(tool)
+        val rendered   = geminiTool.render()
+        (rendered should not).include("\"strict\"")
+        (rendered should not).include("\"additionalProperties\"")
+      case Left(err) => fail(s"Tool build failed: ${err.message}")
+    }
+  }
+
+  it should "include name, description and parameters in the result" in {
+    import org.llm4s.toolapi.{ Schema, ToolBuilder }
+
+    val schema = Schema
+      .`object`[Map[String, Any]]("Input")
+      .withProperty(Schema.property("x", Schema.integer("x")))
+
+    val toolResult = ToolBuilder[Map[String, Any], String]("my_tool", "My tool description", schema)
+      .withHandler(_ => Right("ok"))
+      .buildSafe()
+
+    val client = mkClient(stub[Llm4sHttpClient])
+    toolResult match {
+      case Right(tool) =>
+        val geminiTool = client.convertToolToGeminiFormat(tool)
+        geminiTool("name").str shouldBe "my_tool"
+        geminiTool("description").str shouldBe "My tool description"
+        geminiTool.obj.contains("parameters") shouldBe true
+      case Left(err) => fail(s"Tool build failed: ${err.message}")
+    }
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/OllamaClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/OllamaClientSpec.scala
@@ -1,9 +1,14 @@
 package org.llm4s.llmconnect.provider
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.llm4s.llmconnect.model._
+import org.llm4s.http.{ HttpResponse, Llm4sHttpClient, StreamingHttpResponse }
 import org.llm4s.llmconnect.config.OllamaConfig
+import org.llm4s.llmconnect.model._
 import org.llm4s.metrics.MockMetricsCollector
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
 
 /**
  * Test helper for building Ollama request bodies.
@@ -84,5 +89,202 @@ class OllamaClientSpec extends AnyFunSuite {
 
     // Verify it compiles and doesn't throw (noop metrics should never fail)
     assert(client != null)
+  }
+}
+
+// ============================================================
+// HTTP stub-based tests for OllamaClient
+// ============================================================
+class OllamaClientHttpSpec extends AnyFunSuite with MockFactory {
+
+  private val testConfig = OllamaConfig(
+    model = "llama3.1",
+    baseUrl = "http://localhost:11434",
+    contextWindow = 4096,
+    reserveCompletion = 512
+  )
+
+  private def mkClient(mockHttp: Llm4sHttpClient): OllamaClient =
+    new OllamaClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, mockHttp)
+
+  private def httpOk(body: String): HttpResponse = HttpResponse(200, body, Map.empty)
+  private def conversation(text: String): Conversation =
+    Conversation(messages = Seq(UserMessage(text)))
+
+  // ── complete() happy path ────────────────────────────────────────────────
+
+  test("complete() parses message.content from a 200 response") {
+    val mockHttp = stub[Llm4sHttpClient]
+    val body     = """{"message":{"content":"Hi there!"},"prompt_eval_count":10,"eval_count":5}"""
+    (mockHttp.post _).when(*, *, *, *).returns(httpOk(body))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hello"), CompletionOptions())
+
+    assert(result.isRight)
+    assert(result.toOption.get.content == "Hi there!")
+  }
+
+  test("complete() parses token usage from the response") {
+    val mockHttp = stub[Llm4sHttpClient]
+    val body     = """{"message":{"content":"OK"},"prompt_eval_count":12,"eval_count":8}"""
+    (mockHttp.post _).when(*, *, *, *).returns(httpOk(body))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hello"), CompletionOptions())
+
+    assert(result.isRight)
+    val usage = result.toOption.get.usage.get
+    assert(usage.promptTokens == 12)
+    assert(usage.completionTokens == 8)
+    assert(usage.totalTokens == 20)
+  }
+
+  test("complete() returns None usage when token counts are absent") {
+    val mockHttp = stub[Llm4sHttpClient]
+    val body     = """{"message":{"content":"OK"}}"""
+    (mockHttp.post _).when(*, *, *, *).returns(httpOk(body))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hello"), CompletionOptions())
+
+    assert(result.isRight)
+    assert(result.toOption.get.usage.isEmpty)
+  }
+
+  // ── complete() error cases ───────────────────────────────────────────────
+
+  test("complete() returns AuthenticationError on HTTP 401") {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(401, "Unauthorized", Map.empty))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hello"), CompletionOptions())
+
+    assert(result.isLeft)
+    assert(result.left.toOption.get.isInstanceOf[org.llm4s.error.AuthenticationError])
+  }
+
+  test("complete() returns RateLimitError on HTTP 429") {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(429, "Too Many Requests", Map.empty))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hello"), CompletionOptions())
+
+    assert(result.isLeft)
+    assert(result.left.toOption.get.isInstanceOf[org.llm4s.error.RateLimitError])
+  }
+
+  test("complete() returns ServiceError on HTTP 500") {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(500, "Internal Server Error", Map.empty))
+
+    val client = mkClient(mockHttp)
+    val result = client.complete(conversation("Hello"), CompletionOptions())
+
+    assert(result.isLeft)
+    assert(result.left.toOption.get.isInstanceOf[org.llm4s.error.ServiceError])
+  }
+
+  // ── request body tests via OllamaRequestBodyTestHelper ──────────────────
+
+  test("request body includes system, user and assistant messages with correct roles") {
+    val conv = Conversation(messages =
+      Seq(
+        SystemMessage("Be helpful"),
+        UserMessage("Hello"),
+        AssistantMessage(Some("Hi"), Seq.empty)
+      )
+    )
+    val body = OllamaRequestBodyTestHelper.createRequestBody(conv, CompletionOptions(), stream = false)
+    val msgs = body("messages").arr
+    assert(msgs.exists(_("role").str == "system"))
+    assert(msgs.exists(_("role").str == "user"))
+    assert(msgs.exists(_("role").str == "assistant"))
+  }
+
+  test("request body drops ToolMessages silently") {
+    val conv = Conversation(messages =
+      Seq(
+        UserMessage("Hello"),
+        ToolMessage("tool result", "call-1")
+      )
+    )
+    val body = OllamaRequestBodyTestHelper.createRequestBody(conv, CompletionOptions(), stream = false)
+    val msgs = body("messages").arr
+    // Only the UserMessage should appear; ToolMessage is dropped
+    assert(msgs.size == 1)
+    assert(msgs.head("role").str == "user")
+  }
+
+  test("request body maps maxTokens to num_predict in options") {
+    val options = CompletionOptions(maxTokens = Some(256))
+    val conv    = Conversation(messages = Seq(UserMessage("Hello")))
+    val body    = OllamaRequestBodyTestHelper.createRequestBody(conv, options, stream = false)
+    val opts    = body("options")
+    assert(opts("num_predict").num.toInt == 256)
+  }
+
+  test("request body includes temperature and topP in options") {
+    val options = CompletionOptions(temperature = 0.7, topP = 0.9)
+    val conv    = Conversation(messages = Seq(UserMessage("Hello")))
+    val body    = OllamaRequestBodyTestHelper.createRequestBody(conv, options, stream = false)
+    val opts    = body("options")
+    assert(opts("temperature").num == 0.7)
+    assert(opts("top_p").num == 0.9)
+  }
+
+  // ── streamComplete() tests ───────────────────────────────────────────────
+
+  test("streamComplete() parses JSON lines and accumulates content") {
+    val jsonLines =
+      "{\"message\":{\"content\":\"Hello\"},\"done\":false}\n" +
+        "{\"message\":{\"content\":\" world\"},\"done\":false}\n" +
+        "{\"message\":{\"content\":\"\"},\"done\":true,\"prompt_eval_count\":10,\"eval_count\":5}\n"
+    val inputStream = new ByteArrayInputStream(jsonLines.getBytes(StandardCharsets.UTF_8))
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(200, inputStream))
+
+    val chunks = scala.collection.mutable.Buffer[StreamedChunk]()
+    val client = mkClient(mockHttp)
+    val result = client.streamComplete(conversation("Hello"), CompletionOptions(), chunk => chunks += chunk)
+
+    assert(result.isRight)
+    val completion = result.toOption.get
+    assert(completion.content.contains("Hello"))
+    assert(completion.content.contains("world"))
+  }
+
+  test("streamComplete() parses token counts from the done=true line") {
+    val jsonLines =
+      "{\"message\":{\"content\":\"Done\"},\"done\":true,\"prompt_eval_count\":15,\"eval_count\":7}\n"
+    val inputStream = new ByteArrayInputStream(jsonLines.getBytes(StandardCharsets.UTF_8))
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(200, inputStream))
+
+    val client = mkClient(mockHttp)
+    val result = client.streamComplete(conversation("Hello"), CompletionOptions(), _ => ())
+
+    assert(result.isRight)
+    val usage = result.toOption.get.usage.get
+    assert(usage.promptTokens == 15)
+    assert(usage.completionTokens == 7)
+  }
+
+  test("streamComplete() returns error on non-200 status") {
+    val errorBody   = "Unauthorized"
+    val inputStream = new ByteArrayInputStream(errorBody.getBytes(StandardCharsets.UTF_8))
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(401, inputStream))
+
+    val client = mkClient(mockHttp)
+    val result = client.streamComplete(conversation("Hello"), CompletionOptions(), _ => ())
+
+    assert(result.isLeft)
+    assert(result.left.toOption.get.isInstanceOf[org.llm4s.error.AuthenticationError])
   }
 }

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VoyageAIEmbeddingProviderSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VoyageAIEmbeddingProviderSpec.scala
@@ -1,0 +1,112 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.http.{ HttpResponse, Llm4sHttpClient }
+import org.llm4s.llmconnect.config.{ EmbeddingModelConfig, EmbeddingProviderConfig }
+import org.llm4s.llmconnect.model.EmbeddingRequest
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class VoyageAIEmbeddingProviderSpec extends AnyFlatSpec with Matchers with MockFactory {
+
+  private val cfg = EmbeddingProviderConfig(
+    baseUrl = "http://voyage-test",
+    model = "voyage-3",
+    apiKey = "test-key"
+  )
+  private val modelCfg = EmbeddingModelConfig("voyage-3", 1024)
+  private val req      = EmbeddingRequest(Seq("hello", "world"), modelCfg)
+
+  private def httpOk(body: String): HttpResponse               = HttpResponse(200, body, Map.empty)
+  private def httpErr(status: Int, body: String): HttpResponse = HttpResponse(status, body, Map.empty)
+
+  "VoyageAIEmbeddingProvider" should "parse a successful embedding response with two vectors" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    val body =
+      """{"data":[{"embedding":[0.1,0.2,0.3]},{"embedding":[0.4,0.5,0.6]}]}"""
+    (mockHttp.post _).when(*, *, *, *).returns(httpOk(body))
+
+    val provider = VoyageAIEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(req)
+
+    result.isRight shouldBe true
+    val resp = result.toOption.get
+    resp.embeddings should have size 2
+    resp.embeddings(0) shouldBe Vector(0.1, 0.2, 0.3)
+    resp.embeddings(1) shouldBe Vector(0.4, 0.5, 0.6)
+  }
+
+  it should "return embeddings in the correct order for multiple inputs" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    val body =
+      """{"data":[{"embedding":[1.0]},{"embedding":[2.0]},{"embedding":[3.0]}]}"""
+    (mockHttp.post _).when(*, *, *, *).returns(httpOk(body))
+
+    val multiReq = EmbeddingRequest(Seq("a", "b", "c"), modelCfg)
+    val provider = VoyageAIEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(multiReq)
+
+    result.isRight shouldBe true
+    val resp = result.toOption.get
+    resp.embeddings(0)(0) shouldBe 1.0
+    resp.embeddings(1)(0) shouldBe 2.0
+    resp.embeddings(2)(0) shouldBe 3.0
+  }
+
+  it should "include model metadata in the response" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    val body     = """{"data":[{"embedding":[0.1]},{"embedding":[0.2]}]}"""
+    (mockHttp.post _).when(*, *, *, *).returns(httpOk(body))
+
+    val provider = VoyageAIEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(req)
+
+    result.isRight shouldBe true
+    result.toOption.get.metadata("provider") shouldBe "voyage"
+    result.toOption.get.metadata("model") shouldBe "voyage-3"
+  }
+
+  it should "return EmbeddingError with code '401' on HTTP 401" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(httpErr(401, "Unauthorized"))
+
+    val provider = VoyageAIEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(req)
+
+    result.isLeft shouldBe true
+    result.left.toOption.get.code shouldBe Some("401")
+    result.left.toOption.get.context.get("provider") shouldBe Some("voyage")
+  }
+
+  it should "return EmbeddingError with code '500' on HTTP 500" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(httpErr(500, "Internal Server Error"))
+
+    val provider = VoyageAIEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(req)
+
+    result.isLeft shouldBe true
+    result.left.toOption.get.code shouldBe Some("500")
+  }
+
+  it should "return EmbeddingError on malformed JSON response" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(httpOk("not-json{{{"))
+
+    val provider = VoyageAIEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(req)
+
+    result.isLeft shouldBe true
+    result.left.toOption.get.context.get("provider") shouldBe Some("voyage")
+  }
+
+  it should "return EmbeddingError on missing 'data' field in JSON" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(httpOk("""{"result": []}"""))
+
+    val provider = VoyageAIEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(req)
+
+    result.isLeft shouldBe true
+  }
+}


### PR DESCRIPTION
## Summary

- Add `StreamingHttpResponse` + `postStream()` to `Llm4sHttpClient`, enabling streaming HTTP to be mocked in tests
- Migrate `VoyageAIEmbeddingProvider`, `GeminiClient`, and `OllamaClient` from `java.net.http.HttpClient` to `Llm4sHttpClient`, using the established injection pattern already used by `QdrantVectorStore`
- Add 32 new unit tests across 3 new/extended spec files, all running without network access
- Bonus fix: Gemini streaming now correctly parses `usageMetadata` token counts from SSE chunks

## Changes

### Production
| File | Change |
|---|---|
| `http/Llm4sHttpClient.scala` | Add `StreamingHttpResponse` case class and `postStream()` method |
| `provider/VoyageAIEmbeddingProvider.scala` | Replace Java HttpClient with `Llm4sHttpClient`; add `forTest()` factory |
| `provider/GeminiClient.scala` | Replace Java HttpClient with `Llm4sHttpClient` for `complete()` and `streamComplete()`; parse streaming token usage |
| `provider/OllamaClient.scala` | Replace Java HttpClient with `Llm4sHttpClient` for `connect()` and `streamComplete()` |

### Tests
| File | New Tests |
|---|---|
| `VoyageAIEmbeddingProviderSpec.scala` (new) | 6 — happy path, ordering, metadata, HTTP 401/500, malformed JSON |
| `GeminiClientHttpSpec.scala` (new) | 13 — complete() success/errors, streamComplete() SSE/tokens/errors, schema conversion |
| `OllamaClientSpec.scala` (extended) | 13 — complete() success/usage/errors, request body serialisation, streamComplete() |
| `http/MockHttpClient.scala` | Add `postStream()` to `MockHttpClient` and `FailingHttpClient` |

## Test plan
- [x] `sbt "core/testOnly org.llm4s.llmconnect.provider.*"` — all 222 tests pass
- [x] `sbt "core/testOnly org.llm4s.http.*"` — all 23 tests pass
- [x] Full pre-commit suite (4330 tests) — all pass
- [x] `sbt scalafmtAll` — no formatting violations