### PR TITLE
feat: add clock parameter to CircuitBreaker for improved testability

### DIFF
--- a/modules/core/src/test/scala/org/llm4s/error/ErrorRecoverySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/error/ErrorRecoverySpec.scala
@@ -178,17 +178,19 @@ class ErrorRecoverySpec extends AnyFlatSpec with Matchers {
   }
 
   it should "transition from Open to HalfOpen after recovery timeout" in {
+    var fakeTime = 0L
     val cb = new ErrorRecovery.CircuitBreaker[String](
       failureThreshold = 2,
-      recoveryTimeout = 50.millis
+      recoveryTimeout = 50.millis,
+      clock = () => fakeTime
     )
 
     // Open the circuit
     cb.execute(() => Result.failure(ServiceError(500, "p", "error")))
     cb.execute(() => Result.failure(ServiceError(500, "p", "error")))
 
-    // Wait for recovery timeout
-    Thread.sleep(100)
+    // Advance the clock past the recovery timeout — no Thread.sleep needed
+    fakeTime += 100
 
     // Next call should be allowed (HalfOpen state)
     val result = cb.execute(() => Result.success("recovered"))
@@ -196,17 +198,19 @@ class ErrorRecoverySpec extends AnyFlatSpec with Matchers {
   }
 
   it should "close circuit on success in HalfOpen state" in {
+    var fakeTime = 0L
     val cb = new ErrorRecovery.CircuitBreaker[String](
       failureThreshold = 2,
-      recoveryTimeout = 50.millis
+      recoveryTimeout = 50.millis,
+      clock = () => fakeTime
     )
 
     // Open the circuit
     cb.execute(() => Result.failure(ServiceError(500, "p", "error")))
     cb.execute(() => Result.failure(ServiceError(500, "p", "error")))
 
-    // Wait for recovery timeout
-    Thread.sleep(100)
+    // Advance the clock past the recovery timeout — no Thread.sleep needed
+    fakeTime += 100
 
     // Successful call in HalfOpen closes circuit
     cb.execute(() => Result.success("success"))
@@ -219,17 +223,19 @@ class ErrorRecoverySpec extends AnyFlatSpec with Matchers {
   }
 
   it should "reopen circuit on failure in HalfOpen state" in {
+    var fakeTime = 0L
     val cb = new ErrorRecovery.CircuitBreaker[String](
       failureThreshold = 2,
-      recoveryTimeout = 50.millis
+      recoveryTimeout = 50.millis,
+      clock = () => fakeTime
     )
 
     // Open the circuit
     cb.execute(() => Result.failure(ServiceError(500, "p", "error")))
     cb.execute(() => Result.failure(ServiceError(500, "p", "error")))
 
-    // Wait for recovery timeout
-    Thread.sleep(100)
+    // Advance the clock past the recovery timeout — no Thread.sleep needed
+    fakeTime += 100
 
     // Failure in HalfOpen reopens circuit
     cb.execute(() => Result.failure(ServiceError(500, "p", "error")))


### PR DESCRIPTION
## What does this PR do?
- Added clock: () => Long = () => System.currentTimeMillis() as a third parameter with a sensible default so all existing call sites are unaffected.
- The three Thread.sleep-based timeout tests are rewritten to use a deterministic fake clock

## Related issue
Related to PR https://github.com/llm4s/llm4s/pull/739

## How was this tested?
- sbt "core/testOnly org.llm4s.error.ErrorRecoverySpec"
- sbt scalafmtAll 

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt +test` — tests pass on both Scala 2.13 and 3.x
- [x] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"
