### PR TITLE
docs: ScalaDoc Wave 4 — identity, syntax, trace, and MCP packages

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/identity/Identity.scala
+++ b/modules/core/src/main/scala/org/llm4s/identity/Identity.scala
@@ -1,5 +1,14 @@
 package org.llm4s.identity
 
+/**
+ * Identifies an LLM runtime (provider backend) by its canonical name.
+ *
+ * Used to associate runtime-specific configuration and behaviour with a
+ * named backend, e.g. for tokenizer selection. Constants for all supported
+ * runtimes are defined on the companion object.
+ *
+ * @param name Canonical name string as expected by provider APIs (lower-case).
+ */
 case class RuntimeId(name: String)
 
 //noinspection TypeAnnotation,ScalaUnusedSymbol
@@ -9,6 +18,18 @@ object RuntimeId {
   val ANTHROPIC = RuntimeId("anthropic")
 }
 
+/**
+ * Identifies a specific LLM model by its API name string.
+ *
+ * Model identifiers are forwarded verbatim to the provider's API. The
+ * companion object lists constants for known OpenAI models; other models
+ * (Anthropic, Gemini, Ollama, etc.) are referenced by passing the API
+ * name string directly to [[RuntimeId]] and the relevant
+ * [[org.llm4s.llmconnect.config.ProviderConfig]].
+ *
+ * @param name Model identifier as expected by the provider API
+ *             (e.g. `"gpt-4o"`, `"o3-mini"`).
+ */
 case class ModelId(name: String)
 
 //noinspection TypeAnnotation,ScalaUnusedSymbol
@@ -23,6 +44,18 @@ object ModelId {
   val GPT_4o_2024_05_13          = ModelId("gpt-4o-2024-05-13")
 }
 
+/**
+ * Identifies a BPE tokenizer vocabulary by its canonical name.
+ *
+ * Tokenizer IDs are used by context-window estimation logic to select the
+ * correct byte-pair-encoding vocabulary for a given model, so that prompt
+ * and completion token counts are accurate without calling the provider API.
+ * The mapping from [[ModelId]] to [[TokenizerId]] is maintained by the
+ * context package.
+ *
+ * @param name Tokenizer vocabulary name as used by tiktoken and related
+ *             libraries (e.g. `"cl100k_base"` for GPT-4 / GPT-3.5).
+ */
 case class TokenizerId(name: String)
 
 //noinspection TypeAnnotation,ScalaUnusedSymbol

--- a/modules/core/src/main/scala/org/llm4s/syntax/syntax.scala
+++ b/modules/core/src/main/scala/org/llm4s/syntax/syntax.scala
@@ -3,27 +3,93 @@ package org.llm4s.syntax
 import org.llm4s.error
 import org.llm4s.types.Result
 
+/**
+ * Extension methods for `Result[A]` (`Either[LLMError, A]`).
+ *
+ * Import `org.llm4s.syntax.syntax._` to bring these into scope.
+ *
+ * @example
+ * {{{
+ * import org.llm4s.syntax.syntax._
+ *
+ * val result: Result[String] = Right("hello")
+ * result
+ *   .recover { case _: RateLimitError => "fallback" }
+ *   .tap(println)
+ * }}}
+ */
 object syntax {
+
+  /**
+   * Enriches `Result[A]` with combinators for error handling and side effects.
+   *
+   * These methods parallel standard `Either` and `Try` combinators but are
+   * typed specifically for `LLMError` on the left side, making the failure
+   * domain explicit at each call site.
+   */
   implicit class ResultOps[A](private val result: Result[A]) extends AnyVal {
+
+    /** Returns the success value, or `default` when the result is a `Left`. */
     def getOrElse[B >: A](default: => B): B = result.getOrElse(default)
 
+    /**
+     * Returns this result when it is a `Right`, or evaluates `alternative`
+     * when it is a `Left`.  The original error is discarded.
+     */
     def orElse[B >: A](alternative: => Result[B]): Result[B] =
       result.fold(_ => alternative, Right(_))
 
+    /**
+     * Transforms the error value without changing the success type.
+     * Leaves `Right` values untouched.
+     *
+     * @param f transforms the `LLMError`; must return an `LLMError`
+     */
     def mapError(f: error.LLMError => error.LLMError): Result[A] =
       result.left.map(f)
 
+    /**
+     * Converts a matching `Left` into a `Right` using the supplied partial function.
+     *
+     * If the partial function is not defined for the error, the original `Left`
+     * is returned unchanged.  `Right` values pass through without invoking `pf`.
+     *
+     * @param pf partial function from `LLMError` to a recovery value
+     */
     def recover[B >: A](pf: PartialFunction[error.LLMError, B]): Result[B] =
       result.fold(error => pf.lift(error).map(Right(_)).getOrElse(Left(error)), Right(_))
 
+    /**
+     * Converts a matching `Left` into a new `Result` using the supplied partial function.
+     *
+     * Useful when the recovery operation can itself fail.  If the partial
+     * function is not defined for the error, the original `Left` is returned
+     * unchanged.  `Right` values pass through without invoking `pf`.
+     *
+     * @param pf partial function from `LLMError` to a new `Result[B]`
+     */
     def recoverWith[B >: A](pf: PartialFunction[error.LLMError, Result[B]]): Result[B] =
       result.fold(error => pf.lift(error).getOrElse(Left(error)), Right(_))
 
+    /**
+     * Executes `effect` for its side effect when the result is a `Right`,
+     * then returns the original result unchanged.
+     * Useful for logging or metrics without breaking a `for`-comprehension chain.
+     *
+     * @param effect side-effecting function invoked on success; its return value is discarded
+     */
     def tap(effect: A => Unit): Result[A] = {
       result.foreach(effect)
       result
     }
 
+    /**
+     * Executes `effect` for its side effect when the result is a `Left`,
+     * then returns the original result unchanged.
+     * Useful for logging errors without altering the failure path.
+     *
+     * @param effect side-effecting function invoked on failure; its return value is discarded
+     */
     def tapError(effect: error.LLMError => Unit): Result[A] = {
       result.left.foreach(effect)
       result


### PR DESCRIPTION
## Summary

- Adds ScalaDoc to the Wave 4 file set: `identity/`, `syntax/`, `trace/` (remaining gaps), and `mcp/`
- Completes the documentation rollout started in Waves 1–3 for these supporting infrastructure packages

## Files changed

| File | What was added |
|------|----------------|
| `identity/Identity.scala` | `RuntimeId`: role as provider-backend identifier; `ModelId`: API name forwarded verbatim to provider; `TokenizerId`: BPE vocabulary mapping role and tiktoken naming |
| `syntax/syntax.scala` | `ResultOps` with `@example`; all 7 extension methods: `getOrElse`, `orElse` (original error discarded), `mapError`, `recover` (undefined errors left as-is), `recoverWith`, `tap`, `tapError` |
| `trace/TraceEvent.scala` | Sealed trait: JSON format, 5-frame stack trace truncation in `ErrorOccurred`, `Instant.now()` default; `createTraceEvent`: Langfuse batch-envelope purpose, random envelope UUID, wall-clock `sessionId` |
| `trace/Tracing.scala` | `traceEvent(String)`: `CustomEvent` wrapping with empty data; `CompositeTracing`: soft-failure semantics (Right unless ALL backends fail); `TracingMode`/`fromString`: NoOp fallback on unrecognised mode |
| `mcp/MCPClientImpl.scala` | Class doc: transport auto-detection (Streamable HTTP 2025-06-18 → SSE 2024-11-05 fallback on 404/405), error swallowing in `getTools`, thread-safety caveat; `getTools`: always-Right contract |
| `mcp/MCPToolRegistry.scala` | Class doc: tool lookup order (local first), cache TTL, startup init flag, per-server error isolation, `AutoCloseable` lifecycle; `clearCache`, `refreshCache`, `closeMCPClients`, `healthCheck` individual docs |
| `trace/store/InMemoryTraceStore.scala` | `queryTraces`: cursor semantics (last `traceId` on page, invalid cursor falls back to start), AND-combined filters; `deleteTrace`: span cascade deletion |

## Scaladoc quality

- `sbt "core/clean; core/doc"` produces only the same 2 pre-existing warnings in `LLMConnect.scala` (Wave 1); no new warnings
- `sbt core/scalafmtAll` clean
- All 4705 tests pass

## Test plan

- [x] `sbt core/compile` — no errors
- [x] `sbt core/scalafmtAll` — clean
- [x] `sbt "core/clean; core/doc"` — no new warnings
- [x] `sbt +test` — all 4705 tests pass (pre-commit hook)