### PR TITLE
refactor: split Agent.scala into focused private[agent] modules

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/agent/AgentStreamingExecutor.scala
+++ b/modules/core/src/main/scala/org/llm4s/agent/AgentStreamingExecutor.scala
@@ -1,0 +1,688 @@
+package org.llm4s.agent
+
+import org.llm4s.agent.guardrails.{ InputGuardrail, OutputGuardrail }
+import org.llm4s.agent.streaming.AgentEvent
+import org.llm4s.error.UnknownError
+import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.model._
+import org.llm4s.llmconnect.streaming.StreamingAccumulator
+import org.llm4s.toolapi.{ ToolExecutionStrategy, ToolRegistry }
+import org.llm4s.trace.Tracing
+import org.llm4s.types.Result
+import org.slf4j.LoggerFactory
+
+import java.time.Instant
+import scala.annotation.tailrec
+import scala.concurrent.ExecutionContext
+import scala.util.{ Failure, Success, Try }
+
+/**
+ * Streaming and strategy-based agent execution variants.
+ *
+ * Extracts the `runWithEvents` / `runWithStrategy` family from [[Agent]] so
+ * the core orchestration loop in [[Agent]] stays focused on the
+ * `InProgress → WaitingForTools → Complete` state machine.
+ *
+ * == Why streaming and batch share the same [[AgentState]] machine ==
+ *
+ * Whether or not an `onEvent` callback is attached, the agent transitions
+ * through identical status values (`InProgress`, `WaitingForTools`, `Complete`,
+ * `Failed`, `HandoffRequested`).  Using the same state machine for both paths
+ * guarantees that observable state transitions are identical — a caller that
+ * switches from `run` to `runWithEvents` sees the same sequence of states and
+ * the same final result.
+ *
+ * == Why `runCollectingEvents` exists alongside `runWithEvents` ==
+ *
+ * `runWithEvents` is designed for real-time UIs that need each event as it
+ * occurs.  `runCollectingEvents` is designed for '''testing and logging''': the
+ * caller only cares about the final state and the complete event sequence, not
+ * about real-time delivery.  Collecting all events into a `Seq` also makes
+ * assertions in tests much easier than inspecting a mutable buffer.
+ *
+ * @param client         The LLM client forwarded from the owning [[Agent]].
+ * @param runStep        Reference to [[Agent.runStep]] so the strategy loop can
+ *                       reuse the core state-machine step without duplicating it.
+ * @param initializeSafe Reference to [[Agent.initializeSafe]] so this executor
+ *                       can prepare the initial state without holding a reference
+ *                       to the owning [[Agent]] instance.
+ */
+final private[agent] class AgentStreamingExecutor(
+  client: LLMClient,
+  runStep: (AgentState, AgentContext) => Result[AgentState],
+  initializeSafe: (String, ToolRegistry, Seq[Handoff], Option[String], CompletionOptions) => Result[AgentState]
+) {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /** Best-effort tracing — failures must never affect agent control flow. */
+  private def safeTrace(tracing: Option[Tracing])(f: Tracing => Result[Unit]): Unit =
+    tracing.foreach { tracer =>
+      f(tracer) match {
+        case Left(error) =>
+          error match {
+            case UnknownError(msg, cause) =>
+              logger.debug("Tracing failed: " + msg, cause)
+            case _ =>
+              logger.debug("Tracing failed: {}", error)
+          }
+        case Right(_) =>
+          ()
+      }
+    }
+
+  /** Accumulates token usage from a completion into the agent state. */
+  private def accumulateUsage(state: AgentState, completion: Completion): AgentState =
+    completion.usage match {
+      case Some(usage) =>
+        state.copy(
+          usageSummary = state.usageSummary.add(
+            completion.model,
+            usage,
+            completion.estimatedCost
+          )
+        )
+      case None => state
+    }
+
+  // ============================================================
+  // Streaming Event-based Execution
+  // ============================================================
+
+  /**
+   * Runs the agent with streaming events for real-time progress tracking.
+   *
+   * Pipeline:
+   * 1. Input guardrail events emitted and guardrails evaluated.
+   * 2. [[AgentEvent.AgentStarted]] emitted.
+   * 3. State initialised via [[initializeSafe]].
+   * 4. Streaming execution loop runs via [[runWithEventsInternal]].
+   * 5. Output guardrail events emitted and guardrails evaluated.
+   *
+   * @param query               User message to process.
+   * @param tools               Available tools.
+   * @param onEvent             Callback invoked for each event.
+   * @param inputGuardrails     Applied to `query`; default none.
+   * @param outputGuardrails    Applied to the final assistant message; default none.
+   * @param handoffs            Agents to delegate to; default none.
+   * @param maxSteps            Step cap; default [[Agent.DefaultMaxSteps]].
+   * @param systemPromptAddition Text appended to the built-in system prompt.
+   * @param completionOptions   LLM parameters forwarded on every call.
+   * @param context             Cross-cutting concerns.
+   * @return `Right(state)` on success; `Left` on guardrail or LLM failure.
+   */
+  def runWithEvents(
+    query: String,
+    tools: ToolRegistry,
+    onEvent: AgentEvent => Unit,
+    inputGuardrails: Seq[InputGuardrail] = Seq.empty,
+    outputGuardrails: Seq[OutputGuardrail] = Seq.empty,
+    handoffs: Seq[Handoff] = Seq.empty,
+    maxSteps: Option[Int] = Some(Agent.DefaultMaxSteps),
+    systemPromptAddition: Option[String] = None,
+    completionOptions: CompletionOptions = CompletionOptions(),
+    context: AgentContext = AgentContext.Default
+  ): Result[AgentState] = {
+    val startTime = System.currentTimeMillis()
+
+    inputGuardrails.foreach(g => onEvent(AgentEvent.InputGuardrailStarted(g.name, Instant.now())))
+
+    val inputValidationResult = GuardrailApplicator.validateInput(query, inputGuardrails)
+
+    inputValidationResult match {
+      case Right(_) =>
+        inputGuardrails.foreach(g => onEvent(AgentEvent.InputGuardrailCompleted(g.name, passed = true, Instant.now())))
+      case Left(_) =>
+        inputGuardrails.foreach(g => onEvent(AgentEvent.InputGuardrailCompleted(g.name, passed = false, Instant.now())))
+    }
+
+    inputValidationResult.flatMap { validatedQuery =>
+      onEvent(AgentEvent.agentStarted(validatedQuery, tools.tools.size))
+
+      initializeSafe(validatedQuery, tools, handoffs, systemPromptAddition, completionOptions).flatMap { initialState =>
+        runWithEventsInternal(
+          initialState,
+          onEvent,
+          maxSteps,
+          0,
+          startTime,
+          context
+        ).flatMap { finalState =>
+          outputGuardrails.foreach(g => onEvent(AgentEvent.OutputGuardrailStarted(g.name, Instant.now())))
+
+          val outputValidationResult = GuardrailApplicator.validateOutput(finalState, outputGuardrails)
+
+          outputValidationResult match {
+            case Right(_) =>
+              outputGuardrails.foreach { g =>
+                onEvent(AgentEvent.OutputGuardrailCompleted(g.name, passed = true, Instant.now()))
+              }
+            case Left(_) =>
+              outputGuardrails.foreach { g =>
+                onEvent(AgentEvent.OutputGuardrailCompleted(g.name, passed = false, Instant.now()))
+              }
+          }
+
+          outputValidationResult
+        }
+      }
+    }
+  }
+
+  /**
+   * Internal streaming execution loop.
+   *
+   * Drives the state machine step by step, emitting events at each transition.
+   * Uses `client.streamComplete` so text tokens are forwarded to `onEvent` as
+   * [[AgentEvent.TextDelta]] in real time.
+   *
+   * @param state       Current agent state.
+   * @param onEvent     Callback invoked for each event.
+   * @param maxSteps    Maximum steps remaining.
+   * @param currentStep Current step counter (0-based).
+   * @param startTime   Wall-clock start time in milliseconds.
+   * @param context     Cross-cutting concerns.
+   * @return `Right(state)` on success; `Left` on LLM failure.
+   */
+  def runWithEventsInternal(
+    state: AgentState,
+    onEvent: AgentEvent => Unit,
+    maxSteps: Option[Int],
+    currentStep: Int,
+    startTime: Long,
+    context: AgentContext
+  ): Result[AgentState] = {
+
+    val stepLimitReached = maxSteps.exists(max => currentStep >= max)
+    if (stepLimitReached && (state.status == AgentStatus.InProgress || state.status == AgentStatus.WaitingForTools)) {
+      val failedState = state.withStatus(AgentStatus.Failed("Maximum step limit reached"))
+      onEvent(
+        AgentEvent.agentFailed(
+          org.llm4s.error.ProcessingError("agent-execution", "Maximum step limit reached"),
+          Some(currentStep)
+        )
+      )
+      context.traceLogPath.foreach(path => AgentTraceFormatter.writeTraceLog(failedState, path))
+      return Right(failedState)
+    }
+
+    state.status match {
+      case AgentStatus.InProgress =>
+        onEvent(AgentEvent.stepStarted(currentStep))
+
+        val options     = state.completionOptions.copy(tools = state.tools.tools)
+        val accumulator = StreamingAccumulator.create()
+
+        val streamResult = client.streamComplete(
+          state.toApiConversation,
+          options,
+          onChunk = { chunk =>
+            chunk.content.foreach(delta => onEvent(AgentEvent.textDelta(delta)))
+            accumulator.addChunk(chunk)
+          }
+        )
+
+        streamResult match {
+          case Right(completion) =>
+            val stateWithUsage = accumulateUsage(state, completion)
+
+            if (completion.content.nonEmpty) {
+              onEvent(AgentEvent.textComplete(completion.content))
+            }
+
+            val updatedState = stateWithUsage
+              .log(s"[assistant] text: ${completion.content}")
+              .addMessage(completion.message)
+
+            safeTrace(context.tracing)(tracer => tracer.traceCompletion(completion, completion.model))
+            completion.usage.foreach { usage =>
+              safeTrace(context.tracing) { tracer =>
+                tracer.traceTokenUsage(usage, completion.model, "agent_stream_completion")
+              }
+            }
+
+            completion.message.toolCalls match {
+              case Seq() =>
+                val totalDuration = System.currentTimeMillis() - startTime
+                onEvent(AgentEvent.stepCompleted(currentStep, hasToolCalls = false))
+
+                val finalState = updatedState.withStatus(AgentStatus.Complete)
+                onEvent(AgentEvent.agentCompleted(finalState, currentStep + 1, totalDuration))
+
+                context.traceLogPath.foreach(path => AgentTraceFormatter.writeTraceLog(finalState, path))
+                safeTrace(context.tracing)(_.traceAgentState(finalState))
+                Right(finalState)
+
+              case toolCalls =>
+                onEvent(AgentEvent.stepCompleted(currentStep, hasToolCalls = true))
+
+                val stateAfterTools = ToolProcessor.processToolCallsWithEvents(
+                  updatedState.withStatus(AgentStatus.WaitingForTools),
+                  toolCalls,
+                  onEvent,
+                  context
+                )
+
+                HandoffExecutor.detectHandoff(stateAfterTools) match {
+                  case Some((handoff, reason)) =>
+                    onEvent(
+                      AgentEvent.HandoffStarted(
+                        handoff.handoffName,
+                        Some(reason),
+                        handoff.preserveContext,
+                        Instant.now()
+                      )
+                    )
+                    val handoffResult =
+                      HandoffExecutor.executeHandoff(
+                        stateAfterTools,
+                        handoff,
+                        Some(reason),
+                        maxSteps.map(_ - currentStep),
+                        context
+                      )
+                    onEvent(AgentEvent.HandoffCompleted(handoff.handoffName, handoffResult.isRight, Instant.now()))
+                    handoffResult
+
+                  case None =>
+                    runWithEventsInternal(
+                      stateAfterTools.withStatus(AgentStatus.InProgress),
+                      onEvent,
+                      maxSteps,
+                      currentStep + 1,
+                      startTime,
+                      context
+                    )
+                }
+            }
+
+          case Left(error) =>
+            onEvent(AgentEvent.agentFailed(error, Some(currentStep)))
+            safeTrace(context.tracing) { tracer =>
+              tracer.traceError(new RuntimeException(error.message), "agent_stream_completion")
+            }
+            Left(error)
+        }
+
+      case AgentStatus.Complete | AgentStatus.Failed(_) =>
+        Right(state)
+
+      case AgentStatus.WaitingForTools =>
+        Right(state)
+
+      case AgentStatus.HandoffRequested(handoff, reason) =>
+        onEvent(AgentEvent.HandoffStarted(handoff.handoffName, reason, handoff.preserveContext, Instant.now()))
+        val handoffResult =
+          HandoffExecutor.executeHandoff(state, handoff, reason, maxSteps.map(_ - currentStep), context)
+        onEvent(AgentEvent.HandoffCompleted(handoff.handoffName, handoffResult.isRight, Instant.now()))
+        handoffResult
+    }
+  }
+
+  /**
+   * Continue a conversation with streaming events.
+   *
+   * @param previousState  Previous agent state (must be `Complete` or `Failed`).
+   * @param newUserMessage Follow-up user message.
+   * @param onEvent        Callback invoked for each event.
+   * @param inputGuardrails  Applied to `newUserMessage`.
+   * @param outputGuardrails Applied to the final assistant message.
+   * @param maxSteps         Step cap for this turn.
+   * @param contextWindowConfig When set, prunes oldest messages before running.
+   * @param context          Cross-cutting concerns.
+   * @return `Right(state)` on success; `Left` on validation or LLM failure.
+   */
+  def continueConversationWithEvents(
+    previousState: AgentState,
+    newUserMessage: String,
+    onEvent: AgentEvent => Unit,
+    inputGuardrails: Seq[InputGuardrail] = Seq.empty,
+    outputGuardrails: Seq[OutputGuardrail] = Seq.empty,
+    maxSteps: Option[Int] = None,
+    contextWindowConfig: Option[ContextWindowConfig] = None,
+    context: AgentContext = AgentContext.Default
+  ): Result[AgentState] = {
+    import org.llm4s.error.ValidationError
+
+    val startTime = System.currentTimeMillis()
+
+    inputGuardrails.foreach(g => onEvent(AgentEvent.InputGuardrailStarted(g.name, Instant.now())))
+
+    val inputValidationResult = GuardrailApplicator.validateInput(newUserMessage, inputGuardrails)
+
+    inputValidationResult match {
+      case Right(_) =>
+        inputGuardrails.foreach(g => onEvent(AgentEvent.InputGuardrailCompleted(g.name, passed = true, Instant.now())))
+      case Left(_) =>
+        inputGuardrails.foreach(g => onEvent(AgentEvent.InputGuardrailCompleted(g.name, passed = false, Instant.now())))
+    }
+
+    inputValidationResult.flatMap { validatedMessage =>
+      val stateResult: Result[AgentState] = previousState.status match {
+        case AgentStatus.Complete | AgentStatus.Failed(_) =>
+          onEvent(AgentEvent.agentStarted(validatedMessage, previousState.tools.tools.size))
+
+          val stateWithNewMessage = previousState.copy(
+            conversation = previousState.conversation.addMessage(UserMessage(validatedMessage)),
+            status = AgentStatus.InProgress,
+            logs = Seq.empty
+          )
+
+          val stateToRun = contextWindowConfig match {
+            case Some(config) => AgentState.pruneConversation(stateWithNewMessage, config)
+            case None         => stateWithNewMessage
+          }
+
+          runWithEventsInternal(
+            stateToRun,
+            onEvent,
+            maxSteps,
+            0,
+            startTime,
+            context
+          )
+
+        case _ =>
+          Left(
+            ValidationError.invalid(
+              "agentState",
+              s"Cannot continue from incomplete state: ${previousState.status}"
+            )
+          )
+      }
+
+      stateResult.flatMap { finalState =>
+        outputGuardrails.foreach(g => onEvent(AgentEvent.OutputGuardrailStarted(g.name, Instant.now())))
+
+        val outputValidationResult = GuardrailApplicator.validateOutput(finalState, outputGuardrails)
+
+        outputValidationResult match {
+          case Right(_) =>
+            outputGuardrails.foreach { g =>
+              onEvent(AgentEvent.OutputGuardrailCompleted(g.name, passed = true, Instant.now()))
+            }
+          case Left(_) =>
+            outputGuardrails.foreach { g =>
+              onEvent(AgentEvent.OutputGuardrailCompleted(g.name, passed = false, Instant.now()))
+            }
+        }
+
+        outputValidationResult
+      }
+    }
+  }
+
+  /**
+   * Runs the agent and collects all emitted events into a sequence.
+   *
+   * Convenience method for testing and logging use cases where the caller
+   * needs the complete event sequence after the run completes.
+   *
+   * @param query               User message to process.
+   * @param tools               Available tools.
+   * @param maxSteps            Step cap.
+   * @param systemPromptAddition Text appended to the built-in system prompt.
+   * @param completionOptions   LLM parameters.
+   * @param context             Cross-cutting concerns.
+   * @return `Right((state, events))` on success; `Left` on failure.
+   */
+  def runCollectingEvents(
+    query: String,
+    tools: ToolRegistry,
+    maxSteps: Option[Int] = Some(Agent.DefaultMaxSteps),
+    systemPromptAddition: Option[String] = None,
+    completionOptions: CompletionOptions = CompletionOptions(),
+    context: AgentContext = AgentContext.Default
+  ): Result[(AgentState, Seq[AgentEvent])] = {
+    val events = scala.collection.mutable.ArrayBuffer[AgentEvent]()
+
+    runWithEvents(
+      query = query,
+      tools = tools,
+      onEvent = events += _,
+      maxSteps = maxSteps,
+      systemPromptAddition = systemPromptAddition,
+      completionOptions = completionOptions,
+      context = context
+    ).map(state => (state, events.toSeq))
+  }
+
+  // ============================================================
+  // Async Tool Execution with Configurable Strategy
+  // ============================================================
+
+  /**
+   * Runs the agent with a configurable tool execution strategy.
+   *
+   * @param query                 User message to process.
+   * @param tools                 Available tools.
+   * @param toolExecutionStrategy Strategy for executing multiple tool calls.
+   * @param inputGuardrails       Applied to `query`; default none.
+   * @param outputGuardrails      Applied to the final assistant message; default none.
+   * @param handoffs              Agents to delegate to; default none.
+   * @param maxSteps              Step cap.
+   * @param systemPromptAddition  Text appended to the built-in system prompt.
+   * @param completionOptions     LLM parameters.
+   * @param context               Cross-cutting concerns.
+   * @param ec                    ExecutionContext for async operations.
+   * @return `Right(state)` on success; `Left` on guardrail or LLM failure.
+   */
+  def runWithStrategy(
+    query: String,
+    tools: ToolRegistry,
+    toolExecutionStrategy: ToolExecutionStrategy = ToolExecutionStrategy.Sequential,
+    inputGuardrails: Seq[InputGuardrail] = Seq.empty,
+    outputGuardrails: Seq[OutputGuardrail] = Seq.empty,
+    handoffs: Seq[Handoff] = Seq.empty,
+    maxSteps: Option[Int] = Some(Agent.DefaultMaxSteps),
+    systemPromptAddition: Option[String] = None,
+    completionOptions: CompletionOptions = CompletionOptions(),
+    context: AgentContext = AgentContext.Default
+  )(implicit ec: ExecutionContext): Result[AgentState] =
+    for {
+      validatedQuery <- GuardrailApplicator.validateInput(query, inputGuardrails)
+
+      _ = if (context.debug) {
+        logger.info("[DEBUG] Initializing agent with tool execution strategy: {}", toolExecutionStrategy)
+        logger.info("[DEBUG] Query: {}", validatedQuery)
+        logger.info("[DEBUG] Tools: {}", tools.tools.map(_.name).mkString(", "))
+      }
+      initialState <- initializeSafe(validatedQuery, tools, handoffs, systemPromptAddition, completionOptions)
+      finalState <- runWithStrategyInternal(
+        initialState,
+        strategy = toolExecutionStrategy,
+        maxSteps = maxSteps,
+        context = context
+      )
+
+      validatedState <- GuardrailApplicator.validateOutput(finalState, outputGuardrails)
+    } yield validatedState
+
+  /**
+   * Internal strategy-based execution loop.
+   *
+   * Drives the state machine using [[runStep]] for LLM calls and
+   * [[ToolProcessor.processToolCallsAsync]] for parallel tool execution.
+   *
+   * @param initialState Initial (or current) agent state.
+   * @param strategy     Tool execution strategy.
+   * @param maxSteps     Maximum steps remaining.
+   * @param context      Cross-cutting concerns.
+   * @param ec           ExecutionContext for async tool execution.
+   * @return `Right(state)` on success; `Left` on LLM failure.
+   */
+  def runWithStrategyInternal(
+    initialState: AgentState,
+    strategy: ToolExecutionStrategy,
+    maxSteps: Option[Int],
+    context: AgentContext
+  )(implicit ec: ExecutionContext): Result[AgentState] = {
+    if (context.debug) {
+      logger.info("[DEBUG] Starting runWithStrategy")
+      logger.info("[DEBUG] Strategy: {}", strategy)
+      logger.info("[DEBUG] Max steps: {}", maxSteps.getOrElse("unlimited"))
+    }
+
+    context.traceLogPath.foreach(path => AgentTraceFormatter.writeTraceLog(initialState, path))
+
+    @tailrec
+    def runUntilCompletion(
+      state: AgentState,
+      stepsRemaining: Option[Int] = maxSteps,
+      iteration: Int = 1
+    ): Result[AgentState] =
+      (state.status, stepsRemaining) match {
+        case (s, Some(0)) if s == AgentStatus.InProgress || s == AgentStatus.WaitingForTools =>
+          if (context.debug) {
+            logger.warn("[DEBUG] Step limit reached!")
+          }
+          val updatedState =
+            state.log("[system] Step limit reached").withStatus(AgentStatus.Failed("Maximum step limit reached"))
+          context.traceLogPath.foreach(path => AgentTraceFormatter.writeTraceLog(updatedState, path))
+          Right(updatedState)
+
+        case (AgentStatus.InProgress, _) =>
+          if (context.debug) {
+            logger.info("[DEBUG] ITERATION {}: InProgress -> requesting LLM completion", iteration)
+          }
+
+          runStep(state, context) match {
+            case Right(newState) =>
+              val shouldDecrement = newState.status == AgentStatus.WaitingForTools
+              val updatedSteps    = if (shouldDecrement) stepsRemaining.map(_ - 1) else stepsRemaining
+              context.traceLogPath.foreach(path => AgentTraceFormatter.writeTraceLog(newState, path))
+              safeTrace(context.tracing)(_.traceAgentState(newState))
+              runUntilCompletion(newState, updatedSteps, iteration + 1)
+
+            case Left(error) =>
+              if (context.debug) {
+                logger.error("[DEBUG] LLM completion failed: {}", error.message)
+              }
+              Left(error)
+          }
+
+        case (AgentStatus.WaitingForTools, _) =>
+          val assistantMessageOpt = state.conversation.messages.reverse
+            .collectFirst { case msg: AssistantMessage if msg.toolCalls.nonEmpty => msg }
+
+          assistantMessageOpt match {
+            case Some(assistantMessage) =>
+              val toolNames = assistantMessage.toolCalls.map(_.name).mkString(", ")
+
+              if (context.debug) {
+                logger.info(
+                  "[DEBUG] ITERATION {}: WaitingForTools -> processing {} tools with {}",
+                  iteration,
+                  assistantMessage.toolCalls.size,
+                  strategy
+                )
+              }
+
+              Try {
+                ToolProcessor.processToolCallsAsync(
+                  state.log(s"[tools] executing ${assistantMessage.toolCalls.size} tools ($toolNames) with $strategy"),
+                  assistantMessage.toolCalls,
+                  strategy,
+                  context
+                )
+              } match {
+                case Success(newState) =>
+                  HandoffExecutor.detectHandoff(newState) match {
+                    case Some((handoff, reason)) =>
+                      if (context.debug) {
+                        logger.info("[DEBUG] Handoff detected: {}", handoff.handoffName)
+                      }
+                      Right(newState.withStatus(AgentStatus.HandoffRequested(handoff, Some(reason))))
+
+                    case None =>
+                      if (context.debug) {
+                        logger.info("[DEBUG] Tools processed -> InProgress")
+                      }
+                      context.traceLogPath.foreach(path => AgentTraceFormatter.writeTraceLog(newState, path))
+                      runUntilCompletion(newState.withStatus(AgentStatus.InProgress), stepsRemaining, iteration + 1)
+                  }
+
+                case Failure(error) =>
+                  logger.error("Tool processing failed: {}", error.getMessage)
+                  Right(state.withStatus(AgentStatus.Failed(error.getMessage)))
+              }
+
+            case None =>
+              Right(state.withStatus(AgentStatus.Failed("No tool calls found in conversation")))
+          }
+
+        case (AgentStatus.HandoffRequested(handoff, reason), _) =>
+          if (context.debug) {
+            logger.info("[DEBUG] Executing handoff: {}", handoff.handoffName)
+          }
+          context.traceLogPath.foreach(path => AgentTraceFormatter.writeTraceLog(state, path))
+          HandoffExecutor.executeHandoff(state, handoff, reason, maxSteps, context)
+
+        case (_, _) =>
+          if (context.debug) {
+            logger.info("[DEBUG] Agent completed with status: {}", state.status)
+          }
+          context.traceLogPath.foreach(path => AgentTraceFormatter.writeTraceLog(state, path))
+          Right(state)
+      }
+
+    runUntilCompletion(initialState)
+  }
+
+  /**
+   * Continue a conversation with a configurable tool execution strategy.
+   *
+   * @param previousState         Previous agent state (must be `Complete` or `Failed`).
+   * @param newUserMessage        Follow-up user message.
+   * @param toolExecutionStrategy Strategy for executing multiple tool calls.
+   * @param inputGuardrails       Applied to `newUserMessage`.
+   * @param outputGuardrails      Applied to the final assistant message.
+   * @param maxSteps              Step cap for this turn.
+   * @param contextWindowConfig   When set, prunes oldest messages before running.
+   * @param context               Cross-cutting concerns.
+   * @param ec                    ExecutionContext for async operations.
+   * @return `Right(state)` on success; `Left` on validation or LLM failure.
+   */
+  def continueConversationWithStrategy(
+    previousState: AgentState,
+    newUserMessage: String,
+    toolExecutionStrategy: ToolExecutionStrategy = ToolExecutionStrategy.Sequential,
+    inputGuardrails: Seq[InputGuardrail] = Seq.empty,
+    outputGuardrails: Seq[OutputGuardrail] = Seq.empty,
+    maxSteps: Option[Int] = None,
+    contextWindowConfig: Option[ContextWindowConfig] = None,
+    context: AgentContext = AgentContext.Default
+  )(implicit ec: ExecutionContext): Result[AgentState] = {
+    import org.llm4s.error.ValidationError
+
+    for {
+      validatedMessage <- GuardrailApplicator.validateInput(newUserMessage, inputGuardrails)
+
+      finalState <- previousState.status match {
+        case AgentStatus.Complete | AgentStatus.Failed(_) =>
+          val stateWithNewMessage = previousState.copy(
+            conversation = previousState.conversation.addMessage(UserMessage(validatedMessage)),
+            status = AgentStatus.InProgress,
+            logs = Seq.empty
+          )
+
+          val stateToRun = contextWindowConfig match {
+            case Some(config) => AgentState.pruneConversation(stateWithNewMessage, config)
+            case None         => stateWithNewMessage
+          }
+
+          runWithStrategyInternal(stateToRun, toolExecutionStrategy, maxSteps, context)
+
+        case AgentStatus.InProgress | AgentStatus.WaitingForTools | AgentStatus.HandoffRequested(_, _) =>
+          Left(
+            ValidationError.invalid(
+              "agentState",
+              s"Cannot continue from incomplete state: ${previousState.status}"
+            )
+          )
+      }
+
+      validatedState <- GuardrailApplicator.validateOutput(finalState, outputGuardrails)
+    } yield validatedState
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/agent/AgentTraceFormatter.scala
+++ b/modules/core/src/main/scala/org/llm4s/agent/AgentTraceFormatter.scala
@@ -1,0 +1,172 @@
+package org.llm4s.agent
+
+import org.llm4s.core.safety.Safety
+import org.llm4s.llmconnect.model.{ AssistantMessage, MessageRole, ToolMessage }
+import org.slf4j.{ Logger, LoggerFactory }
+
+import scala.util.Try
+
+/**
+ * Renders [[AgentState]] as a human-readable markdown document and optionally
+ * persists it to a file.
+ *
+ * == Format stability ==
+ *
+ * The output format is intentionally '''unstable''' across library versions.
+ * Do not parse the markdown programmatically — use the structured [[AgentState]]
+ * directly.  The unstable contract lets us improve the trace output without
+ * treating every change as a breaking API change.
+ *
+ * == Why write errors are swallowed ==
+ *
+ * Trace logging is a diagnostic aid, not part of the agent's control flow.
+ * A failed write (permission error, disk full, path not found) must never
+ * cause the agent run to fail — the end-user cares about the answer, not the
+ * trace file.  Errors are logged at ERROR level via SLF4J so operators can
+ * investigate without the agent surfacing them to callers.
+ *
+ * == Why system messages are excluded from the conversation section ==
+ *
+ * System messages are stored separately from conversation history in
+ * [[AgentState]] (injected at API call time so they can be updated without
+ * re-running the full history).  Including them in the trace would suggest
+ * they are part of the mutable conversation, which is misleading.
+ */
+private[agent] object AgentTraceFormatter {
+
+  private val logger: Logger = LoggerFactory.getLogger(getClass)
+
+  /**
+   * Renders `state` as a markdown document.
+   *
+   * Covers the conversation transcript, tool call arguments/results, and
+   * execution log entries.  System messages stored in
+   * [[AgentState.systemMessage]] are intentionally omitted from the
+   * conversation section (see class-level note).
+   *
+   * @param state Agent state to render; may be in any status.
+   * @return A markdown string suitable for human inspection.
+   */
+  def formatStateAsMarkdown(state: AgentState): String = {
+    val sb = new StringBuilder()
+
+    sb.append("# Agent Execution Trace\n\n")
+    state.initialQuery.foreach(q => sb.append(s"**Initial Query:** $q\n"))
+    sb.append(s"**Status:** ${state.status}\n")
+    sb.append(s"**Tools Available:** ${state.tools.tools.map(_.name).mkString(", ")}\n\n")
+
+    sb.append("## Conversation Flow\n\n")
+
+    state.conversation.messages.zipWithIndex.foreach { case (message, index) =>
+      val step = index + 1
+
+      message.role match {
+        case MessageRole.System =>
+          sb.append(s"### Step $step: System Message\n\n")
+          sb.append("```\n")
+          sb.append(message.content)
+          sb.append("\n```\n\n")
+
+        case MessageRole.User =>
+          sb.append(s"### Step $step: User Message\n\n")
+          sb.append(message.content)
+          sb.append("\n\n")
+
+        case MessageRole.Assistant =>
+          sb.append(s"### Step $step: Assistant Message\n\n")
+
+          message match {
+            case msg: AssistantMessage if msg.toolCalls.nonEmpty =>
+              if (msg.content != null)
+                if (msg.content.trim.nonEmpty) {
+                  sb.append(msg.content)
+                  sb.append("\n\n")
+                } else
+                  sb.append("--NO CONTENT--\n\n")
+
+              sb.append("**Tool Calls:**\n\n")
+
+              msg.toolCalls.foreach { tc =>
+                sb.append(s"Tool: **${tc.name}**\n\n")
+                sb.append("Arguments:\n")
+                sb.append("```json\n")
+                sb.append(tc.arguments)
+                sb.append("\n```\n\n")
+              }
+
+            case _ =>
+              sb.append(message.content)
+              sb.append("\n\n")
+          }
+
+        case MessageRole.Tool =>
+          message match {
+            case msg: ToolMessage =>
+              sb.append(s"### Step $step: Tool Response\n\n")
+              sb.append(s"Tool Call ID: `${msg.toolCallId}`\n\n")
+              sb.append("Result:\n")
+              sb.append("```json\n")
+              sb.append(msg.content)
+              sb.append("\n```\n\n")
+
+            case _ =>
+              sb.append(s"### Step $step: Tool Response\n\n")
+              sb.append("```\n")
+              sb.append(message.content)
+              sb.append("\n```\n\n")
+          }
+      }
+    }
+
+    if (state.logs.nonEmpty) {
+      sb.append("## Execution Logs\n\n")
+
+      state.logs.zipWithIndex.foreach { case (log, index) =>
+        sb.append(s"${index + 1}. ")
+
+        log match {
+          case l if l.startsWith("[assistant]") =>
+            sb.append(s"**Assistant:** ${l.stripPrefix("[assistant] ")}\n")
+
+          case l if l.startsWith("[tool]") =>
+            val content = l.stripPrefix("[tool] ")
+            sb.append(s"**Tool Output:** ${content}\n")
+
+          case l if l.startsWith("[tools]") =>
+            sb.append(s"**Tools:** ${l.stripPrefix("[tools] ")}\n")
+
+          case l if l.startsWith("[system]") =>
+            sb.append(s"**System:** ${l.stripPrefix("[system] ")}\n")
+
+          case _ =>
+            sb.append(s"$log\n")
+        }
+      }
+    }
+
+    sb.toString
+  }
+
+  /**
+   * Writes a markdown trace of `state` to `traceLogPath`.
+   *
+   * The file is created or truncated on each call.  Write failures are
+   * swallowed: errors are logged at ERROR level but never propagated so that
+   * trace logging never affects agent control flow.
+   *
+   * @param state        Agent state to render and persist.
+   * @param traceLogPath Absolute or relative path to the output file.
+   */
+  def writeTraceLog(state: AgentState, traceLogPath: String): Unit = {
+    import java.nio.charset.StandardCharsets
+    import java.nio.file.{ Files, Paths }
+
+    Safety
+      .fromTry(Try {
+        val content = formatStateAsMarkdown(state)
+        Files.write(Paths.get(traceLogPath), content.getBytes(StandardCharsets.UTF_8))
+      })
+      .left
+      .foreach(err => logger.error("Failed to write trace log: {}", err.message))
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/agent/GuardrailApplicator.scala
+++ b/modules/core/src/main/scala/org/llm4s/agent/GuardrailApplicator.scala
@@ -1,0 +1,79 @@
+package org.llm4s.agent
+
+import org.llm4s.agent.guardrails.{ CompositeGuardrail, InputGuardrail, OutputGuardrail }
+import org.llm4s.llmconnect.model.MessageRole
+import org.llm4s.types.Result
+
+/**
+ * Stateless helpers for applying input and output guardrail chains.
+ *
+ * Guardrails use a '''fail-fast''' security posture: the first failure
+ * short-circuits evaluation and returns `Left` immediately.  Running subsequent
+ * guardrails after one has already rejected the value would waste cycles and
+ * could surface false-positive results that mask the root rejection.
+ *
+ * == Why output validation extracts only the last assistant message ==
+ *
+ * An agent run may produce several intermediate assistant messages
+ * (e.g. "let me look that up", followed by tool results, followed by the
+ * final answer).  Only the last assistant message represents the final answer
+ * that is delivered to the caller.  Validating earlier intermediate messages
+ * would reject legitimate tool-use flows where the LLM acknowledges partial
+ * progress.  The empty string is used as a fallback so guardrails that check
+ * for content length (e.g. `LengthCheck`) still fire correctly when the
+ * conversation has no assistant turn at all.
+ *
+ * @see [[org.llm4s.agent.guardrails.InputGuardrail]]
+ * @see [[org.llm4s.agent.guardrails.OutputGuardrail]]
+ * @see [[CompositeGuardrail]]
+ */
+private[agent] object GuardrailApplicator {
+
+  /**
+   * Validates `query` against the supplied input guardrails.
+   *
+   * Returns `Right(query)` unchanged when `guardrails` is empty so that
+   * callers do not need to special-case the no-guardrail path.
+   *
+   * @param query      The user input to validate.
+   * @param guardrails Guardrails to apply; short-circuits on first failure.
+   * @return `Right(query)` if all guardrails pass; `Left` on first failure.
+   */
+  def validateInput(
+    query: String,
+    guardrails: Seq[InputGuardrail]
+  ): Result[String] =
+    if (guardrails.isEmpty) {
+      Right(query)
+    } else {
+      CompositeGuardrail.all(guardrails).validate(query)
+    }
+
+  /**
+   * Validates the final assistant response inside `state` against the supplied
+   * output guardrails.
+   *
+   * Returns `Right(state)` unchanged when `guardrails` is empty.  When
+   * guardrails are present, the last `Assistant`-role message is extracted and
+   * validated; an empty string is used when no assistant message exists so that
+   * length-based guardrails still trigger correctly.
+   *
+   * @param state      Agent state whose last assistant message is validated.
+   * @param guardrails Guardrails to apply; short-circuits on first failure.
+   * @return `Right(state)` if all guardrails pass; `Left` on first failure.
+   */
+  def validateOutput(
+    state: AgentState,
+    guardrails: Seq[OutputGuardrail]
+  ): Result[AgentState] =
+    if (guardrails.isEmpty) {
+      Right(state)
+    } else {
+      val finalMessage = state.conversation.messages
+        .findLast(_.role == MessageRole.Assistant)
+        .map(_.content)
+        .getOrElse("")
+
+      CompositeGuardrail.all(guardrails).validate(finalMessage).map(_ => state)
+    }
+}

--- a/modules/core/src/main/scala/org/llm4s/agent/HandoffExecutor.scala
+++ b/modules/core/src/main/scala/org/llm4s/agent/HandoffExecutor.scala
@@ -1,0 +1,214 @@
+package org.llm4s.agent
+
+import org.llm4s.llmconnect.model.{ AssistantMessage, Conversation, MessageRole }
+import org.llm4s.toolapi.{ Schema, ToolBuilder, ToolFunction, ToolRegistry }
+import org.llm4s.types.Result
+import org.slf4j.LoggerFactory
+
+import cats.implicits._
+
+import scala.util.Try
+
+/**
+ * Pure and nearly-pure helpers for the handoff-as-tool delegation pattern.
+ *
+ * == Why handoffs are synthesised as tools ==
+ *
+ * Representing handoffs as synthetic LLM tool calls keeps the LLM in full
+ * control of '''when''' to delegate.  Hard-coded routing logic (e.g. "if the
+ * query contains 'physics' forward to the science agent") is brittle and
+ * requires code changes for every new domain.  A synthesised tool lets the
+ * LLM apply its own reasoning about relevance, which is both more flexible
+ * and more accurate.
+ *
+ * == Why `preserveContext=false` transfers only the last user message ==
+ *
+ * Specialist agents often have their own system prompts and tool sets that
+ * conflict with the source agent's context.  Sending the full conversation
+ * history also leaks data the target agent has no need for and increases
+ * token cost unnecessarily.  The default (`preserveContext=false`) sends only
+ * the user's most recent question so the specialist starts with a clean slate.
+ *
+ * == Why tracing context is propagated unchanged ==
+ *
+ * End-to-end observability across multi-agent runs requires all spans to share
+ * the same trace ID.  Propagating the [[AgentContext]] unchanged ensures that
+ * the target agent's spans are nested under the same root trace as the source
+ * agent, giving operators a single timeline view.
+ */
+private[agent] object HandoffExecutor {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /**
+   * Converts each [[Handoff]] into a synthetic [[ToolFunction]] the LLM can
+   * invoke to trigger delegation.
+   *
+   * The generated tool name is [[Handoff.handoffId]] so that
+   * [[detectHandoff]] can identify it by the `handoff_to_agent_` prefix.
+   * The tool schema exposes a single required `reason` field that the LLM must
+   * populate, giving operators visibility into why the delegation occurred.
+   *
+   * @param handoffs Handoffs to convert; may be empty.
+   * @return `Right(tools)` — one tool per handoff — or `Left` if tool creation
+   *         fails (e.g. invalid schema definition).
+   */
+  def createHandoffTools(handoffs: Seq[Handoff]): Result[Seq[ToolFunction[_, _]]] = {
+    import HandoffResult._
+
+    handoffs.traverse { handoff =>
+      val toolName = handoff.handoffId
+      val toolDescription = handoff.transferReason.fold(
+        "Hand off this query to a specialist agent."
+      )(reason => s"Hand off this query to a specialist agent. $reason")
+
+      val schema = Schema
+        .`object`[Map[String, Any]]("Handoff parameters")
+        .withRequiredField("reason", Schema.string("Reason for the handoff"))
+
+      ToolBuilder[Map[String, Any], HandoffResult](
+        toolName,
+        toolDescription,
+        schema
+      ).withHandler { extractor =>
+        extractor.getString("reason").map { reason =>
+          HandoffResult(
+            handoff_requested = true,
+            handoff_id = handoff.handoffId,
+            reason = reason
+          )
+        }
+      }.buildSafe()
+    }
+  }
+
+  /**
+   * Scans the most recent assistant message in `state` for a handoff tool call.
+   *
+   * Returns `None` when there is no assistant message with tool calls, or when
+   * none of the tool calls have the `handoff_to_agent_` prefix.  Returns
+   * `Some((handoff, reason))` on the '''first''' matching tool call — multiple
+   * handoffs in a single turn are not supported (only the first is executed).
+   *
+   * @param state Current agent state; [[AgentState.availableHandoffs]] is used
+   *              to match tool-call names to [[Handoff]] instances.
+   * @return `Some((handoff, reason))` if a handoff was requested; `None` otherwise.
+   */
+  def detectHandoff(state: AgentState): Option[(Handoff, String)] = {
+    val latestAssistantMessage = state.conversation.messages.reverse
+      .collectFirst { case msg: AssistantMessage if msg.toolCalls.nonEmpty => msg }
+
+    latestAssistantMessage.flatMap { assistantMessage =>
+      val handoffToolCalls = assistantMessage.toolCalls.filter(tc => tc.name.startsWith("handoff_to_agent_"))
+
+      handoffToolCalls.headOption.flatMap { toolCall =>
+        val reasonOpt = Try {
+          val args = ujson.read(toolCall.arguments)
+          args.obj.get("reason").map(_.str).getOrElse("No reason provided")
+        }.toOption
+
+        val handoffId  = toolCall.name
+        val handoffOpt = state.availableHandoffs.find(_.handoffId == handoffId)
+
+        handoffOpt.flatMap(handoff => reasonOpt.map(reason => (handoff, reason)))
+      }
+    }
+  }
+
+  /**
+   * Builds the initial [[AgentState]] for the handoff target agent.
+   *
+   * The conversation messages transferred are controlled by
+   * [[Handoff.preserveContext]]:
+   *  - `true`  — full conversation history is transferred.
+   *  - `false` — only the last user message is transferred (privacy / cost).
+   *
+   * [[Handoff.transferSystemMessage]] controls whether the source agent's
+   * system message is forwarded.  The target agent starts with no available
+   * handoffs of its own, preventing unintended chain-delegation.
+   *
+   * @param sourceState State from the source agent at the point of delegation.
+   * @param handoff     Handoff configuration driving the transfer behaviour.
+   * @param reason      Optional reason string provided by the LLM; appended to
+   *                    the initial log entry for the target agent.
+   * @return Initialised state ready to be passed to the target agent's `run`.
+   */
+  def buildHandoffState(
+    sourceState: AgentState,
+    handoff: Handoff,
+    reason: Option[String]
+  ): AgentState = {
+    val transferredMessages = if (handoff.preserveContext) {
+      sourceState.conversation.messages
+    } else {
+      sourceState.conversation.messages
+        .findLast(_.role == MessageRole.User)
+        .toVector
+    }
+
+    val conversation = Conversation(transferredMessages)
+
+    val systemMessage = if (handoff.transferSystemMessage) {
+      sourceState.systemMessage
+    } else {
+      None
+    }
+
+    val handoffLog = s"[handoff] Received handoff from agent" +
+      reason.map(r => s" (Reason: $r)").getOrElse("")
+
+    AgentState(
+      conversation = conversation,
+      tools = ToolRegistry.empty,
+      initialQuery = sourceState.initialQuery,
+      status = AgentStatus.InProgress,
+      logs = Vector(handoffLog),
+      systemMessage = systemMessage,
+      availableHandoffs = Seq.empty
+    )
+  }
+
+  /**
+   * Runs the target agent from the prepared handoff state and merges usage.
+   *
+   * Tracing context is propagated unchanged to the target agent to preserve
+   * end-to-end trace continuity across multi-agent flows (see class-level note).
+   *
+   * @param sourceState The state from the source agent at delegation time.
+   * @param handoff     The handoff configuration (carries the target [[Agent]]).
+   * @param reason      Optional LLM-provided reason for the delegation.
+   * @param maxSteps    Step budget forwarded to the target agent.
+   * @param context     Cross-cutting concerns (tracing, debug, trace log path).
+   * @return `Right(state)` from the target agent with merged usage; `Left` on
+   *         LLM or initialisation error in the target agent.
+   */
+  def executeHandoff(
+    sourceState: AgentState,
+    handoff: Handoff,
+    reason: Option[String],
+    maxSteps: Option[Int],
+    context: AgentContext
+  ): Result[AgentState] = {
+    val logEntry = s"[handoff] Executing handoff: ${handoff.handoffName}" +
+      reason.map(r => s" (Reason: $r)").getOrElse("")
+
+    if (context.debug) {
+      logger.info("[DEBUG] {}", logEntry)
+      logger.info("[DEBUG] preserveContext: {}", handoff.preserveContext)
+      logger.info("[DEBUG] transferSystemMessage: {}", handoff.transferSystemMessage)
+    }
+
+    val targetState = buildHandoffState(sourceState, handoff, reason)
+
+    if (context.debug) {
+      logger.info("[DEBUG] Target state conversation messages: {}", targetState.conversation.messages.length)
+      logger.info("[DEBUG] Target state system message: {}", targetState.systemMessage.isDefined)
+    }
+
+    handoff.targetAgent.run(targetState, maxSteps, context).map { targetFinalState =>
+      targetFinalState.copy(
+        usageSummary = sourceState.usageSummary.merge(targetFinalState.usageSummary)
+      )
+    }
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/agent/ToolProcessor.scala
+++ b/modules/core/src/main/scala/org/llm4s/agent/ToolProcessor.scala
@@ -1,0 +1,303 @@
+package org.llm4s.agent
+
+import org.llm4s.agent.streaming.AgentEvent
+import org.llm4s.error.UnknownError
+import org.llm4s.llmconnect.model.ToolMessage
+import org.llm4s.toolapi.{ ToolCallErrorJson, ToolCallRequest }
+import org.llm4s.trace.Tracing
+import org.llm4s.types.Result
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ Await, ExecutionContext }
+import scala.concurrent.duration._
+
+/**
+ * Tool execution variants for the agent state machine.
+ *
+ * == Why three execution variants coexist ==
+ *
+ *  - '''Synchronous''' (`processToolCalls`) is the default path used in the
+ *    core `runStep` / `run` loop.  It is simple, deterministic, and safe.
+ *  - '''Async/strategy-based''' (`processToolCallsAsync`) is a performance knob
+ *    for agentic workloads where the LLM requests many independent tools in a
+ *    single step (e.g. weather in 10 cities).  Sequential strategy degrades
+ *    gracefully to the sync variant's behaviour.
+ *  - '''Event-emitting''' (`processToolCallsWithEvents`) is the streaming path.
+ *    It emits [[AgentEvent.ToolCallStarted]] / [[AgentEvent.ToolCallCompleted]]
+ *    callbacks synchronously so the caller sees each result as it arrives,
+ *    rather than batched at the end of all tool calls.  This is used by
+ *    [[AgentStreamingExecutor]] for the `runWithEvents` family.
+ *
+ * == Why tool failures return structured JSON rather than propagating `Left` ==
+ *
+ * When a tool throws or returns `Left`, the error is serialised to a JSON
+ * error object and stored as the tool result in the conversation.  The LLM
+ * then sees the structured error message and can decide whether to retry with
+ * different arguments, fall back to another tool, or inform the user.
+ * Propagating `Left` immediately would terminate the entire agent run on any
+ * tool exception — including transient errors and user-correctable mistakes —
+ * which is almost never the right behaviour.
+ */
+private[agent] object ToolProcessor {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /**
+   * Best-effort tracing helper — failures must never affect agent control flow.
+   */
+  private def safeTrace(tracing: Option[Tracing])(f: Tracing => Result[Unit]): Unit =
+    tracing.foreach { tracer =>
+      f(tracer) match {
+        case Left(error) =>
+          error match {
+            case UnknownError(msg, cause) =>
+              logger.debug("Tracing failed: " + msg, cause)
+            case _ =>
+              logger.debug("Tracing failed: {}", error)
+          }
+        case Right(_) =>
+          ()
+      }
+    }
+
+  /**
+   * Processes tool calls synchronously and threads the results back into `state`.
+   *
+   * Each tool call is executed in order; tool failures are captured as
+   * structured JSON error messages rather than terminating the run.  The
+   * returned state contains all tool result messages appended to the
+   * conversation.
+   *
+   * @param state     Current agent state; its [[AgentState.tools]] registry is used.
+   * @param toolCalls Tool invocations requested by the LLM.
+   * @param context   Cross-cutting concerns (tracing, debug logging).
+   * @return Updated state with tool results and log entries appended.
+   */
+  def processToolCalls(
+    state: AgentState,
+    toolCalls: Seq[org.llm4s.llmconnect.model.ToolCall],
+    context: AgentContext
+  ): AgentState = {
+    val toolRegistry = state.tools
+
+    if (context.debug) {
+      logger.info("[DEBUG] processToolCalls: Processing {} tool calls", toolCalls.size)
+    }
+
+    val (finalState, toolMessages) = toolCalls.zipWithIndex.foldLeft((state, Seq.empty[ToolMessage])) {
+      case ((currentState, messages), (toolCall, index)) =>
+        val startTime = System.currentTimeMillis()
+
+        if (context.debug) {
+          logger.info("[DEBUG] Tool call {}/{}: {}", index + 1, toolCalls.size, toolCall.name)
+          logger.info("[DEBUG]   Tool call ID: {}", toolCall.id)
+          logger.info("[DEBUG]   Arguments (raw JSON): {}", toolCall.arguments)
+          logger.info("[DEBUG]   Arguments type: {}", toolCall.arguments.getClass.getSimpleName)
+        } else {
+          logger.info("Executing tool: {} with arguments: {}", toolCall.name, toolCall.arguments)
+        }
+
+        val request = ToolCallRequest(toolCall.name, toolCall.arguments)
+
+        if (context.debug) {
+          logger.info("[DEBUG]   Created ToolCallRequest")
+          logger.info("[DEBUG]   Executing via ToolRegistry...")
+        }
+
+        val result   = toolRegistry.execute(request)
+        val endTime  = System.currentTimeMillis()
+        val duration = endTime - startTime
+
+        val resultContent = result match {
+          case Right(json) =>
+            val jsonStr = json.render()
+            if (context.debug) {
+              logger.info("[DEBUG]   Tool {} SUCCESS in {}ms", toolCall.name, duration)
+              logger.info("[DEBUG]   Result (raw JSON): {}", jsonStr)
+              logger.info("[DEBUG]   Result type: {}", json.getClass.getSimpleName)
+            } else {
+              logger.info("Tool {} completed successfully in {}ms. Result: {}", toolCall.name, duration, jsonStr)
+            }
+            safeTrace(context.tracing)(tracer =>
+              tracer.traceToolCall(toolCall.name, toolCall.arguments.render(), jsonStr)
+            )
+            jsonStr
+          case Left(error) =>
+            val errorMessage = error.getFormattedMessage
+            if (context.debug) {
+              logger.error("[DEBUG]   Tool {} FAILED in {}ms", toolCall.name, duration)
+              logger.error("[DEBUG]   Error type: {}", error.getClass.getSimpleName)
+              logger.error("[DEBUG]   Error message: {}", errorMessage)
+            }
+            val errorJson = ToolCallErrorJson.toJson(error).render()
+            if (!context.debug) {
+              logger.warn("Tool {} failed in {}ms with error: {}", toolCall.name, duration, errorMessage)
+            }
+            safeTrace(context.tracing)(tracer =>
+              tracer.traceToolCall(toolCall.name, toolCall.arguments.render(), errorJson)
+            )
+            errorJson
+        }
+
+        if (context.debug) {
+          logger.info("[DEBUG]   Creating ToolMessage with ID: {}", toolCall.id)
+        }
+
+        val stateWithLog = currentState.log(s"[tool] ${toolCall.name} (${duration}ms): $resultContent")
+        val toolMessage  = ToolMessage(resultContent, toolCall.id)
+        (stateWithLog, messages :+ toolMessage)
+    }
+
+    if (context.debug) {
+      logger.info("[DEBUG] All {} tool calls processed successfully", toolCalls.size)
+      logger.info("[DEBUG] Adding {} tool messages to conversation", toolMessages.size)
+    }
+
+    finalState.addMessages(toolMessages)
+  }
+
+  /**
+   * Processes tool calls asynchronously using the supplied execution strategy.
+   *
+   * Results are awaited with a 5-minute timeout before being folded back into
+   * `state`.  This method is used by the `runWithStrategy` family where parallel
+   * or rate-limited execution can reduce wall-clock time for independent tools.
+   *
+   * @param state     Current agent state.
+   * @param toolCalls Tool invocations requested by the LLM.
+   * @param strategy  Execution strategy (Sequential, Parallel, ParallelWithLimit).
+   * @param context   Cross-cutting concerns.
+   * @param ec        ExecutionContext for async dispatch.
+   * @return Updated state with tool results appended.
+   */
+  def processToolCallsAsync(
+    state: AgentState,
+    toolCalls: Seq[org.llm4s.llmconnect.model.ToolCall],
+    strategy: org.llm4s.toolapi.ToolExecutionStrategy,
+    context: AgentContext
+  )(implicit ec: ExecutionContext): AgentState = {
+    val toolRegistry = state.tools
+
+    if (context.debug) {
+      logger.info(
+        "[DEBUG] processToolCallsAsync: Processing {} tool calls with strategy {}",
+        toolCalls.size,
+        strategy
+      )
+    }
+
+    val requests   = toolCalls.map(tc => ToolCallRequest(tc.name, tc.arguments))
+    val startTimes = toolCalls.map(_ => System.currentTimeMillis())
+
+    val resultsFuture = toolRegistry.executeAll(requests, strategy)
+    val timeout       = 5.minutes
+    val results       = Await.result(resultsFuture, timeout)
+
+    val toolMessages = toolCalls.zip(results).zipWithIndex.map { case ((toolCall, result), index) =>
+      val duration = System.currentTimeMillis() - startTimes(index)
+
+      val resultContent = result match {
+        case Right(json) =>
+          val jsonStr = json.render()
+          if (context.debug) {
+            logger.info("[DEBUG] Tool {} SUCCESS in {}ms", toolCall.name, duration)
+          } else {
+            logger.info("Tool {} completed successfully in {}ms", toolCall.name, duration)
+          }
+          safeTrace(context.tracing)(tracer =>
+            tracer.traceToolCall(toolCall.name, toolCall.arguments.render(), jsonStr)
+          )
+          jsonStr
+
+        case Left(error) =>
+          val errorMessage = error.getFormattedMessage
+          if (context.debug) {
+            logger.error("[DEBUG] Tool {} FAILED in {}ms: {}", toolCall.name, duration, errorMessage)
+          }
+          val errorJson = ToolCallErrorJson.toJson(error).render()
+          safeTrace(context.tracing)(tracer =>
+            tracer.traceToolCall(toolCall.name, toolCall.arguments.render(), errorJson)
+          )
+          errorJson
+      }
+
+      ToolMessage(resultContent, toolCall.id)
+    }
+
+    if (context.debug) {
+      logger.info("[DEBUG] All {} tool calls processed with strategy {}", toolCalls.size, strategy)
+    }
+
+    state.addMessages(toolMessages)
+  }
+
+  /**
+   * Processes tool calls synchronously, emitting [[AgentEvent]] callbacks for
+   * each tool start and completion.
+   *
+   * Used by [[AgentStreamingExecutor]] so that the caller's `onEvent` handler
+   * receives real-time tool progress notifications.  Tool failures are captured
+   * as structured JSON (same as `processToolCalls`) and emit a
+   * [[AgentEvent.ToolCallFailed]] event.
+   *
+   * @param state     Current agent state.
+   * @param toolCalls Tool invocations requested by the LLM.
+   * @param onEvent   Callback invoked for each [[AgentEvent]].
+   * @param context   Cross-cutting concerns.
+   * @return Updated state with tool results appended.
+   */
+  def processToolCallsWithEvents(
+    state: AgentState,
+    toolCalls: Seq[org.llm4s.llmconnect.model.ToolCall],
+    onEvent: AgentEvent => Unit,
+    context: AgentContext
+  ): AgentState = {
+    val toolRegistry = state.tools
+
+    val toolMessages = toolCalls.map { toolCall =>
+      val toolStartTime = System.currentTimeMillis()
+
+      onEvent(AgentEvent.toolStarted(toolCall.id, toolCall.name, toolCall.arguments.render()))
+
+      val request = ToolCallRequest(toolCall.name, toolCall.arguments)
+      val result  = toolRegistry.execute(request)
+
+      val toolEndTime = System.currentTimeMillis()
+      val duration    = toolEndTime - toolStartTime
+
+      val (resultContent, success) = result match {
+        case Right(json) =>
+          val jsonStr = json.render()
+          if (context.debug) {
+            logger.info("[DEBUG] Tool {} SUCCESS in {}ms", toolCall.name, duration)
+          }
+          safeTrace(context.tracing)(tracer =>
+            tracer.traceToolCall(toolCall.name, toolCall.arguments.render(), jsonStr)
+          )
+          (jsonStr, true)
+
+        case Left(error) =>
+          val errorMessage = error.getFormattedMessage
+          val errorJson    = ToolCallErrorJson.toJson(error).render()
+          if (context.debug) {
+            logger.error("[DEBUG] Tool {} FAILED in {}ms: {}", toolCall.name, duration, errorMessage)
+          }
+          safeTrace(context.tracing)(tracer =>
+            tracer.traceToolCall(toolCall.name, toolCall.arguments.render(), errorJson)
+          )
+          (errorJson, false)
+      }
+
+      if (success) {
+        onEvent(AgentEvent.toolCompleted(toolCall.id, toolCall.name, resultContent, success = true, duration))
+      } else {
+        import java.time.Instant
+        onEvent(AgentEvent.ToolCallFailed(toolCall.id, toolCall.name, resultContent, Instant.now()))
+      }
+
+      ToolMessage(resultContent, toolCall.id)
+    }
+
+    state.addMessages(toolMessages)
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/agent/AgentTraceFormatterSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/AgentTraceFormatterSpec.scala
@@ -1,0 +1,142 @@
+package org.llm4s.agent
+
+import org.llm4s.llmconnect.model.{ AssistantMessage, Conversation, ToolCall, ToolMessage, UserMessage }
+import org.llm4s.toolapi.ToolRegistry
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+
+/** Unit tests for [[AgentTraceFormatter]] — all tests are pure (no LLM calls). */
+class AgentTraceFormatterSpec extends AnyFlatSpec with Matchers {
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+
+  private def minimalState(query: String = "hello"): AgentState =
+    AgentState(
+      conversation = Conversation(Seq(UserMessage(query))),
+      tools = ToolRegistry.empty,
+      initialQuery = Some(query),
+      status = AgentStatus.Complete
+    )
+
+  private def stateWithMessages(msgs: org.llm4s.llmconnect.model.Message*): AgentState =
+    AgentState(
+      conversation = Conversation(msgs.toSeq),
+      tools = ToolRegistry.empty,
+      initialQuery = Some("test"),
+      status = AgentStatus.Complete
+    )
+
+  private def stateWithLogs(logs: String*): AgentState =
+    AgentState(
+      conversation = Conversation(Seq(UserMessage("q"))),
+      tools = ToolRegistry.empty,
+      initialQuery = Some("q"),
+      logs = logs.toSeq,
+      status = AgentStatus.Complete
+    )
+
+  // ── formatStateAsMarkdown ─────────────────────────────────────────────────────
+
+  "AgentTraceFormatter.formatStateAsMarkdown" should "contain the Agent Execution Trace header" in {
+    val md = AgentTraceFormatter.formatStateAsMarkdown(minimalState())
+    md should include("# Agent Execution Trace")
+  }
+
+  it should "include the initial query" in {
+    val md = AgentTraceFormatter.formatStateAsMarkdown(minimalState("what is 2+2?"))
+    md should include("what is 2+2?")
+  }
+
+  it should "include the agent status" in {
+    val md = AgentTraceFormatter.formatStateAsMarkdown(minimalState())
+    md should include("Complete")
+  }
+
+  it should "render a User message under Conversation Flow" in {
+    val md = AgentTraceFormatter.formatStateAsMarkdown(minimalState("user question"))
+    md should include("## Conversation Flow")
+    md should include("User Message")
+    md should include("user question")
+  }
+
+  it should "render an Assistant message with text content" in {
+    val state = stateWithMessages(
+      UserMessage("q"),
+      AssistantMessage("the answer", Seq.empty)
+    )
+    val md = AgentTraceFormatter.formatStateAsMarkdown(state)
+    md should include("Assistant Message")
+    md should include("the answer")
+  }
+
+  it should "render tool call arguments in a fenced JSON code block" in {
+    val toolCall = ToolCall(
+      id = "call-1",
+      name = "weather",
+      arguments = ujson.Obj("city" -> ujson.Str("London"))
+    )
+    val state = stateWithMessages(
+      UserMessage("q"),
+      AssistantMessage("", Seq(toolCall))
+    )
+    val md = AgentTraceFormatter.formatStateAsMarkdown(state)
+    md should include("```json")
+    md should include("weather")
+  }
+
+  it should "render Tool response messages" in {
+    val toolMsg = ToolMessage("{\"temp\": 20}", "call-1")
+    val state   = stateWithMessages(UserMessage("q"), toolMsg)
+    val md      = AgentTraceFormatter.formatStateAsMarkdown(state)
+    md should include("Tool Response")
+    md should include("call-1")
+    md should include("temp")
+  }
+
+  it should "omit the Execution Logs section when state.logs is empty" in {
+    val state = minimalState()
+    val md    = AgentTraceFormatter.formatStateAsMarkdown(state)
+    (md should not).include("## Execution Logs")
+  }
+
+  it should "include the Execution Logs section when logs are present" in {
+    val state = stateWithLogs("[assistant] thinking about it", "[tool] calc(5ms): 42")
+    val md    = AgentTraceFormatter.formatStateAsMarkdown(state)
+    md should include("## Execution Logs")
+    md should include("thinking about it")
+  }
+
+  it should "format assistant log entries with bold label" in {
+    val state = stateWithLogs("[assistant] my response")
+    val md    = AgentTraceFormatter.formatStateAsMarkdown(state)
+    md should include("**Assistant:**")
+  }
+
+  it should "format tool log entries with bold label" in {
+    val state = stateWithLogs("[tool] calc(5ms): result")
+    val md    = AgentTraceFormatter.formatStateAsMarkdown(state)
+    md should include("**Tool Output:**")
+  }
+
+  // ── writeTraceLog ─────────────────────────────────────────────────────────────
+
+  "AgentTraceFormatter.writeTraceLog" should "write the formatted state to a file" in {
+    val tmpFile = Files.createTempFile("agent-trace-", ".md")
+    try {
+      AgentTraceFormatter.writeTraceLog(minimalState("written query"), tmpFile.toString)
+      val contents = new String(Files.readAllBytes(tmpFile))
+      contents should include("written query")
+      contents should include("# Agent Execution Trace")
+    } finally
+      Files.deleteIfExists(tmpFile)
+  }
+
+  it should "silently swallow write failures without throwing an exception" in {
+    // Writing to an invalid path should not throw
+    noException should be thrownBy {
+      AgentTraceFormatter.writeTraceLog(minimalState(), "/nonexistent/path/trace.md")
+    }
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/agent/GuardrailApplicatorSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/GuardrailApplicatorSpec.scala
@@ -1,0 +1,163 @@
+package org.llm4s.agent
+
+import org.llm4s.agent.guardrails.{ InputGuardrail, OutputGuardrail }
+import org.llm4s.error.ValidationError
+import org.llm4s.llmconnect.model.{ AssistantMessage, Conversation, UserMessage }
+import org.llm4s.toolapi.ToolRegistry
+import org.llm4s.types.Result
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Unit tests for [[GuardrailApplicator]] — all tests are pure (no mocks, no LLM). */
+class GuardrailApplicatorSpec extends AnyFlatSpec with Matchers {
+
+  // ── Stub guardrails ──────────────────────────────────────────────────────────
+
+  private def passingInputGuardrail(guardName: String): InputGuardrail = new InputGuardrail {
+    val name                                    = guardName
+    def validate(value: String): Result[String] = Right(value)
+  }
+
+  private def failingInputGuardrail(guardName: String, errorMsg: String): InputGuardrail = new InputGuardrail {
+    val name = guardName
+    def validate(value: String): Result[String] =
+      Left(ValidationError.invalid("test", errorMsg))
+  }
+
+  private def passingOutputGuardrail(guardName: String): OutputGuardrail = new OutputGuardrail {
+    val name                                    = guardName
+    def validate(value: String): Result[String] = Right(value)
+  }
+
+  private def failingOutputGuardrail(guardName: String, errorMsg: String): OutputGuardrail = new OutputGuardrail {
+    val name = guardName
+    def validate(value: String): Result[String] =
+      Left(ValidationError.invalid("test", errorMsg))
+  }
+
+  // ── Helper: minimal AgentState ───────────────────────────────────────────────
+
+  private def stateWithLastMessage(content: String): AgentState = {
+    val msg = AssistantMessage(content, Seq.empty)
+    AgentState(
+      conversation = Conversation(Seq(UserMessage("hello"), msg)),
+      tools = ToolRegistry.empty
+    )
+  }
+
+  private def stateWithNoAssistantMessage: AgentState =
+    AgentState(
+      conversation = Conversation(Seq(UserMessage("hello"))),
+      tools = ToolRegistry.empty
+    )
+
+  private def stateWithMultipleAssistantMessages: AgentState = {
+    val first  = AssistantMessage("intermediate answer", Seq.empty)
+    val second = AssistantMessage("final answer", Seq.empty)
+    AgentState(
+      conversation = Conversation(Seq(UserMessage("q"), first, UserMessage("q2"), second)),
+      tools = ToolRegistry.empty
+    )
+  }
+
+  // ── validateInput ────────────────────────────────────────────────────────────
+
+  "GuardrailApplicator.validateInput" should "pass unchanged when guardrail seq is empty" in {
+    val result = GuardrailApplicator.validateInput("hello world", Seq.empty)
+    result shouldBe Right("hello world")
+  }
+
+  it should "pass through when all guardrails succeed" in {
+    val guards = Seq(passingInputGuardrail("a"), passingInputGuardrail("b"))
+    val result = GuardrailApplicator.validateInput("test query", guards)
+    result shouldBe Right("test query")
+  }
+
+  it should "return Left when the first guardrail fails" in {
+    val guards = Seq(
+      failingInputGuardrail("blocker", "blocked by first"),
+      passingInputGuardrail("second")
+    )
+    val result = GuardrailApplicator.validateInput("bad input", guards)
+    result shouldBe a[Left[_, _]]
+  }
+
+  it should "return Left when any guardrail fails (all-mode)" in {
+    val guards = Seq(
+      passingInputGuardrail("first"),
+      failingInputGuardrail("blocker", "blocked by second")
+    )
+    val result = GuardrailApplicator.validateInput("bad input", guards)
+    result shouldBe a[Left[_, _]]
+  }
+
+  it should "include the failure reason in the error" in {
+    val guards = Seq(failingInputGuardrail("g", "profanity detected"))
+    GuardrailApplicator.validateInput("bad word", guards) match {
+      case Left(err) => err.message should include("profanity detected")
+      case Right(_)  => fail("Expected Left but got Right")
+    }
+  }
+
+  // ── validateOutput ───────────────────────────────────────────────────────────
+
+  "GuardrailApplicator.validateOutput" should "pass state unchanged when guardrail seq is empty" in {
+    val state  = stateWithLastMessage("some response")
+    val result = GuardrailApplicator.validateOutput(state, Seq.empty)
+    result shouldBe Right(state)
+  }
+
+  it should "return Right(state) when output guardrail passes" in {
+    val state  = stateWithLastMessage("valid response")
+    val guards = Seq(passingOutputGuardrail("pass"))
+    val result = GuardrailApplicator.validateOutput(state, guards)
+    result shouldBe Right(state)
+  }
+
+  it should "return Left when output guardrail rejects" in {
+    val state  = stateWithLastMessage("bad response")
+    val guards = Seq(failingOutputGuardrail("reject", "content policy violated"))
+    val result = GuardrailApplicator.validateOutput(state, guards)
+    result shouldBe a[Left[_, _]]
+  }
+
+  it should "validate empty string when no assistant message is present" in {
+    // A length-based output guardrail that requires at least 5 chars should fail on ""
+    val minLengthGuardrail = new OutputGuardrail {
+      val name = "min-length"
+      def validate(value: String): Result[String] =
+        if (value.length >= 5) Right(value)
+        else Left(ValidationError.invalid("min-length", s"Too short: '${value}'"))
+    }
+    val state  = stateWithNoAssistantMessage
+    val result = GuardrailApplicator.validateOutput(state, Seq(minLengthGuardrail))
+    result shouldBe a[Left[_, _]]
+  }
+
+  it should "validate only the LAST assistant message when multiple are present" in {
+    val capturedValues = scala.collection.mutable.ListBuffer[String]()
+
+    val capturingGuardrail = new OutputGuardrail {
+      val name = "capture"
+      def validate(value: String): Result[String] = {
+        capturedValues += value
+        Right(value)
+      }
+    }
+
+    val state = stateWithMultipleAssistantMessages
+    GuardrailApplicator.validateOutput(state, Seq(capturingGuardrail))
+
+    capturedValues should have size 1
+    capturedValues.head shouldBe "final answer"
+  }
+
+  it should "include the failure reason from output validation in the error" in {
+    val guards = Seq(failingOutputGuardrail("g", "JSON parse failed"))
+    val state  = stateWithLastMessage("not json")
+    GuardrailApplicator.validateOutput(state, guards) match {
+      case Left(err) => err.message should include("JSON parse failed")
+      case Right(_)  => fail("Expected Left but got Right")
+    }
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/agent/HandoffExecutorSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/HandoffExecutorSpec.scala
@@ -1,0 +1,255 @@
+package org.llm4s.agent
+
+import org.llm4s.llmconnect.model.{ AssistantMessage, Conversation, ToolCall, UserMessage }
+import org.llm4s.toolapi.ToolRegistry
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Unit tests for [[HandoffExecutor]].
+ *
+ * The pure helpers (`detectHandoff`, `buildHandoffState`, `createHandoffTools`)
+ * are tested directly without assembling a full Agent or LLM client.
+ */
+class HandoffExecutorSpec extends AnyFlatSpec with Matchers {
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+
+  private def mkAgent(): Agent = new Agent(
+    new DeterministicFakeLLMClient(
+      org.llm4s.llmconnect.model.Completion(
+        id = "test",
+        created = 0L,
+        content = "done",
+        model = "test-model",
+        message = AssistantMessage("done", Seq.empty),
+        toolCalls = Nil,
+        usage = None
+      )
+    )
+  )
+
+  private def handoff(
+    agent: Agent,
+    reason: Option[String] = Some("specialist"),
+    preserveContext: Boolean = true,
+    transferSystemMessage: Boolean = false
+  ): Handoff =
+    Handoff(
+      targetAgent = agent,
+      transferReason = reason,
+      preserveContext = preserveContext,
+      transferSystemMessage = transferSystemMessage
+    )
+
+  private def handoffToolCall(handoffId: String, reason: String): ToolCall =
+    ToolCall(
+      id = "tc-1",
+      name = handoffId,
+      arguments = ujson.Obj("reason" -> ujson.Str(reason))
+    )
+
+  private def stateWithHandoffToolCall(h: Handoff, reason: String): AgentState = {
+    val tc = handoffToolCall(h.handoffId, reason)
+    AgentState(
+      conversation = Conversation(
+        Seq(
+          UserMessage("physics question"),
+          AssistantMessage("", Seq(tc))
+        )
+      ),
+      tools = ToolRegistry.empty,
+      availableHandoffs = Seq(h)
+    )
+  }
+
+  private def stateWithAssistantText(text: String, handoffs: Seq[Handoff] = Seq.empty): AgentState =
+    AgentState(
+      conversation = Conversation(
+        Seq(
+          UserMessage("q"),
+          AssistantMessage(text, Seq.empty)
+        )
+      ),
+      tools = ToolRegistry.empty,
+      availableHandoffs = handoffs
+    )
+
+  private def stateWithUserMessageOnly(handoffs: Seq[Handoff] = Seq.empty): AgentState =
+    AgentState(
+      conversation = Conversation(Seq(UserMessage("q"))),
+      tools = ToolRegistry.empty,
+      availableHandoffs = handoffs
+    )
+
+  // ── detectHandoff ─────────────────────────────────────────────────────────────
+
+  "HandoffExecutor.detectHandoff" should "return None when no assistant message is present" in {
+    val state = stateWithUserMessageOnly()
+    HandoffExecutor.detectHandoff(state) shouldBe None
+  }
+
+  it should "return None when assistant has no tool calls" in {
+    val state = stateWithAssistantText("I can answer this myself")
+    HandoffExecutor.detectHandoff(state) shouldBe None
+  }
+
+  it should "return None when tool calls are present but none match the handoff prefix" in {
+    val tc = ToolCall(id = "tc-1", name = "weather_tool", arguments = ujson.Obj("city" -> ujson.Str("London")))
+    val state = AgentState(
+      conversation = Conversation(
+        Seq(
+          UserMessage("q"),
+          AssistantMessage("", Seq(tc))
+        )
+      ),
+      tools = ToolRegistry.empty,
+      availableHandoffs = Seq.empty
+    )
+    HandoffExecutor.detectHandoff(state) shouldBe None
+  }
+
+  it should "return Some((handoff, reason)) when a matching handoff tool call is found" in {
+    val agent = mkAgent()
+    val h     = handoff(agent)
+    val state = stateWithHandoffToolCall(h, "needs physics expertise")
+
+    val result = HandoffExecutor.detectHandoff(state)
+    result shouldBe defined
+    val (detectedHandoff, reason) = result.get
+    detectedHandoff.handoffId shouldBe h.handoffId
+    reason shouldBe "needs physics expertise"
+  }
+
+  it should "return None when handoff prefix matches but no matching handoff in availableHandoffs" in {
+    val tc =
+      ToolCall(id = "tc-1", name = "handoff_to_agent_deadbeef", arguments = ujson.Obj("reason" -> ujson.Str("r")))
+    val state = AgentState(
+      conversation = Conversation(
+        Seq(
+          UserMessage("q"),
+          AssistantMessage("", Seq(tc))
+        )
+      ),
+      tools = ToolRegistry.empty,
+      availableHandoffs = Seq.empty // no matching handoff
+    )
+    HandoffExecutor.detectHandoff(state) shouldBe None
+  }
+
+  // ── buildHandoffState ─────────────────────────────────────────────────────────
+
+  "HandoffExecutor.buildHandoffState" should "transfer full conversation when preserveContext=true" in {
+    val agent = mkAgent()
+    val h     = handoff(agent, preserveContext = true)
+    val source = AgentState(
+      conversation = Conversation(
+        Seq(
+          UserMessage("first q"),
+          AssistantMessage("first a", Seq.empty),
+          UserMessage("second q")
+        )
+      ),
+      tools = ToolRegistry.empty
+    )
+    val target = HandoffExecutor.buildHandoffState(source, h, Some("transfer all"))
+    target.conversation.messages should have size 3
+  }
+
+  it should "transfer only the last user message when preserveContext=false" in {
+    val agent = mkAgent()
+    val h     = handoff(agent, preserveContext = false)
+    val source = AgentState(
+      conversation = Conversation(
+        Seq(
+          UserMessage("first q"),
+          AssistantMessage("first a", Seq.empty),
+          UserMessage("final question")
+        )
+      ),
+      tools = ToolRegistry.empty
+    )
+    val target = HandoffExecutor.buildHandoffState(source, h, None)
+    target.conversation.messages should have size 1
+    target.conversation.messages.head.content shouldBe "final question"
+  }
+
+  it should "include system message when transferSystemMessage=true" in {
+    val agent  = mkAgent()
+    val h      = handoff(agent, transferSystemMessage = true)
+    val sysMsg = org.llm4s.llmconnect.model.SystemMessage("be a physics expert")
+    val source = AgentState(
+      conversation = Conversation(Seq(UserMessage("q"))),
+      tools = ToolRegistry.empty,
+      systemMessage = Some(sysMsg)
+    )
+    val target = HandoffExecutor.buildHandoffState(source, h, None)
+    target.systemMessage shouldBe defined
+    target.systemMessage.get.content shouldBe "be a physics expert"
+  }
+
+  it should "clear system message when transferSystemMessage=false" in {
+    val agent  = mkAgent()
+    val h      = handoff(agent, transferSystemMessage = false)
+    val sysMsg = org.llm4s.llmconnect.model.SystemMessage("source system prompt")
+    val source = AgentState(
+      conversation = Conversation(Seq(UserMessage("q"))),
+      tools = ToolRegistry.empty,
+      systemMessage = Some(sysMsg)
+    )
+    val target = HandoffExecutor.buildHandoffState(source, h, None)
+    target.systemMessage shouldBe None
+  }
+
+  it should "start with no available handoffs" in {
+    val agent = mkAgent()
+    val h     = handoff(agent)
+    val source = AgentState(
+      conversation = Conversation(Seq(UserMessage("q"))),
+      tools = ToolRegistry.empty,
+      availableHandoffs = Seq(h)
+    )
+    val target = HandoffExecutor.buildHandoffState(source, h, None)
+    target.availableHandoffs shouldBe empty
+  }
+
+  it should "include a handoff log entry" in {
+    val agent = mkAgent()
+    val h     = handoff(agent)
+    val source = AgentState(
+      conversation = Conversation(Seq(UserMessage("q"))),
+      tools = ToolRegistry.empty
+    )
+    val target = HandoffExecutor.buildHandoffState(source, h, Some("physics needed"))
+    target.logs should have size 1
+    target.logs.head should include("Received handoff")
+    target.logs.head should include("physics needed")
+  }
+
+  // ── createHandoffTools ────────────────────────────────────────────────────────
+
+  "HandoffExecutor.createHandoffTools" should "return empty seq when no handoffs are provided" in {
+    HandoffExecutor.createHandoffTools(Seq.empty) shouldBe Right(Seq.empty)
+  }
+
+  it should "create one ToolFunction per handoff" in {
+    val agent1 = mkAgent()
+    val agent2 = mkAgent()
+    val h1     = handoff(agent1, reason = Some("reason A"))
+    val h2     = handoff(agent2, reason = Some("reason B"))
+    val result = HandoffExecutor.createHandoffTools(Seq(h1, h2))
+    result shouldBe a[Right[_, _]]
+    result.getOrElse(Seq.empty) should have size 2
+  }
+
+  it should "use the handoffId as the tool name" in {
+    val agent = mkAgent()
+    val h     = handoff(agent)
+    HandoffExecutor.createHandoffTools(Seq(h)) match {
+      case Right(tools) =>
+        tools should have size 1
+        tools.head.name shouldBe h.handoffId
+      case Left(err) => fail(s"Expected Right but got Left: $err")
+    }
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/agent/TestFixtures.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/TestFixtures.scala
@@ -1,9 +1,21 @@
 package org.llm4s.agent
 
+import org.llm4s.error.LLMError
 import org.llm4s.llmconnect.LLMClient
-import org.llm4s.llmconnect.model.{ Completion, CompletionOptions, Conversation, StreamedChunk }
+import org.llm4s.llmconnect.model._
+import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.types.Result
 
+/**
+ * Deterministic fake LLM client that always returns the same completion.
+ *
+ * Use when:
+ *  - The test only needs one LLM response (e.g. a single `run` with no tool calls).
+ *  - The response content is irrelevant and only the state transition matters.
+ *
+ * Prefer over `MockLLMClient` when the single-response constraint makes the
+ * test intent clearer and eliminates index-management boilerplate.
+ */
 final private[agent] class DeterministicFakeLLMClient(
   response: Completion
 ) extends LLMClient {
@@ -26,6 +38,18 @@ final private[agent] class DeterministicFakeLLMClient(
   override def getReserveCompletion(): Int = 4096
 }
 
+/**
+ * Deterministic fake LLM client that returns `first` until it sees a tool
+ * result or assistant message in the conversation, then returns `second`.
+ *
+ * Use when:
+ *  - The test covers a one-tool-call round-trip (LLM → tool → LLM).
+ *  - The exact number of turns is two and both responses are meaningful.
+ *
+ * The turn-detection heuristic (presence of Tool or Assistant messages) is
+ * intentionally simple — use `NTurnFakeLLMClient` when more precision is
+ * needed.
+ */
 final private[agent] class TwoTurnDeterministicFakeLLMClient(
   first: Completion,
   second: Completion
@@ -52,4 +76,199 @@ final private[agent] class TwoTurnDeterministicFakeLLMClient(
   override def getContextWindow(): Int = 128000
 
   override def getReserveCompletion(): Int = 4096
+}
+
+/**
+ * LLM client that always returns `Left(error)`.
+ *
+ * Use when:
+ *  - The test verifies error-propagation paths (e.g. `run` returns `Left` when
+ *    the LLM call fails).
+ *  - You need to simulate a hard LLM failure on the first (or any) call.
+ *
+ * Unlike `MockLLMClient` with an error response, this client makes the failure
+ * intent immediately obvious from the class name alone.
+ */
+final private[agent] class FailingLLMClient(error: LLMError) extends LLMClient {
+
+  override def complete(
+    conversation: Conversation,
+    options: CompletionOptions
+  ): Result[Completion] =
+    Left(error)
+
+  override def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions,
+    onChunk: StreamedChunk => Unit
+  ): Result[Completion] =
+    Left(error)
+
+  override def getContextWindow(): Int = 128000
+
+  override def getReserveCompletion(): Int = 4096
+}
+
+/**
+ * LLM client that rotates through N pre-configured responses.
+ *
+ * Call N is answered by `responses(N % responses.size)`.  If `responses` is
+ * empty, every call returns a default text-only completion.
+ *
+ * Use when:
+ *  - The test exercises exactly N LLM turns with distinct responses.
+ *  - You want predictable, index-based turn control without a mutable counter.
+ */
+final private[agent] class NTurnFakeLLMClient(responses: Completion*) extends LLMClient {
+
+  private var callIndex = 0
+
+  override def complete(
+    conversation: Conversation,
+    options: CompletionOptions
+  ): Result[Completion] = {
+    val result =
+      if (responses.isEmpty)
+        Right(CompletionFixture.simple(s"turn-$callIndex"))
+      else
+        Right(responses(callIndex % responses.size))
+    callIndex += 1
+    result
+  }
+
+  override def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions,
+    onChunk: StreamedChunk => Unit
+  ): Result[Completion] =
+    complete(conversation, options)
+
+  override def getContextWindow(): Int = 128000
+
+  override def getReserveCompletion(): Int = 4096
+}
+
+/**
+ * Factory methods for building [[Completion]] instances in tests.
+ *
+ * Reduces boilerplate in tests that only care about one or two fields of the
+ * completion and want sensible defaults for everything else.
+ */
+private[agent] object CompletionFixture {
+
+  /**
+   * A plain text completion with no tool calls and synthetic token usage.
+   *
+   * @param text The assistant's response text.
+   */
+  def simple(text: String): Completion = {
+    val message = AssistantMessage(text, Seq.empty)
+    Completion(
+      id = s"fixture-${System.nanoTime()}",
+      created = System.currentTimeMillis(),
+      content = text,
+      model = "test-model",
+      message = message,
+      toolCalls = Nil,
+      usage = Some(TokenUsage(promptTokens = 10, completionTokens = 20, totalTokens = 30))
+    )
+  }
+
+  /**
+   * A completion whose only content is a single tool call.
+   *
+   * @param name   Tool name.
+   * @param args   Tool arguments as a ujson value (typically `ujson.Obj(...)`).
+   * @param callId Tool call identifier; defaults to `"call-1"`.
+   */
+  def withToolCall(name: String, args: ujson.Value, callId: String = "call-1"): Completion = {
+    val tc      = ToolCall(id = callId, name = name, arguments = args)
+    val message = AssistantMessage("", Seq(tc))
+    Completion(
+      id = s"fixture-tc-${System.nanoTime()}",
+      created = System.currentTimeMillis(),
+      content = "",
+      model = "test-model",
+      message = message,
+      toolCalls = List(tc),
+      usage = Some(TokenUsage(promptTokens = 15, completionTokens = 5, totalTokens = 20))
+    )
+  }
+
+  /**
+   * A plain text completion with explicit token usage.
+   *
+   * Use when the test verifies usage accumulation or cost tracking.
+   *
+   * @param text       The assistant's response text.
+   * @param prompt     Prompt token count.
+   * @param completion Completion token count.
+   */
+  def withUsage(text: String, prompt: Int, completion: Int): Completion = {
+    val message = AssistantMessage(text, Seq.empty)
+    Completion(
+      id = s"fixture-usage-${System.nanoTime()}",
+      created = System.currentTimeMillis(),
+      content = text,
+      model = "test-model",
+      message = message,
+      toolCalls = Nil,
+      usage = Some(TokenUsage(promptTokens = prompt, completionTokens = completion, totalTokens = prompt + completion))
+    )
+  }
+}
+
+/**
+ * Factory methods for building [[AgentState]] instances in tests.
+ *
+ * These builders create the minimum viable state for each scenario and leave
+ * all other fields at their defaults, keeping test setup concise.
+ */
+private[agent] object AgentStateFixture {
+
+  /**
+   * An [[AgentState]] ready for its first [[Agent.runStep]] call.
+   *
+   * @param query The user's initial question.
+   * @param tools Tool registry; defaults to an empty registry.
+   */
+  def initial(query: String, tools: ToolRegistry = ToolRegistry.empty): AgentState =
+    AgentState(
+      conversation = Conversation(Seq(UserMessage(query))),
+      tools = tools,
+      initialQuery = Some(query),
+      status = AgentStatus.InProgress
+    )
+
+  /**
+   * An [[AgentState]] in terminal `Complete` status with both a user message
+   * and a final assistant response.
+   *
+   * Use to construct the `previousState` argument for
+   * [[Agent.continueConversation]] tests.
+   *
+   * @param query    The user's question.
+   * @param response The assistant's final response.
+   */
+  def complete(query: String, response: String): AgentState =
+    AgentState(
+      conversation = Conversation(Seq(UserMessage(query), AssistantMessage(response, Seq.empty))),
+      tools = ToolRegistry.empty,
+      initialQuery = Some(query),
+      status = AgentStatus.Complete
+    )
+
+  /**
+   * An [[AgentState]] with exactly the supplied messages in its conversation.
+   *
+   * The state is `InProgress`; override with `.withStatus(...)` if needed.
+   *
+   * @param msgs Ordered sequence of messages forming the conversation.
+   */
+  def withMessages(msgs: Message*): AgentState =
+    AgentState(
+      conversation = Conversation(msgs.toSeq),
+      tools = ToolRegistry.empty,
+      status = AgentStatus.InProgress
+    )
 }

--- a/modules/core/src/test/scala/org/llm4s/agent/ToolProcessorSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/ToolProcessorSpec.scala
@@ -1,0 +1,215 @@
+package org.llm4s.agent
+
+import org.llm4s.agent.streaming.AgentEvent
+import org.llm4s.llmconnect.model._
+import org.llm4s.toolapi._
+import org.llm4s.types.Result
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import upickle.default._
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/** Unit tests for [[ToolProcessor]] — uses stub ToolRegistry, no LLM calls. */
+class ToolProcessorSpec extends AnyFlatSpec with Matchers {
+
+  // ── Stub tool infrastructure ──────────────────────────────────────────────────
+
+  case class EchoResult(echo: String)
+  object EchoResult {
+    implicit val rw: ReadWriter[EchoResult] = macroRW
+  }
+
+  private def echoTool(): Result[ToolFunction[Map[String, Any], EchoResult]] = {
+    val schema = Schema
+      .`object`[Map[String, Any]]("Echo parameters")
+      .withRequiredField("message", Schema.string("Message to echo"))
+
+    ToolBuilder[Map[String, Any], EchoResult](
+      "echo",
+      "Echoes the message back",
+      schema
+    ).withHandler(extractor => extractor.getString("message").map(m => EchoResult(m))).buildSafe()
+  }
+
+  private def failingTool(): Result[ToolFunction[Map[String, Any], EchoResult]] = {
+    val schema = Schema
+      .`object`[Map[String, Any]]("Fail parameters")
+      .withRequiredField("message", Schema.string("Message"))
+
+    ToolBuilder[Map[String, Any], EchoResult](
+      "fail_tool",
+      "Always fails",
+      schema
+    ).withHandler(_ => Left("intentional failure")).buildSafe()
+  }
+
+  private def mkEchoRegistry(): ToolRegistry =
+    echoTool() match {
+      case Right(t) => new ToolRegistry(Seq(t))
+      case Left(e)  => fail(s"Tool creation failed: $e")
+    }
+
+  private def mkFailRegistry(): ToolRegistry =
+    failingTool() match {
+      case Right(t) => new ToolRegistry(Seq(t))
+      case Left(e)  => fail(s"Tool creation failed: $e")
+    }
+
+  private def mkState(registry: ToolRegistry): AgentState =
+    AgentState(
+      conversation = Conversation(Seq(UserMessage("q"))),
+      tools = registry
+    )
+
+  private def echoToolCall(message: String, id: String = "tc-1"): ToolCall =
+    ToolCall(
+      id = id,
+      name = "echo",
+      arguments = ujson.Obj("message" -> ujson.Str(message))
+    )
+
+  private def failToolCall(id: String = "tc-fail"): ToolCall =
+    ToolCall(
+      id = id,
+      name = "fail_tool",
+      arguments = ujson.Obj("message" -> ujson.Str("oops"))
+    )
+
+  private val noOpContext = AgentContext.Default
+
+  // ── processToolCalls ──────────────────────────────────────────────────────────
+
+  "ToolProcessor.processToolCalls" should "add a ToolMessage for a successful tool call" in {
+    val registry = mkEchoRegistry()
+    val state    = mkState(registry)
+    val tc       = echoToolCall("hello")
+
+    val result       = ToolProcessor.processToolCalls(state, Seq(tc), noOpContext)
+    val toolMessages = result.conversation.messages.collect { case m: ToolMessage => m }
+    toolMessages should have size 1
+    toolMessages.head.content should include("hello")
+  }
+
+  it should "record a log entry for each tool call" in {
+    val registry = mkEchoRegistry()
+    val state    = mkState(registry)
+    val tc       = echoToolCall("world")
+
+    val result = ToolProcessor.processToolCalls(state, Seq(tc), noOpContext)
+    result.logs.exists(_.contains("echo")) shouldBe true
+  }
+
+  it should "return structured JSON error on tool failure rather than Left" in {
+    val registry = mkFailRegistry()
+    val state    = mkState(registry)
+    val tc       = failToolCall()
+
+    val result = ToolProcessor.processToolCalls(state, Seq(tc), noOpContext)
+    // Should return Right (error captured in tool message), not Left
+    val toolMessages = result.conversation.messages.collect { case m: ToolMessage => m }
+    toolMessages should have size 1
+    toolMessages.head.content should include("error")
+  }
+
+  it should "include duration in log entry" in {
+    val registry = mkEchoRegistry()
+    val state    = mkState(registry)
+    val tc       = echoToolCall("duration-test")
+
+    val result = ToolProcessor.processToolCalls(state, Seq(tc), noOpContext)
+    result.logs.exists(l => l.contains("echo") && l.contains("ms")) shouldBe true
+  }
+
+  it should "process multiple tool calls in sequence and thread state correctly" in {
+    val registry = mkEchoRegistry()
+    val state    = mkState(registry)
+    val tcs = Seq(
+      echoToolCall("first", "tc-1"),
+      echoToolCall("second", "tc-2")
+    )
+
+    val result       = ToolProcessor.processToolCalls(state, tcs, noOpContext)
+    val toolMessages = result.conversation.messages.collect { case m: ToolMessage => m }
+    toolMessages should have size 2
+    (toolMessages.map(_.toolCallId) should contain).allOf("tc-1", "tc-2")
+  }
+
+  // ── processToolCallsWithEvents ────────────────────────────────────────────────
+
+  "ToolProcessor.processToolCallsWithEvents" should "emit ToolCallStarted before execution" in {
+    val registry = mkEchoRegistry()
+    val state    = mkState(registry)
+    val tc       = echoToolCall("event-test")
+    val events   = ArrayBuffer[AgentEvent]()
+
+    ToolProcessor.processToolCallsWithEvents(state, Seq(tc), events += _, noOpContext)
+
+    events.exists {
+      case AgentEvent.ToolCallStarted(_, name, _, _) => name == "echo"
+      case _                                         => false
+    } shouldBe true
+  }
+
+  it should "emit ToolCallCompleted with success=true on a successful tool call" in {
+    val registry = mkEchoRegistry()
+    val state    = mkState(registry)
+    val tc       = echoToolCall("success-event")
+    val events   = ArrayBuffer[AgentEvent]()
+
+    ToolProcessor.processToolCallsWithEvents(state, Seq(tc), events += _, noOpContext)
+
+    events.exists {
+      case AgentEvent.ToolCallCompleted(_, name, _, true, _, _) => name == "echo"
+      case _                                                    => false
+    } shouldBe true
+  }
+
+  it should "emit ToolCallFailed on tool error" in {
+    val registry = mkFailRegistry()
+    val state    = mkState(registry)
+    val tc       = failToolCall()
+    val events   = ArrayBuffer[AgentEvent]()
+
+    ToolProcessor.processToolCallsWithEvents(state, Seq(tc), events += _, noOpContext)
+
+    events.exists {
+      case AgentEvent.ToolCallFailed(_, name, _, _) => name == "fail_tool"
+      case _                                        => false
+    } shouldBe true
+  }
+
+  it should "add tool result messages to state" in {
+    val registry = mkEchoRegistry()
+    val state    = mkState(registry)
+    val tc       = echoToolCall("msg-check")
+    val events   = ArrayBuffer[AgentEvent]()
+
+    val result       = ToolProcessor.processToolCallsWithEvents(state, Seq(tc), events += _, noOpContext)
+    val toolMessages = result.conversation.messages.collect { case m: ToolMessage => m }
+    toolMessages should have size 1
+  }
+
+  // ── processToolCallsAsync (Sequential strategy == sync) ──────────────────────
+
+  "ToolProcessor.processToolCallsAsync" should "produce same results as sync for Sequential strategy" in {
+    val registry = mkEchoRegistry()
+    val state    = mkState(registry)
+    val tc       = echoToolCall("async-test")
+
+    val asyncResult = ToolProcessor.processToolCallsAsync(
+      state,
+      Seq(tc),
+      ToolExecutionStrategy.Sequential,
+      noOpContext
+    )
+
+    val syncResult = ToolProcessor.processToolCalls(state, Seq(tc), noOpContext)
+
+    val asyncMsgs = asyncResult.conversation.messages.collect { case m: ToolMessage => m }
+    val syncMsgs  = syncResult.conversation.messages.collect { case m: ToolMessage => m }
+    asyncMsgs should have size syncMsgs.size
+    asyncMsgs.head.toolCallId shouldBe syncMsgs.head.toolCallId
+  }
+}


### PR DESCRIPTION
## Summary

`Agent.scala` was a 2,241-line monolith handling five distinct concerns in one class, making it hard to test individual pieces in isolation and reason about which code path owned a given behaviour.

This PR extracts each concern into a dedicated `private[agent]` module:

- **`GuardrailApplicator`** – pure input/output guardrail validation (no LLM, no IO)
- **`AgentTraceFormatter`** – markdown trace rendering and file write
- **`HandoffExecutor`** – handoff-as-tool detection, state building, and execution
- **`ToolProcessor`** – sync, async, and event-emitting tool execution variants
- **`AgentStreamingExecutor`** – all streaming and strategy-based run variants (~700 lines)

`Agent.scala` now delegates to these modules and retains only core orchestration (`initializeSafe`, `runStep`, `runUntilCompletion`, `run`, `continueConversation`, `runMultiTurn`). **Line count: 2,241 → 1,246.**

## New unit tests

Four new focused spec files — each testing a single extracted module with no LLM client required:

- `GuardrailApplicatorSpec` – pure function tests for input/output validation
- `AgentTraceFormatterSpec` – markdown render output + silent file write failure
- `HandoffExecutorSpec` – detectHandoff, buildHandoffState, createHandoffTools
- `ToolProcessorSpec` – success/failure paths, event emission, async strategy

## TestFixtures expansion

Added builders to reduce boilerplate across the test suite:
- `FailingLLMClient(error)` – always returns `Left(error)`
- `NTurnFakeLLMClient(responses*)` – rotates through N completions
- `CompletionFixture` – `simple`, `withToolCall`, `withUsage` factories
- `AgentStateFixture` – `initial`, `complete`, `withMessages` factories

## AgentSpec additions

New test groups covering previously-untested paths:
- Step limit exhaustion → `AgentStatus.Failed`
- LLM error on first step / mid-run → propagated as `Left`
- Streaming error events: `AgentFailed`, `ToolCallFailed`

## Test plan

- [x] `sbt +test` – 4,759 tests pass on Scala 2.13 and 3.x
- [x] Pre-commit hook (full `core/test`) passed on commit
- [x] No public API changes (all extracted modules are `private[agent]`)
- [x] Deprecated shim overloads retained and unchanged