### PR TITLE
Tool execution retry and per-tool timeout

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/agent/Agent.scala
+++ b/modules/core/src/main/scala/org/llm4s/agent/Agent.scala
@@ -39,11 +39,14 @@ private[agent] object HandoffResult {
  *                     transition, tool argument, and LLM response via SLF4J.
  * @param traceLogPath Path to write a markdown execution trace after each step;
  *                     useful for post-run inspection without a full tracing backend.
+ * @param toolExecutionConfig Optional per-tool timeout and retry; when None, tools run
+ *                            with no timeout and no retry (default).
  */
 case class AgentContext(
   tracing: Option[Tracing] = None,
   debug: Boolean = false,
-  traceLogPath: Option[String] = None
+  traceLogPath: Option[String] = None,
+  toolExecutionConfig: Option[org.llm4s.toolapi.ToolExecutionConfig] = None
 )
 
 object AgentContext {

--- a/modules/core/src/main/scala/org/llm4s/agent/ToolProcessor.scala
+++ b/modules/core/src/main/scala/org/llm4s/agent/ToolProcessor.scala
@@ -3,7 +3,7 @@ package org.llm4s.agent
 import org.llm4s.agent.streaming.AgentEvent
 import org.llm4s.error.UnknownError
 import org.llm4s.llmconnect.model.ToolMessage
-import org.llm4s.toolapi.{ ToolCallErrorJson, ToolCallRequest }
+import org.llm4s.toolapi.{ ToolCallErrorJson, ToolCallRequest, ToolExecutionConfig }
 import org.llm4s.trace.Tracing
 import org.llm4s.types.Result
 import org.slf4j.LoggerFactory
@@ -104,9 +104,11 @@ private[agent] object ToolProcessor {
           logger.info("[DEBUG]   Executing via ToolRegistry...")
         }
 
-        val result   = toolRegistry.execute(request)
-        val endTime  = System.currentTimeMillis()
-        val duration = endTime - startTime
+        implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+        val config                        = context.toolExecutionConfig.getOrElse(ToolExecutionConfig())
+        val result                        = toolRegistry.execute(request, config)
+        val endTime                       = System.currentTimeMillis()
+        val duration                      = endTime - startTime
 
         val resultContent = result match {
           case Right(json) =>
@@ -189,9 +191,10 @@ private[agent] object ToolProcessor {
     val requests   = toolCalls.map(tc => ToolCallRequest(tc.name, tc.arguments))
     val startTimes = toolCalls.map(_ => System.currentTimeMillis())
 
-    val resultsFuture = toolRegistry.executeAll(requests, strategy)
-    val timeout       = 5.minutes
-    val results       = Await.result(resultsFuture, timeout)
+    val config        = context.toolExecutionConfig.getOrElse(ToolExecutionConfig())
+    val resultsFuture = toolRegistry.executeAll(requests, strategy, config)
+    val batchTimeout  = config.timeout.fold(5.minutes)(t => t + 10.seconds)
+    val results       = Await.result(resultsFuture, batchTimeout)
 
     val toolMessages = toolCalls.zip(results).zipWithIndex.map { case ((toolCall, result), index) =>
       val duration = System.currentTimeMillis() - startTimes(index)
@@ -259,8 +262,10 @@ private[agent] object ToolProcessor {
 
       onEvent(AgentEvent.toolStarted(toolCall.id, toolCall.name, toolCall.arguments.render()))
 
-      val request = ToolCallRequest(toolCall.name, toolCall.arguments)
-      val result  = toolRegistry.execute(request)
+      val request                       = ToolCallRequest(toolCall.name, toolCall.arguments)
+      implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+      val config                        = context.toolExecutionConfig.getOrElse(ToolExecutionConfig())
+      val result                        = toolRegistry.execute(request, config)
 
       val toolEndTime = System.currentTimeMillis()
       val duration    = toolEndTime - toolStartTime

--- a/modules/core/src/main/scala/org/llm4s/toolapi/ToolExecutionConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/ToolExecutionConfig.scala
@@ -1,0 +1,29 @@
+package org.llm4s.toolapi
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * Configuration for tool execution: optional per-tool timeout and retry policy.
+ *
+ * Default is no timeout and no retry (backward compatible).
+ */
+case class ToolExecutionConfig(
+  timeout: Option[FiniteDuration] = None,
+  retryPolicy: Option[ToolRetryPolicy] = None
+)
+
+/**
+ * Simple retry policy with exponential backoff.
+ *
+ * @param maxAttempts  Total attempts (first try + retries); must be >= 1.
+ * @param baseDelay    Delay after first failure before first retry.
+ * @param backoffFactor Multiplier for each subsequent delay (e.g. 2.0 => baseDelay, 2*baseDelay, 4*baseDelay).
+ */
+case class ToolRetryPolicy(
+  maxAttempts: Int,
+  baseDelay: FiniteDuration,
+  backoffFactor: Double = 2.0
+) {
+  require(maxAttempts >= 1, "maxAttempts must be >= 1")
+  require(backoffFactor >= 1.0, "backoffFactor must be >= 1.0")
+}

--- a/modules/core/src/main/scala/org/llm4s/toolapi/ToolParameterError.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/ToolParameterError.scala
@@ -89,6 +89,22 @@ sealed trait ToolCallError {
 object ToolCallError {
 
   /**
+   * Whether this error is considered retryable (e.g. timeout, transient execution failure).
+   * UnknownFunction, NullArguments, InvalidArguments, HandlerError are not retryable.
+   * ExecutionError is retryable when the cause is IOException or TimeoutException (transient).
+   */
+  def isRetryable(error: ToolCallError): Boolean = error match {
+    case _: UnknownFunction | _: NullArguments | _: InvalidArguments | _: HandlerError =>
+      false
+    case _: Timeout =>
+      true
+    case ExecutionError(_, cause) =>
+      import java.io.IOException
+      import java.util.concurrent.TimeoutException
+      cause.isInstanceOf[IOException] || cause.isInstanceOf[TimeoutException]
+  }
+
+  /**
    * Tool function doesn't exist
    */
   case class UnknownFunction(toolName: String) extends ToolCallError {
@@ -137,6 +153,19 @@ object ToolCallError {
     error: String
   ) extends ToolCallError {
     def getMessage: String = s"failed with error: $error"
+  }
+
+  /**
+   * Tool execution did not complete within the configured timeout.
+   *
+   * @param toolName  Name of the tool that timed out
+   * @param duration Timeout duration that was exceeded
+   */
+  case class Timeout(
+    toolName: String,
+    duration: scala.concurrent.duration.FiniteDuration
+  ) extends ToolCallError {
+    def getMessage: String = s"$toolName timed out after $duration"
   }
 }
 
@@ -268,6 +297,12 @@ object ToolCallErrorJson {
         base("errorType") = "execution_error"
         // Optionally include exception class name for debugging (safe, no stack trace)
         base("exceptionType") = cause.getClass.getSimpleName
+        base
+
+      case ToolCallError.Timeout(_, duration) =>
+        base("errorType") = "timeout"
+        base("code") = "timeout"
+        base("duration") = duration.toString
         base
     }
   }

--- a/modules/core/src/main/scala/org/llm4s/toolapi/ToolRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/ToolRegistry.scala
@@ -1,11 +1,12 @@
 package org.llm4s.toolapi
 
-import org.llm4s.core.safety.Safety
 import org.llm4s.error.ValidationError
 import org.llm4s.types.Result
 
-import scala.concurrent.{ ExecutionContext, Future, blocking }
+import scala.concurrent.{ Await, ExecutionContext, Future, Promise, blocking }
+import scala.concurrent.duration._
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ Executors, ScheduledExecutorService, TimeUnit }
 import scala.util.control.NonFatal
 
 /**
@@ -57,32 +58,118 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
   /**
    * Executes a tool call synchronously, wrapping any thrown exception.
    *
-   * Delegates to [[org.llm4s.core.safety.Safety.safely]] so that exceptions
-   * thrown inside the tool implementation are caught and converted to
-   * `ToolCallError.ExecutionError` rather than propagating to the caller.
-   * This means callers always receive a typed `Either` and never need to
-   * guard against unexpected exceptions from tool code.
+   * We use `Try` here (rather than `org.llm4s.core.safety.Safety.safely`) so that tool
+   * execution remains independent of the Safety API and returns `Either` for direct use
+   * by retry/timeout logic. Safety is still used elsewhere in the codebase (e.g. tracing,
+   * agent entry points).
    *
-   * Tool-returned `Left` values are propagated unchanged via `.flatten`, so
-   * callers may receive any `ToolCallError` subtype that the tool itself
-   * produces (not only `ExecutionError`).
+   * Exceptions thrown inside the tool implementation are caught and converted to
+   * `ToolCallError.ExecutionError` with the original throwable preserved (so
+   * retry logic can treat e.g. IOException as retryable). Callers always receive
+   * a typed `Either` and never need to guard against unexpected exceptions from tool code.
+   *
+   * Tool-returned `Left` values are propagated unchanged, so callers may receive
+   * any `ToolCallError` subtype that the tool itself produces (not only `ExecutionError`).
    *
    * @param request The tool name and pre-parsed JSON arguments.
    * @return `Right(result)` on success; `Left(ToolCallError.UnknownFunction)`
    *         when no tool with the given name is registered;
    *         `Left(ToolCallError.ExecutionError)` when the tool throws an
-   *         exception (caught by `Safety.safely`); or `Left(error)` with the
-   *         tool's own `ToolCallError` when the tool returns a `Left` directly.
+   *         exception; or `Left(error)` with the tool's own `ToolCallError` when
+   *         the tool returns a `Left` directly.
    */
   def execute(request: ToolCallRequest): Either[ToolCallError, ujson.Value] =
+    runOneAttempt(request)
+
+  /**
+   * Executes a tool call with optional per-tool timeout and retry.
+   *
+   * When `config` is default (no timeout, no retry), behavior is identical to [[execute(request)]].
+   *
+   * @param request The tool call request
+   * @param config  Optional timeout and retry policy
+   * @param ec      ExecutionContext required when timeout or retry is used
+   */
+  def execute(
+    request: ToolCallRequest,
+    config: ToolExecutionConfig
+  )(implicit ec: ExecutionContext): Either[ToolCallError, ujson.Value] = {
+    val noTimeout = config.timeout.isEmpty
+    val noRetry   = config.retryPolicy.isEmpty
+    if (noTimeout && noRetry) {
+      runOneAttempt(request)
+    } else {
+      runWithRetry(request, config)
+    }
+  }
+
+  /** Single attempt: find tool and run it (no timeout, no retry). */
+  private def runOneAttempt(request: ToolCallRequest): Either[ToolCallError, ujson.Value] =
     tools.find(_.name == request.functionName) match {
       case Some(tool) =>
-        Safety
-          .safely(tool.execute(request.arguments))
-          .left
-          .map(err => ToolCallError.ExecutionError(request.functionName, new Exception(err.message)))
-          .flatten
+        scala.util.Try(tool.execute(request.arguments)) match {
+          case scala.util.Success(Right(v)) => Right(v)
+          case scala.util.Success(Left(e))  => Left(e)
+          case scala.util.Failure(t)        => Left(ToolCallError.ExecutionError(request.functionName, t))
+        }
       case None => Left(ToolCallError.UnknownFunction(request.functionName))
+    }
+
+  private def runWithRetry(
+    request: ToolCallRequest,
+    config: ToolExecutionConfig
+  )(implicit ec: ExecutionContext): Either[ToolCallError, ujson.Value] =
+    config.retryPolicy match {
+      case None =>
+        runOneAttemptWithTimeout(request, config.timeout)
+      case Some(policy) =>
+        var attempt                                        = 0
+        var lastResult: Either[ToolCallError, ujson.Value] = null
+        while (attempt < policy.maxAttempts) {
+          lastResult = runOneAttemptWithTimeout(request, config.timeout)
+          lastResult match {
+            case Right(_) => return lastResult
+            case Left(err) if ToolCallError.isRetryable(err) && attempt + 1 < policy.maxAttempts =>
+              attempt += 1
+              // Exponential backoff: delay = baseDelay * backoffFactor^(attempt-1)
+              // attempt 1 -> baseDelay, attempt 2 -> baseDelay * factor, attempt 3 -> baseDelay * factor^2, ...
+              val delayMs =
+                (policy.baseDelay.toMillis * math.pow(policy.backoffFactor, (attempt - 1).toDouble)).toLong
+              if (delayMs > 0) {
+                blocking {
+                  Thread.sleep(delayMs)
+                }
+              }
+            case _ => return lastResult
+          }
+        }
+        lastResult
+    }
+
+  private def runOneAttemptWithTimeout(
+    request: ToolCallRequest,
+    timeoutOpt: Option[FiniteDuration]
+  )(implicit ec: ExecutionContext): Either[ToolCallError, ujson.Value] =
+    timeoutOpt match {
+      case None =>
+        runOneAttempt(request)
+      case Some(duration) =>
+        val promise = Promise[Either[ToolCallError, ujson.Value]]()
+        val timeoutError =
+          Left(ToolCallError.Timeout(request.functionName, duration)): Either[ToolCallError, ujson.Value]
+        val runFuture = Future(blocking(runOneAttempt(request)))
+        val scheduled = ToolRegistry.timeoutScheduler.schedule(
+          new Runnable {
+            override def run(): Unit = promise.trySuccess(timeoutError)
+          },
+          duration.length,
+          duration.unit
+        )
+        runFuture.onComplete { result =>
+          scheduled.cancel(false)
+          promise.tryComplete(result)
+        }
+        Await.result(promise.future, duration + 1.second)
     }
 
   /**
@@ -99,7 +186,20 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
   def executeAsync(request: ToolCallRequest)(implicit
     ec: ExecutionContext
   ): Future[Either[ToolCallError, ujson.Value]] =
-    Future(blocking(execute(request)))
+    executeAsync(request, ToolExecutionConfig())
+
+  /**
+   * Execute a tool call asynchronously with optional timeout and retry.
+   *
+   * @param request The tool call request
+   * @param config  Optional timeout and retry policy
+   * @param ec      ExecutionContext for async execution
+   */
+  def executeAsync(
+    request: ToolCallRequest,
+    config: ToolExecutionConfig
+  )(implicit ec: ExecutionContext): Future[Either[ToolCallError, ujson.Value]] =
+    Future(blocking(execute(request, config)))
 
   /**
    * Execute multiple tool calls with a configurable strategy.
@@ -111,36 +211,39 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
    */
   def executeAll(
     requests: Seq[ToolCallRequest],
-    strategy: ToolExecutionStrategy = ToolExecutionStrategy.default
+    strategy: ToolExecutionStrategy = ToolExecutionStrategy.default,
+    config: ToolExecutionConfig = ToolExecutionConfig()
   )(implicit ec: ExecutionContext): Future[Seq[Either[ToolCallError, ujson.Value]]] =
     strategy match {
       case ToolExecutionStrategy.Sequential =>
-        executeSequential(requests)
+        executeSequential(requests, config)
 
       case ToolExecutionStrategy.Parallel =>
-        executeParallel(requests)
+        executeParallel(requests, config)
 
       case ToolExecutionStrategy.ParallelWithLimit(maxConcurrency) =>
-        executeWithLimit(requests, maxConcurrency)
+        executeWithLimit(requests, maxConcurrency, config)
     }
 
   /**
    * Execute requests sequentially (one at a time).
    */
   private def executeSequential(
-    requests: Seq[ToolCallRequest]
+    requests: Seq[ToolCallRequest],
+    config: ToolExecutionConfig
   )(implicit ec: ExecutionContext): Future[Seq[Either[ToolCallError, ujson.Value]]] =
     requests.foldLeft(Future.successful(Seq.empty[Either[ToolCallError, ujson.Value]])) { (accFuture, request) =>
-      accFuture.flatMap(acc => executeAsync(request).map(result => acc :+ result))
+      accFuture.flatMap(acc => executeAsync(request, config).map(result => acc :+ result))
     }
 
   /**
    * Execute all requests in parallel.
    */
   private def executeParallel(
-    requests: Seq[ToolCallRequest]
+    requests: Seq[ToolCallRequest],
+    config: ToolExecutionConfig
   )(implicit ec: ExecutionContext): Future[Seq[Either[ToolCallError, ujson.Value]]] =
-    Future.traverse(requests)(executeAsync)
+    Future.traverse(requests)(req => executeAsync(req, config))
 
   /**
    * Execute requests in parallel with a concurrency limit using a sliding window.
@@ -148,7 +251,8 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
    */
   private def executeWithLimit(
     requests: Seq[ToolCallRequest],
-    maxConcurrency: Int
+    maxConcurrency: Int,
+    config: ToolExecutionConfig
   )(implicit ec: ExecutionContext): Future[Seq[Either[ToolCallError, ujson.Value]]] =
     if (requests.isEmpty) {
       Future.successful(Seq.empty)
@@ -164,7 +268,7 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
           Future.successful(())
         } else {
           val request = tasks(idx)
-          executeAsync(request)
+          executeAsync(request, config)
             .recover { case NonFatal(ex) =>
               Left(ToolCallError.ExecutionError(request.functionName, new Exception(ex.getMessage)))
             }
@@ -231,6 +335,28 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
 }
 
 object ToolRegistry {
+
+  /** Shared scheduler for per-tool timeouts. Single thread, no thread per tool call. */
+  private[toolapi] lazy val timeoutScheduler: ScheduledExecutorService = {
+    val executor = Executors.newSingleThreadScheduledExecutor { (r: Runnable) =>
+      val t = new Thread(r, "tool-registry-timeout")
+      t.setDaemon(true)
+      t
+    }
+    sys.addShutdownHook {
+      executor.shutdown()
+      try
+        if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+          executor.shutdownNow()
+        }
+      catch {
+        case _: InterruptedException =>
+          executor.shutdownNow()
+          Thread.currentThread().interrupt()
+      }
+    }
+    executor
+  }
 
   /**
    * Creates an empty tool registry with no tools

--- a/modules/core/src/test/scala/org/llm4s/agent/AgentTracingSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/AgentTracingSpec.scala
@@ -371,9 +371,13 @@ class AgentTracingSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "trace unexpected tool processing failures when processToolCalls throws" in {
-    // Tool registry that throws from execute, causing processToolCalls to throw inside runStep
+    // Tool registry that throws from execute, causing processToolCalls to throw inside runStep.
+    // Override the two-arg execute used by ToolProcessor (not the single-arg one).
     val throwingRegistry = new ToolRegistry(Seq.empty) {
-      override def execute(request: ToolCallRequest): Either[ToolCallError, ujson.Value] =
+      override def execute(
+        request: ToolCallRequest,
+        config: ToolExecutionConfig
+      )(implicit ec: scala.concurrent.ExecutionContext): Either[ToolCallError, ujson.Value] =
         throw new RuntimeException("registry failure")
     }
 

--- a/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
@@ -72,6 +72,60 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
       .buildSafe()
   }
 
+  /** Tool that sleeps for a given number of milliseconds then returns. Used for timeout tests. */
+  def createSleepTool(): Result[ToolFunction[Map[String, Any], MathResult]] = {
+    val schema = Schema
+      .`object`[Map[String, Any]]("Sleep parameters")
+      .withProperty(Schema.property("ms", Schema.integer("Milliseconds to sleep")))
+
+    ToolBuilder[Map[String, Any], MathResult](
+      "sleep",
+      "Sleeps for given ms",
+      schema
+    ).withHandler { extractor =>
+      for {
+        ms <- extractor.getInt("ms")
+      } yield {
+        Thread.sleep(ms.toLong)
+        MathResult(0.0)
+      }
+    }.buildSafe()
+  }
+
+  /** Tool that fails with IOException the first N times then succeeds. Used for retry tests. */
+  def createFlakyTool(failCount: Int): Result[ToolFunction[Map[String, Any], MathResult]] = {
+    val schema = Schema
+      .`object`[Map[String, Any]]("Flaky parameters")
+      .withProperty(Schema.property("x", Schema.number("Value")))
+    val counter = new java.util.concurrent.atomic.AtomicInteger(0)
+    ToolBuilder[Map[String, Any], MathResult](
+      "flaky",
+      "Fails N times then succeeds",
+      schema
+    ).withHandler { extractor =>
+      for {
+        x <- extractor.getDouble("x")
+      } yield {
+        if (counter.getAndIncrement() < failCount) {
+          throw new java.io.IOException("transient failure")
+        }
+        MathResult(x)
+      }
+    }.buildSafe()
+  }
+
+  /** Tool that always returns Left (handler error). Not retryable. */
+  def createFailingTool(): Result[ToolFunction[Map[String, Any], MathResult]] = {
+    val schema = Schema
+      .`object`[Map[String, Any]]("Fail parameters")
+      .withProperty(Schema.property("x", Schema.number("Value")))
+    ToolBuilder[Map[String, Any], MathResult](
+      "fail",
+      "Always fails",
+      schema
+    ).withHandler(_ => Left("validation error")).buildSafe()
+  }
+
   // ============ ToolRegistry.empty ============
 
   "ToolRegistry.empty" should "create an empty registry" in {
@@ -303,6 +357,107 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
         val results       = Await.result(futureResults, 5.seconds)
         results shouldBe empty
       }
+    )
+  }
+
+  // ============ Timeout and Retry ============
+
+  "ToolRegistry.execute with timeout" should "return timeout error when tool sleeps longer than timeout" in {
+    createSleepTool().fold(
+      e => fail(s"Tool creation failed: ${e.formatted}"),
+      sleepTool => {
+        val registry = new ToolRegistry(Seq(sleepTool))
+        val config   = ToolExecutionConfig(timeout = Some(100.millis))
+        val request  = ToolCallRequest("sleep", ujson.Obj("ms" -> 500))
+        val result   = registry.execute(request, config)
+        result.isLeft shouldBe true
+        result.left.toOption.get shouldBe a[ToolCallError.Timeout]
+        result.left.toOption.get.getMessage should include("timed out")
+        result.left.toOption.get.getMessage should include("sleep")
+      }
+    )
+  }
+
+  it should "succeed when tool completes within timeout" in {
+    createSleepTool().fold(
+      e => fail(s"Tool creation failed: ${e.formatted}"),
+      sleepTool => {
+        val registry = new ToolRegistry(Seq(sleepTool))
+        val config   = ToolExecutionConfig(timeout = Some(2.seconds))
+        val request  = ToolCallRequest("sleep", ujson.Obj("ms" -> 50))
+        val result   = registry.execute(request, config)
+        result.isRight shouldBe true
+      }
+    )
+  }
+
+  "ToolRegistry.execute with retry" should "succeed after retries when tool fails then succeeds" in {
+    createFlakyTool(2).fold(
+      e => fail(s"Tool creation failed: ${e.formatted}"),
+      flakyTool => {
+        val registry = new ToolRegistry(Seq(flakyTool))
+        val config = ToolExecutionConfig(
+          retryPolicy = Some(ToolRetryPolicy(maxAttempts = 3, baseDelay = 10.millis, backoffFactor = 1.5))
+        )
+        val request = ToolCallRequest("flaky", ujson.Obj("x" -> 42.0))
+        val result  = registry.execute(request, config)
+        result.isRight shouldBe true
+        result.toOption.get("result").num shouldBe 42.0
+      }
+    )
+  }
+
+  it should "return failure when retry disabled and tool fails once" in {
+    createFlakyTool(1).fold(
+      e => fail(s"Tool creation failed: ${e.formatted}"),
+      flakyTool => {
+        val registry = new ToolRegistry(Seq(flakyTool))
+        val config   = ToolExecutionConfig() // no retry
+        val request  = ToolCallRequest("flaky", ujson.Obj("x" -> 1.0))
+        val result   = registry.execute(request, config)
+        result.isLeft shouldBe true
+      }
+    )
+  }
+
+  it should "not retry on non-retryable error (e.g. handler error)" in {
+    createFailingTool().fold(
+      e => fail(s"Tool creation failed: ${e.formatted}"),
+      failTool => {
+        val registry = new ToolRegistry(Seq(failTool))
+        val config = ToolExecutionConfig(
+          retryPolicy = Some(ToolRetryPolicy(maxAttempts = 3, baseDelay = 10.millis))
+        )
+        val request = ToolCallRequest("fail", ujson.Obj("x" -> 1.0))
+        val result  = registry.execute(request, config)
+        result.isLeft shouldBe true
+        result.left.toOption.get shouldBe a[ToolCallError.HandlerError]
+      }
+    )
+  }
+
+  "ToolRegistry.executeAll with timeout" should "complete batch when one tool times out and others succeed" in {
+    createAddTool().fold(
+      e => fail(s"Tool creation failed: ${e.formatted}"),
+      addTool =>
+        createSleepTool().fold(
+          e2 => fail(s"Sleep tool failed: ${e2.formatted}"),
+          sleepTool => {
+            val registry = new ToolRegistry(Seq(addTool, sleepTool))
+            val config   = ToolExecutionConfig(timeout = Some(150.millis))
+            val requests = Seq(
+              ToolCallRequest("add", ujson.Obj("a" -> 1, "b" -> 2)),
+              ToolCallRequest("sleep", ujson.Obj("ms" -> 5000)),
+              ToolCallRequest("add", ujson.Obj("a" -> 3, "b" -> 4))
+            )
+            val futureResults = registry.executeAll(requests, ToolExecutionStrategy.Parallel, config)
+            val results       = Await.result(futureResults, 10.seconds)
+            results should have size 3
+            results(0).map(_("result").num) shouldBe Right(3.0)
+            results(1).left.toOption.get shouldBe a[ToolCallError.Timeout]
+            results(2).map(_("result").num) shouldBe Right(7.0)
+          }
+        )
     )
   }
 


### PR DESCRIPTION
## What this PR does

Adds **configurable per-tool timeout** and **optional retry** for tool execution. Callers can set a timeout and/or retry policy via `ToolExecutionConfig`; `ToolProcessor` uses config from `AgentContext`. Defaults preserve current behavior (no timeout wrap, no retry).

## Problem

Previously, tool execution had no retry and no per-tool timeout. A transient failure (e.g. network/5xx) was immediately surfaced to the LLM, and a slow tool could block the entire batch due to a fixed 5-minute Await. A single transient failure (e.g. network, 5xx) was turned into a JSON error and sent back to the LLM. Synchronous tool runs could block indefinitely; the async path used a single 5-minute `Await.result` for the whole batch. A slow or hanging tool could block the entire step or batch.

## Changes made to resolve it

**1. Config and error types**

- **New** `ToolExecutionConfig(timeout: Option[FiniteDuration], retryPolicy: Option[ToolRetryPolicy])` for per-tool timeout and optional retry.
- **New** `ToolRetryPolicy(maxAttempts, baseDelay, backoffFactor = 2.0)` with validation.
- **New** `ToolCallError.Timeout(toolName, duration)` with message including tool name and duration; `ToolCallErrorJson` extended for timeout (`errorType = "timeout"`, `code = "timeout"`, `duration`).
- **ToolCallError.isRetryable:** `true` for `Timeout` and `ExecutionError` with `IOException` cause; `false` for `UnknownFunction`, `NullArguments`, `InvalidArguments`, `HandlerError`.

**2. ToolRegistry**

- **execute(request)** — unchanged; single attempt, no timeout/retry.
- **execute(request, config)(implicit ec)** — when config has timeout and/or retry: runs via `runOneAttemptWithTimeout` (Future race with timeout) and optional retry loop with exponential backoff; otherwise delegates to `runOneAttempt`.
- **runOneAttempt** — now uses `Try(tool.execute(...))` and preserves the original throwable in `ExecutionError`, so `isRetryable` works for `IOException` (e.g. transient failures).
- **executeAll(requests, strategy, config)** — all strategies pass `config` into `executeAsync`; batch timeout derived from config when present.

**3. Agent integration**

- **AgentContext:** New optional field `toolExecutionConfig: Option[ToolExecutionConfig] = None`.
- **ToolProcessor:** `processToolCalls` / `processToolCallsWithEvents` / `processToolCallsAsync` use `context.toolExecutionConfig.getOrElse(ToolExecutionConfig())` and call `toolRegistry.execute(request, config)` (or `executeAll(..., config)`); batch timeout uses config when set.

**4. Tests**

- **ToolRegistrySpec:** Timeout (tool sleeps longer than timeout → `Left(Timeout)`; within timeout → success); retry (flaky tool fails then succeeds with retry; no retry when disabled; non-retryable handler error not retried); batch with one timeout and others succeed.
- **AgentTracingSpec:** Custom registry now overrides two-arg `execute(request, config)` so “trace unexpected tool processing failures when processToolCalls throws” exercises the throwing path used by ToolProcessor.

## Result

- Callers can set `AgentContext(toolExecutionConfig = Some(ToolExecutionConfig(timeout = Some(30.seconds), retryPolicy = Some(ToolRetryPolicy(maxAttempts = 3, ...)))))` (or load from config) to get per-tool timeout and optional retry for transient/IO failures.
- Default behavior is unchanged: no timeout, no retry.
- Timeout and retryable execution errors are surfaced as structured `ToolCallError` (including `Timeout` with tool name in the message) and continue to be returned as JSON to the LLM.
- All changes covered by the above tests.
Closes: #786 
