### PR TITLE
feat(metrics): add in-process CostTracker with thread-safe aggregation and full test coverage (#515)

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/metrics/CostTracker.scala
+++ b/modules/core/src/main/scala/org/llm4s/metrics/CostTracker.scala
@@ -1,0 +1,200 @@
+package org.llm4s.metrics
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.{ DoubleAdder, LongAdder }
+
+import org.llm4s.llmconnect.model.TokenUsage
+
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters._
+
+trait CostTracker extends MetricsCollector {
+  def record(model: String, usage: TokenUsage, cost: Option[Double]): Unit
+  def totalCost: Double
+  def totalTokens: Int
+  def totalRequests: Int
+  def byModel: Map[String, ModelCostSummary]
+  def reset(): Unit
+  def summary: String
+}
+
+case class ModelCostSummary(
+  inputTokens: Long,
+  outputTokens: Long,
+  requestCount: Int,
+  totalCostUsd: Double
+)
+
+object CostTracker {
+  def create(): CostTracker = new InMemoryCostTracker()
+  val noop: CostTracker     = new NoopCostTracker()
+}
+
+final private[metrics] class InMemoryCostTracker extends CostTracker {
+
+  final private class ModelAccumulators {
+    val inputTokens: LongAdder    = new LongAdder()
+    val outputTokens: LongAdder   = new LongAdder()
+    val requestCount: LongAdder   = new LongAdder()
+    val totalCostUsd: DoubleAdder = new DoubleAdder()
+
+    def snapshot: ModelCostSummary =
+      ModelCostSummary(
+        inputTokens = inputTokens.sum(),
+        outputTokens = outputTokens.sum(),
+        requestCount = requestCount.sum().toInt,
+        totalCostUsd = totalCostUsd.sum()
+      )
+  }
+
+  private val totalCostUsd: DoubleAdder    = new DoubleAdder()
+  private val totalInputTokens: LongAdder  = new LongAdder()
+  private val totalOutputTokens: LongAdder = new LongAdder()
+  private val totalRequestCount: LongAdder = new LongAdder()
+
+  private val perModel: ConcurrentHashMap[String, ModelAccumulators] = new ConcurrentHashMap()
+
+  private def modelAccumulators(model: String): ModelAccumulators =
+    perModel.computeIfAbsent(model, _ => new ModelAccumulators)
+
+  private def incRequest(model: String): Unit = {
+    totalRequestCount.add(1)
+    modelAccumulators(model).requestCount.add(1)
+  }
+
+  private def incTokens(model: String, inputTokens: Long, outputTokens: Long): Unit = {
+    totalInputTokens.add(inputTokens)
+    totalOutputTokens.add(outputTokens)
+
+    val acc = modelAccumulators(model)
+    acc.inputTokens.add(inputTokens)
+    acc.outputTokens.add(outputTokens)
+  }
+
+  private def incCost(model: String, costUsd: Double): Unit = {
+    totalCostUsd.add(costUsd)
+    modelAccumulators(model).totalCostUsd.add(costUsd)
+  }
+
+  override def record(model: String, usage: TokenUsage, cost: Option[Double]): Unit =
+    try {
+      incRequest(model)
+      incTokens(
+        model = model,
+        inputTokens = usage.promptTokens.toLong,
+        outputTokens = usage.completionTokens.toLong
+      )
+      cost.foreach(incCost(model, _))
+    } catch {
+      case _: Throwable => ()
+    }
+
+  override def observeRequest(
+    provider: String,
+    model: String,
+    outcome: Outcome,
+    duration: FiniteDuration
+  ): Unit =
+    try
+      incRequest(model)
+    catch {
+      case _: Throwable => ()
+    }
+
+  override def addTokens(
+    provider: String,
+    model: String,
+    inputTokens: Long,
+    outputTokens: Long
+  ): Unit =
+    try
+      incTokens(model, inputTokens, outputTokens)
+    catch {
+      case _: Throwable => ()
+    }
+
+  override def recordCost(
+    provider: String,
+    model: String,
+    costUsd: Double
+  ): Unit =
+    try
+      incCost(model, costUsd)
+    catch {
+      case _: Throwable => ()
+    }
+
+  override def totalCost: Double = totalCostUsd.sum()
+
+  override def totalTokens: Int = {
+    val total = totalInputTokens.sum() + totalOutputTokens.sum()
+    if (total > Int.MaxValue) Int.MaxValue else total.toInt
+  }
+
+  override def totalRequests: Int = {
+    val total = totalRequestCount.sum()
+    if (total > Int.MaxValue) Int.MaxValue else total.toInt
+  }
+
+  override def byModel: Map[String, ModelCostSummary] =
+    perModel.asScala.view.mapValues(_.snapshot).toMap
+
+  override def reset(): Unit =
+    try {
+      totalCostUsd.reset()
+      totalInputTokens.reset()
+      totalOutputTokens.reset()
+      totalRequestCount.reset()
+      perModel.clear()
+    } catch {
+      case _: Throwable => ()
+    }
+
+  override def summary: String = {
+    val models = byModel.toSeq.sortBy(_._1)
+
+    val header =
+      s"totalCostUsd=${totalCost} totalTokens=${totalTokens} totalRequests=${totalRequests}"
+
+    if (models.isEmpty) header
+    else {
+      val perModelStr = models
+        .map { case (model, s) =>
+          s"$model: requests=${s.requestCount} inputTokens=${s.inputTokens} outputTokens=${s.outputTokens} costUsd=${s.totalCostUsd}"
+        }
+        .mkString("\n")
+      s"$header\n$perModelStr"
+    }
+  }
+}
+
+final private[metrics] class NoopCostTracker extends CostTracker {
+  override def record(model: String, usage: TokenUsage, cost: Option[Double]): Unit = ()
+
+  override def observeRequest(
+    provider: String,
+    model: String,
+    outcome: Outcome,
+    duration: FiniteDuration
+  ): Unit = ()
+
+  override def addTokens(
+    provider: String,
+    model: String,
+    inputTokens: Long,
+    outputTokens: Long
+  ): Unit = ()
+
+  override def recordCost(
+    provider: String,
+    model: String,
+    costUsd: Double
+  ): Unit = ()
+
+  override def totalCost: Double                      = 0.0
+  override def totalTokens: Int                       = 0
+  override def totalRequests: Int                     = 0
+  override def byModel: Map[String, ModelCostSummary] = Map.empty
+  override def reset(): Unit                          = ()
+  override def summary: String                        = "totalCostUsd=0.0 totalTokens=0 totalRequests=0"
+}

--- a/modules/core/src/main/scala/org/llm4s/metrics/MetricsCollector.scala
+++ b/modules/core/src/main/scala/org/llm4s/metrics/MetricsCollector.scala
@@ -106,6 +106,54 @@ trait MetricsCollector {
 
 object MetricsCollector {
 
+  def compose(collectors: MetricsCollector*): MetricsCollector =
+    if (collectors.isEmpty) {
+      noop
+    } else {
+      new MetricsCollector {
+        override def observeRequest(
+          provider: String,
+          model: String,
+          outcome: Outcome,
+          duration: FiniteDuration
+        ): Unit =
+          collectors.foreach(_.observeRequest(provider, model, outcome, duration))
+
+        override def addTokens(
+          provider: String,
+          model: String,
+          inputTokens: Long,
+          outputTokens: Long
+        ): Unit =
+          collectors.foreach(_.addTokens(provider, model, inputTokens, outputTokens))
+
+        override def recordCost(
+          provider: String,
+          model: String,
+          costUsd: Double
+        ): Unit =
+          collectors.foreach(_.recordCost(provider, model, costUsd))
+
+        override def recordRetryAttempt(
+          provider: String,
+          attemptNumber: Int
+        ): Unit =
+          collectors.foreach(_.recordRetryAttempt(provider, attemptNumber))
+
+        override def recordCircuitBreakerTransition(
+          provider: String,
+          newState: String
+        ): Unit =
+          collectors.foreach(_.recordCircuitBreakerTransition(provider, newState))
+
+        override def recordError(
+          errorKind: ErrorKind,
+          provider: String
+        ): Unit =
+          collectors.foreach(_.recordError(errorKind, provider))
+      }
+    }
+
   /**
    * No-op implementation that does nothing.
    * Use as default when metrics are disabled.

--- a/modules/core/src/test/scala/org/llm4s/metrics/CostTrackerSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/metrics/CostTrackerSpec.scala
@@ -1,0 +1,242 @@
+package org.llm4s.metrics
+
+import org.llm4s.llmconnect.model.TokenUsage
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class CostTrackerSpec extends AnyFlatSpec with Matchers with ScalaFutures {
+
+  behavior.of("CostTracker")
+
+  it should "accumulate a single record" in {
+    val tracker = CostTracker.create()
+
+    tracker.observeRequest("openai", "gpt-4", Outcome.Success, 10.millis)
+    tracker.addTokens("openai", "gpt-4", inputTokens = 100, outputTokens = 50)
+    tracker.recordCost("openai", "gpt-4", costUsd = 0.0123)
+
+    tracker.totalRequests shouldBe 1
+    tracker.totalTokens shouldBe 150
+    tracker.totalCost shouldBe 0.0123 +- 1e-12
+
+    val byModel = tracker.byModel
+    byModel.keySet shouldBe Set("gpt-4")
+
+    val s = byModel("gpt-4")
+    s.requestCount shouldBe 1
+    s.inputTokens shouldBe 100
+    s.outputTokens shouldBe 50
+    s.totalCostUsd shouldBe 0.0123 +- 1e-12
+  }
+
+  it should "aggregate multiple models independently" in {
+    val tracker = CostTracker.create()
+
+    tracker.observeRequest("openai", "gpt-4", Outcome.Success, 10.millis)
+    tracker.addTokens("openai", "gpt-4", inputTokens = 100, outputTokens = 50)
+    tracker.recordCost("openai", "gpt-4", costUsd = 0.01)
+
+    tracker.observeRequest("anthropic", "claude", Outcome.Success, 20.millis)
+    tracker.addTokens("anthropic", "claude", inputTokens = 200, outputTokens = 25)
+    tracker.recordCost("anthropic", "claude", costUsd = 0.02)
+
+    tracker.totalRequests shouldBe 2
+    tracker.totalTokens shouldBe (150 + 225)
+    tracker.totalCost shouldBe 0.03 +- 1e-12
+
+    tracker.byModel("gpt-4").totalCostUsd shouldBe 0.01 +- 1e-12
+    tracker.byModel("claude").totalCostUsd shouldBe 0.02 +- 1e-12
+  }
+
+  it should "reset all counters" in {
+    val tracker = CostTracker.create()
+
+    tracker.observeRequest("openai", "gpt-4", Outcome.Success, 10.millis)
+    tracker.addTokens("openai", "gpt-4", inputTokens = 100, outputTokens = 50)
+    tracker.recordCost("openai", "gpt-4", costUsd = 0.0123)
+
+    tracker.reset()
+
+    tracker.totalRequests shouldBe 0
+    tracker.totalTokens shouldBe 0
+    tracker.totalCost shouldBe 0.0 +- 1e-12
+    tracker.byModel shouldBe empty
+  }
+
+  it should "support record with None cost (tokens and requests increment; cost does not)" in {
+    val tracker = CostTracker.create()
+
+    val usage = TokenUsage(
+      promptTokens = 10,
+      completionTokens = 5,
+      totalTokens = 15
+    )
+
+    tracker.record(model = "gpt-4", usage = usage, cost = None)
+
+    tracker.totalRequests shouldBe 1
+    tracker.totalTokens shouldBe 15
+    tracker.totalCost shouldBe 0.0 +- 1e-12
+
+    val s = tracker.byModel("gpt-4")
+    s.requestCount shouldBe 1
+    s.inputTokens shouldBe 10
+    s.outputTokens shouldBe 5
+    s.totalCostUsd shouldBe 0.0 +- 1e-12
+  }
+
+  it should "provide a stable empty summary after reset" in {
+    val tracker = CostTracker.create()
+
+    tracker.observeRequest("openai", "gpt-4", Outcome.Success, 10.millis)
+    tracker.addTokens("openai", "gpt-4", inputTokens = 100, outputTokens = 50)
+    tracker.recordCost("openai", "gpt-4", costUsd = 0.0123)
+
+    tracker.reset()
+
+    tracker.summary shouldBe "totalCostUsd=0.0 totalTokens=0 totalRequests=0"
+  }
+
+  it should "include per-model data in non-empty summary" in {
+    val tracker = CostTracker.create()
+
+    val usage = TokenUsage(
+      promptTokens = 2,
+      completionTokens = 3,
+      totalTokens = 5
+    )
+
+    tracker.record(model = "gpt-4", usage = usage, cost = Some(0.0001))
+
+    val s = tracker.summary
+    s should include("totalCostUsd=")
+    s should include("totalTokens=")
+    s should include("totalRequests=")
+    s should include("gpt-4")
+    s should include("requests=1")
+    s should include("inputTokens=2")
+    s should include("outputTokens=3")
+    s should include("costUsd=")
+  }
+
+  it should "compose and forward calls to all collectors" in {
+    val tracker = CostTracker.create()
+    val mock    = new MockMetricsCollector()
+
+    val composed = MetricsCollector.compose(tracker, mock)
+
+    composed.observeRequest("openai", "gpt-4", Outcome.Success, 10.millis)
+    composed.addTokens("openai", "gpt-4", inputTokens = 100, outputTokens = 50)
+    composed.recordCost("openai", "gpt-4", costUsd = 0.0123)
+
+    tracker.totalRequests shouldBe 1
+    tracker.totalTokens shouldBe 150
+    tracker.totalCost shouldBe 0.0123 +- 1e-12
+
+    mock.totalRequests shouldBe 1
+    mock.totalTokenCalls shouldBe 1
+    mock.totalCostCalls shouldBe 1
+  }
+
+  it should "compose with empty input and return noop" in {
+    val composed = MetricsCollector.compose()
+    composed eq MetricsCollector.noop shouldBe true
+  }
+
+  it should "compose and forward calls to three collectors" in {
+    val a = new MockMetricsCollector()
+    val b = new MockMetricsCollector()
+    val c = new MockMetricsCollector()
+
+    val composed = MetricsCollector.compose(a, b, c)
+
+    composed.observeRequest("openai", "gpt-4", Outcome.Success, 10.millis)
+    composed.addTokens("openai", "gpt-4", inputTokens = 1, outputTokens = 2)
+    composed.recordCost("openai", "gpt-4", costUsd = 0.01)
+
+    a.totalRequests shouldBe 1
+    b.totalRequests shouldBe 1
+    c.totalRequests shouldBe 1
+
+    a.totalTokenCalls shouldBe 1
+    b.totalTokenCalls shouldBe 1
+    c.totalTokenCalls shouldBe 1
+
+    a.totalCostCalls shouldBe 1
+    b.totalCostCalls shouldBe 1
+    c.totalCostCalls shouldBe 1
+  }
+
+  it should "have a noop implementation that stays at zero" in {
+    val tracker = CostTracker.noop
+
+    val usage = TokenUsage(
+      promptTokens = 10,
+      completionTokens = 5,
+      totalTokens = 15
+    )
+
+    noException should be thrownBy tracker.record("gpt-4", usage, Some(0.1))
+
+    tracker.totalRequests shouldBe 0
+    tracker.totalTokens shouldBe 0
+    tracker.totalCost shouldBe 0.0 +- 1e-12
+    tracker.byModel shouldBe empty
+    tracker.summary shouldBe "totalCostUsd=0.0 totalTokens=0 totalRequests=0"
+  }
+
+  it should "clamp totalTokens and totalRequests to Int.MaxValue" in {
+    val tracker = CostTracker.create()
+
+    val impl = tracker match {
+      case t: InMemoryCostTracker => t
+      case _                      => fail("Expected InMemoryCostTracker")
+    }
+
+    def addToLongAdder(fieldName: String, value: Long): Unit = {
+      val f = classOf[InMemoryCostTracker].getDeclaredField(fieldName)
+      f.setAccessible(true)
+      val adder = f.get(impl).asInstanceOf[java.util.concurrent.atomic.LongAdder]
+      adder.add(value)
+    }
+
+    addToLongAdder("totalInputTokens", Int.MaxValue.toLong)
+    addToLongAdder("totalOutputTokens", 1L)
+    addToLongAdder("totalRequestCount", Int.MaxValue.toLong + 1L)
+
+    tracker.totalTokens shouldBe Int.MaxValue
+    tracker.totalRequests shouldBe Int.MaxValue
+  }
+
+  it should "handle basic concurrent updates" in {
+    val tracker = CostTracker.create()
+
+    val n = 200
+
+    val futures = (1 to n).map { _ =>
+      Future {
+        tracker.observeRequest("openai", "gpt-4", Outcome.Success, 1.millis)
+        tracker.addTokens("openai", "gpt-4", inputTokens = 2, outputTokens = 3)
+        tracker.recordCost("openai", "gpt-4", costUsd = 0.0001)
+      }
+    }
+
+    val all: Future[Seq[Unit]] = Future.sequence(futures)
+    whenReady(all) { _ =>
+      tracker.totalRequests shouldBe n
+      tracker.totalTokens shouldBe n * 5
+      tracker.totalCost shouldBe (n * 0.0001) +- 1e-8
+
+      val model = tracker.byModel("gpt-4")
+      model.requestCount shouldBe n
+      model.inputTokens shouldBe n.toLong * 2
+      model.outputTokens shouldBe n.toLong * 3
+      model.totalCostUsd shouldBe (n * 0.0001) +- 1e-8
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Implements Issue #515 by introducing a lightweight, thread-safe in-process `CostTracker` that allows users to aggregate request counts, token usage, and total cost within a session — without requiring Prometheus or external observability systems.

Previously, users needed PrometheusMetrics or tracing integrations to inspect cost metrics. This PR provides a simple in-memory API suitable for scripts, agents, and applications that want direct programmatic access to cost totals.

Key additions:

- `CostTracker` trait extending `MetricsCollector`
- `InMemoryCostTracker` (thread-safe implementation)
- `NoopCostTracker`
- `CostTracker.create()` factory
- `MetricsCollector.compose(...)` combinator for composing collectors

The tracker supports both:
- Split metric calls (`observeRequest`, `addTokens`, `recordCost`)
- Single-call API via `record(model, usage, cost: Option[Double])`

Thread safety is achieved using:
- `ConcurrentHashMap`
- `LongAdder`
- `DoubleAdder`

No `synchronized` or mutable `var` state is used.

---

## Related issue

Fixes #515  
Parent: #15

---

## How was this tested?

Ran full cross-build test suite:
sbt clean
sbt +test



Added `CostTrackerSpec.scala` covering:

- Single-record aggregation
- Multiple model aggregation
- `record(Some)` and `record(None)` paths
- Reset behavior
- Summary (empty and non-empty branches)
- NoopCostTracker behavior
- `MetricsCollector.compose` (empty, 2 collectors, 3 collectors)
- Concurrent update safety using Futures
- Int.MaxValue clamp branches

All tests pass on Scala 2.13 and 3.x.

---

## Checklist

- [x] I have read the Contributing Guide
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt +test` — tests pass on both Scala 2.13 and 3.x
- [x] New code includes tests
- [x] No unrelated changes included (branched from `main`)
- [x] Commit messages explain the "why"