### PR TITLE
docs: ScalaDoc Wave 5 — UsageSummary, TracingConfig, Tokens, ZaiClient

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/agent/UsageSummary.scala
+++ b/modules/core/src/main/scala/org/llm4s/agent/UsageSummary.scala
@@ -3,6 +3,19 @@ package org.llm4s.agent
 import org.llm4s.llmconnect.model.TokenUsage
 import upickle.default.{ ReadWriter => RW, macroRW, readwriter }
 
+/**
+ * Accumulates token and cost statistics for a single model across one or more requests.
+ *
+ * `totalCost` is stored as [[BigDecimal]] to avoid floating-point accumulation drift
+ * that would occur when summing many `Double` values; incoming `Option[Double]` costs
+ * are converted once via [[BigDecimal.decimal]] on first contact.
+ *
+ * @param requestCount   number of API calls attributed to this model
+ * @param inputTokens    cumulative prompt tokens sent to the model
+ * @param outputTokens   cumulative completion tokens received from the model
+ * @param thinkingTokens cumulative extended-thinking tokens (Anthropic only; zero for other providers)
+ * @param totalCost      cumulative estimated cost in USD; `BigDecimal(0)` when cost data is unavailable
+ */
 case class ModelUsage(
   requestCount: Long = 0L,
   inputTokens: Long = 0L,
@@ -10,6 +23,13 @@ case class ModelUsage(
   thinkingTokens: Long = 0L,
   totalCost: BigDecimal = BigDecimal(0)
 ) {
+
+  /**
+   * Returns a new [[ModelUsage]] with `usage` and `cost` folded in.
+   *
+   * @param usage token-usage record from a [[org.llm4s.llmconnect.model.Completion]]
+   * @param cost  optional estimated cost in USD; treated as zero when absent
+   */
   def add(usage: TokenUsage, cost: Option[Double]): ModelUsage = {
     val thinking  = usage.thinkingTokens.getOrElse(0)
     val costValue = cost.map(BigDecimal.decimal).getOrElse(BigDecimal(0))
@@ -22,6 +42,12 @@ case class ModelUsage(
     )
   }
 
+  /**
+   * Combines two [[ModelUsage]] records by summing every field.
+   *
+   * Useful when aggregating per-model statistics from parallel agent runs or
+   * multi-step pipelines where each step produces its own [[ModelUsage]].
+   */
   def merge(other: ModelUsage): ModelUsage =
     ModelUsage(
       requestCount = requestCount + other.requestCount,
@@ -36,6 +62,27 @@ object ModelUsage {
   implicit val rw: RW[ModelUsage] = macroRW
 }
 
+/**
+ * Aggregates token and cost statistics across all models used in an agent run.
+ *
+ * The top-level fields (`requestCount`, `inputTokens`, etc.) are roll-ups across
+ * every model.  The `byModel` map breaks the same figures down per model name
+ * (e.g. `"claude-sonnet-4-5-latest"`, `"gpt-4o"`), allowing cost attribution
+ * per provider in multi-model pipelines.
+ *
+ * `totalCost` uses [[BigDecimal]] rather than `Double` to keep cumulative sums
+ * deterministic regardless of the number of requests.
+ *
+ * @param requestCount   total API calls across all models
+ * @param inputTokens    total prompt tokens sent across all models
+ * @param outputTokens   total completion tokens received across all models
+ * @param thinkingTokens total extended-thinking tokens (non-zero only for Anthropic models)
+ * @param totalCost      total estimated cost in USD; `BigDecimal(0)` when unavailable
+ * @param byModel        per-model breakdown; keyed by the model identifier string
+ *
+ * @see [[ModelUsage]] for the per-model record type
+ * @see [[org.llm4s.agent.AgentState]] which carries a [[UsageSummary]] for the whole run
+ */
 case class UsageSummary(
   requestCount: Long = 0L,
   inputTokens: Long = 0L,
@@ -45,6 +92,15 @@ case class UsageSummary(
   byModel: Map[String, ModelUsage] = Map.empty
 ) {
 
+  /**
+   * Returns a new [[UsageSummary]] with the given usage record folded in.
+   *
+   * Creates a new [[ModelUsage]] entry for `model` if one does not yet exist.
+   *
+   * @param model model identifier string (e.g. `"gpt-4o"`)
+   * @param usage token-usage record from a [[org.llm4s.llmconnect.model.Completion]]
+   * @param cost  optional estimated cost in USD; treated as zero when absent
+   */
   def add(model: String, usage: TokenUsage, cost: Option[Double]): UsageSummary = {
     val thinking = usage.thinkingTokens.getOrElse(0)
 
@@ -68,6 +124,13 @@ case class UsageSummary(
     )
   }
 
+  /**
+   * Combines two [[UsageSummary]] records by summing every field and merging
+   * the per-model maps.
+   *
+   * Use this when aggregating results from parallel sub-agents or separate
+   * pipeline stages into a single top-level summary.
+   */
   def merge(other: UsageSummary): UsageSummary = {
     val mergedByModel = other.byModel.foldLeft(byModel) { case (acc, (model, usage)) =>
       val merged = acc.getOrElse(model, ModelUsage()).merge(usage)

--- a/modules/core/src/main/scala/org/llm4s/context/tokens/Tokens.scala
+++ b/modules/core/src/main/scala/org/llm4s/context/tokens/Tokens.scala
@@ -3,17 +3,50 @@ package org.llm4s.context.tokens
 import com.knuddels.jtokkit.Encodings
 import org.llm4s.identity.TokenizerId
 
+/**
+ * Represents a single BPE token as an integer vocabulary index.
+ *
+ * The integer corresponds to the token identifier used by the underlying
+ * jtokkit / TikToken encoding (e.g. `cl100k_base` for GPT-4).
+ */
 case class Token(tokenId: Int) {
   override def toString: String = s"$tokenId"
 }
 
+/**
+ * Converts a plain string into a sequence of [[Token]]s using a specific BPE vocabulary.
+ *
+ * Implementations are backed by jtokkit encodings and obtained via
+ * [[Tokenizer.lookupStringTokenizer]]; the interface is kept minimal to allow
+ * test doubles without a real encoding registry.
+ */
 trait StringTokenizer {
+
+  /** Encodes `text` into a list of BPE [[Token]]s. */
   def encode(text: String): List[Token]
 }
 
+/**
+ * Factory for obtaining [[StringTokenizer]] instances backed by jtokkit BPE encodings.
+ *
+ * Encodings are looked up from the jtokkit default registry which bundles the
+ * standard TikToken vocabularies (`cl100k_base`, `o200k_base`, etc.).
+ * An unknown `tokenizerId` — one whose name does not match any bundled vocabulary —
+ * returns `None`; callers must handle the absent case explicitly.
+ *
+ * @see [[org.llm4s.identity.TokenizerId]] for vocabulary name constants
+ * @see [[org.llm4s.context.tokens.TokenizerMapping]] for the model → tokenizer mapping
+ */
 object Tokenizer {
   private val registry = Encodings.newDefaultEncodingRegistry
 
+  /**
+   * Returns a [[StringTokenizer]] for the given vocabulary, or `None` if the
+   * vocabulary name is not recognised by the bundled jtokkit registry.
+   *
+   * @param tokenizerId identifies the BPE vocabulary (e.g. `TokenizerId("cl100k_base")`)
+   * @return `Some` tokenizer when the vocabulary is available; `None` otherwise
+   */
   def lookupStringTokenizer(tokenizerId: TokenizerId): Option[StringTokenizer] = {
     val encoderOptional = registry.getEncoding(tokenizerId.name)
     if (encoderOptional.isPresent) {

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/config/TracingConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/config/TracingConfig.scala
@@ -4,6 +4,22 @@ import org.llm4s.config.DefaultConfig
 import org.llm4s.trace.TracingMode
 import org.llm4s.util.Redaction
 
+/**
+ * Connection and metadata settings for the Langfuse tracing backend.
+ *
+ * Normally obtained via [[org.llm4s.config.Llm4sConfig]] which reads
+ * `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL`
+ * from the environment.
+ *
+ * `toString` redacts both keys so that the config can be safely logged.
+ *
+ * @param url       Langfuse ingestion endpoint; defaults to `https://cloud.langfuse.com/api/public/ingestion`
+ * @param publicKey Langfuse public API key; `None` disables tracing with a warning
+ * @param secretKey Langfuse secret API key; redacted in `toString`
+ * @param env       deployment environment tag attached to every trace; defaults to `"production"`
+ * @param release   application release identifier forwarded to Langfuse; defaults to `"1.0.0"`
+ * @param version   SDK/integration version forwarded to Langfuse; defaults to `"1.0.0"`
+ */
 case class LangfuseConfig(
   url: String = DefaultConfig.DEFAULT_LANGFUSE_URL,
   publicKey: Option[String] = None,
@@ -17,12 +33,36 @@ case class LangfuseConfig(
       s"env=$env, release=$release, version=$version)"
 }
 
+/**
+ * Connection settings for an OpenTelemetry collector.
+ *
+ * Spans are exported via OTLP/gRPC to `endpoint`.  Set `OTEL_EXPORTER_OTLP_ENDPOINT`
+ * in the environment (picked up by [[org.llm4s.config.Llm4sConfig]]) to override the
+ * default local collector address.
+ *
+ * @param serviceName logical service name attached to every span as `service.name`;
+ *                    defaults to `"llm4s-agent"`
+ * @param endpoint    OTLP/gRPC collector address; defaults to `"http://localhost:4317"`
+ * @param headers     additional HTTP headers sent with each OTLP export request
+ *                    (e.g. authentication tokens for hosted collectors)
+ */
 case class OpenTelemetryConfig(
   serviceName: String = "llm4s-agent",
   endpoint: String = "http://localhost:4317",
   headers: Map[String, String] = Map.empty
 )
 
+/**
+ * Combined tracing configuration used by [[org.llm4s.trace.Tracing]].
+ *
+ * `mode` selects the active backend; the other fields supply backend-specific
+ * connection details.  Only the sub-config matching the active mode is used —
+ * e.g. when `mode = TracingMode.Langfuse`, `openTelemetry` is ignored.
+ *
+ * @param mode          selects the tracing backend (`Langfuse`, `OpenTelemetry`, `Console`, or `NoOp`)
+ * @param langfuse      Langfuse connection details; only used when `mode = TracingMode.Langfuse`
+ * @param openTelemetry OpenTelemetry collector details; only used when `mode = TracingMode.OpenTelemetry`
+ */
 case class TracingSettings(
   mode: TracingMode,
   langfuse: LangfuseConfig,

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/ZaiClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/ZaiClient.scala
@@ -18,6 +18,22 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.util.Try
 
+/**
+ * LLM client for the Z.ai API.
+ *
+ * Z.ai uses an OpenAI-compatible `/chat/completions` endpoint with one important
+ * difference: message content is always an array of typed objects
+ * (`[{"type":"text","text":"..."}]`) rather than a plain string.  This applies
+ * to user, system, assistant, and tool messages alike.  Sending a plain string
+ * causes a rejection from the Z.ai API.
+ *
+ * Both non-streaming (`complete`) and streaming (`streamComplete`) are supported.
+ * Tool calling follows the standard OpenAI function-calling format.
+ *
+ * @param config  Z.ai connection configuration (API key, model, base URL, context window)
+ * @param metrics records per-call latency and token-usage events;
+ *                use [[org.llm4s.metrics.MetricsCollector.noop]] when metrics are not needed
+ */
 class ZaiClient(
   config: ZaiConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop


### PR DESCRIPTION
## Summary

Closes out the remaining meaningful ScalaDoc gaps identified in the post-Wave-4 coverage review. Four files had zero documentation where the type signature alone left important behaviour undescribed.

### `agent/UsageSummary.scala` — `ModelUsage` + `UsageSummary`

- Documents that `totalCost` is `BigDecimal` (not `Double`) to prevent float-accumulation drift across many requests; incoming `Option[Double]` costs are converted once via `BigDecimal.decimal`.
- Explains `merge` as the correct aggregation primitive for parallel sub-agents or pipeline stages.
- Clarifies the `byModel` map as the per-provider cost-attribution mechanism.
- Documents `thinkingTokens` as Anthropic-only (zero for all other providers).

### `llmconnect/config/TracingConfig.scala` — `LangfuseConfig`, `OpenTelemetryConfig`, `TracingSettings`

- Surfaces the non-obvious defaults: `env="production"`, `release/version="1.0.0"`, OTel defaults to `localhost:4317`.
- Notes that `LangfuseConfig.toString` redacts both API keys.
- Clarifies that `TracingSettings` only uses the sub-config matching the active `TracingMode`.

### `context/tokens/Tokens.scala` — `Token`, `StringTokenizer`, `Tokenizer`

- Documents the jtokkit / TikToken BPE backing (`cl100k_base`, `o200k_base`, etc.).
- Makes explicit that `lookupStringTokenizer` returns `None` for unrecognised vocabulary names — callers must handle the absent case.

### `llmconnect/provider/ZaiClient.scala` — `ZaiClient`

- Documents the key protocol difference from standard OpenAI: Z.ai requires content as a typed array (`[{"type":"text","text":"..."}]`) rather than a plain string. Sending a plain string causes an API rejection.

## Test plan

- [x] `sbt core/scalafmtCheck` — no formatting issues
- [x] `sbt core/compile` — no errors
- [x] Full suite `sbt +test` — 4724 tests, 0 failures