### PR TITLE
Adds OpenTelemetry to the tracing configuration in configuration.md.

### DIFF
--- a/docs/getting-started/ollama-quickstart.md
+++ b/docs/getting-started/ollama-quickstart.md
@@ -212,10 +212,10 @@ the Java Virtual Machine (JVM).
 You can easily switch models:
 
 ```bash
-# Try Llama 3.2 (good balance of reasoning and quality,impressive 128K context window)
+# Try Llama 3.2 (good balance of reasoning and quality)
 export LLM_MODEL=ollama/llama3.2
 
-# Try Phi3 (lightweight,faster,smaller(1.4GB))
+# Try Phi3 (lightweight,faster, smaller)
 export LLM_MODEL=ollama/phi3
 
 # Try CodeLlama (for coding tasks)
@@ -226,7 +226,56 @@ Then run your program again without code changes!
 
 ---
 
-## Step 6a: Write Your First LLM4S + Ollama/CodeLlama App
+## Step 6a: Write Your First LLM4S + Ollama/Llama3.2 App
+
+Llama 3.2 is Meta's latest with an impressive 128K context window. Perfect for processing large documents and long conversations.
+
+For the code, use the same Scala example from **Step 5** - simply change the configuration:
+
+```bash
+# Linux / macOS
+export LLM_MODEL=ollama/llama3.2
+
+# Windows PowerShell
+$env:LLM_MODEL = "ollama/llama3.2"
+```
+
+Then run:
+
+```bash
+sbt run
+```
+
+{: .tip }
+> **Why Llama 3.2?** Latest Llama model with 128K context window. Excellent for RAG applications, long-form content generation, and processing large documents. Available in 1B, 3B, 8B, 70B, and 405B sizes.
+
+---
+
+## Step 6b: Write Your First LLM4S + Ollama/Phi3 App
+
+Phi3 is Microsoft's efficient model, even smaller than Phi. Ideal for ultra-low-latency applications and edge deployment.
+
+For the code, use the same Scala example from **Step 5** - simply change the configuration:
+
+```bash
+# Linux / macOS
+export LLM_MODEL=ollama/phi3
+
+# Windows PowerShell
+$env:LLM_MODEL = "ollama/phi3"
+```
+
+Then run:
+
+```bash
+sbt run
+```
+
+{: .tip }
+> **Why Phi3?** Microsoft's compact model optimized for efficiency. Smaller than Phi (1.4GB) with competitive quality. Perfect for resource-constrained environments and real-time applications requiring minimal latency.
+
+---
+## Step 6c: Write Your First LLM4S + Ollama/CodeLlama App
 
 CodeLlama is purpose-built for code generation and understanding. Create `HelloCodeLlama.scala`:
 

--- a/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceAgentInterfaceImpl.scala
+++ b/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceAgentInterfaceImpl.scala
@@ -639,49 +639,12 @@ class WorkspaceAgentInterfaceImpl(
       val completed = process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)
 
       if (!completed) {
-        // Attempt graceful termination first
         process.destroy()
-<<<<<<< new-branch
-
-        // Wait briefly for graceful termination (3 seconds)
-        val gracefulTerminationTimeoutMs = 3000L
-        val terminationStart             = System.currentTimeMillis()
-        while (process.isAlive() && System.currentTimeMillis() - terminationStart < gracefulTerminationTimeoutMs)
-          Thread.sleep(100)
-
-        // If still alive, force kill the process using ProcessHandle API
-        if (process.isAlive()) {
-          Try {
-            // Get the underlying Java Process and use ProcessHandle for force kill
-            val processField = process.getClass.getDeclaredField("p")
-            processField.setAccessible(true)
-            val javaProcess   = processField.get(process).asInstanceOf[java.lang.Process]
-            val pid           = javaProcess.pid()
-            val processHandle = java.lang.ProcessHandle.of(pid)
-            if (processHandle.isPresent) {
-              processHandle.get().destroyForcibly()
-            }
-          }.recover { case _: Exception =>
-            // Fallback: try to call destroyForcibly via reflection if ProcessHandle approach fails
-            Try {
-              process.getClass.getMethod("destroyForcibly").invoke(process)
-            }
-          }
-
-          // Wait briefly for forced termination (2 seconds)
-          val forceTerminationTimeoutMs = 2000L
-          val forceStart                = System.currentTimeMillis()
-          while (process.isAlive() && System.currentTimeMillis() - forceStart < forceTerminationTimeoutMs)
-            Thread.sleep(100)
-        }
-
-=======
         // Wait up to 2 seconds for graceful termination before escalating
         if (!process.waitFor(2, TimeUnit.SECONDS)) {
           process.destroyForcibly()
           process.waitFor(3, TimeUnit.SECONDS)
         }
->>>>>>> main
         throw new WorkspaceAgentException(
           s"Command execution timed out after ${timeoutMs}ms",
           "TIMEOUT",


### PR DESCRIPTION
**What does this PR do?**

Adds OpenTelemetry to the tracing configuration documentation, configure a collector for better observability.

Specifically, it adds instructions for:

* Setting environment variables for OpenTelemetry tracing (`TRACING_MODE=opentelemetry`, `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`)
* Using OpenTelemetry for development and sending spans to a collector
* Explaining how OpenTelemetry output differs from console or Langfuse tracing

This helps users configure the LLM4s runner with OpenTelemetry for better observability and debugging.

