### PR TITLE
refactor: extract shared client lifecycle management into BaseLifecycleLLMClient trait

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/BaseLifecycleLLMClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/BaseLifecycleLLMClient.scala
@@ -1,0 +1,37 @@
+package org.llm4s.llmconnect
+
+import org.llm4s.error.ConfigurationError
+import org.llm4s.types.Result
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Mixin trait providing standard lifecycle management for [[LLMClient]] implementations.
+ *
+ * Tracks whether the client has been closed via an `AtomicBoolean` and provides:
+ *  - `validateNotClosed` — a pre-check returning `Left(ConfigurationError)` once closed.
+ *  - `close()` — an idempotent close that delegates to `releaseResources()` exactly once.
+ *
+ * Concrete clients mix in this trait and optionally override `releaseResources()` to
+ * free provider-specific resources (HTTP clients, SDK connections, etc.).
+ */
+trait BaseLifecycleLLMClient extends LLMClient {
+
+  /** Human-readable label used in the "already closed" error message. */
+  protected def clientDescription: String
+
+  /**
+   * Hook for releasing provider-specific resources.
+   * Called at most once, inside `close()`. The default is a no-op.
+   */
+  protected def releaseResources(): Unit = ()
+
+  private val closed: AtomicBoolean = new AtomicBoolean(false)
+
+  protected def validateNotClosed: Result[Unit] =
+    if (closed.get()) Left(ConfigurationError(s"$clientDescription is already closed"))
+    else Right(())
+
+  override def close(): Unit =
+    if (closed.compareAndSet(false, true)) releaseResources()
+}

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
@@ -8,17 +8,16 @@ import com.anthropic.models.messages.{
   ThinkingConfigEnabled,
   Tool
 }
-import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.config.{ AnthropicConfig, ProviderConfig }
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.streaming._
 import org.llm4s.model.TransformationResult
 import org.llm4s.toolapi.{ ObjectSchema, ToolFunction }
 import org.llm4s.types.Result
-import org.llm4s.error.{ AuthenticationError, ConfigurationError, RateLimitError, ValidationError }
+import org.llm4s.error.{ AuthenticationError, RateLimitError, ValidationError }
 import org.llm4s.error.ThrowableOps._
 
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
@@ -70,7 +69,7 @@ import scala.util.Try
 class AnthropicClient(
   config: AnthropicConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop
-) extends LLMClient
+) extends BaseLifecycleLLMClient
     with MetricsRecording {
   // Store config for budget calculations
   private val providerConfig: ProviderConfig = config
@@ -82,7 +81,7 @@ class AnthropicClient(
     .baseUrl(config.baseUrl)
     .build()
 
-  private val closed: AtomicBoolean = new AtomicBoolean(false)
+  protected def clientDescription: String = s"Anthropic client for model ${config.model}"
 
   override def complete(
     conversation: Conversation,
@@ -537,17 +536,8 @@ curl https://api.anthropic.com/v1/messages \
     toolCalls
   }
 
-  override def close(): Unit =
-    if (closed.compareAndSet(false, true)) {
-      client.close()
-    }
-
-  private def validateNotClosed: Result[Unit] =
-    if (closed.get()) {
-      Left(ConfigurationError(s"Anthropic client for model ${config.model} is already closed"))
-    } else {
-      Right(())
-    }
+  override protected def releaseResources(): Unit =
+    client.close()
 }
 
 object AnthropicClient {

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/CohereClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/CohereClient.scala
@@ -2,7 +2,7 @@ package org.llm4s.llmconnect.provider
 
 import org.llm4s.error.{ AuthenticationError, ConfigurationError, RateLimitError, ServiceError, ValidationError }
 import org.llm4s.error.ThrowableOps._
-import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.config.CohereConfig
 import org.llm4s.llmconnect.model._
 import org.llm4s.types.Result
@@ -11,7 +11,6 @@ import java.net.URI
 import java.net.http.{ HttpClient, HttpRequest, HttpResponse }
 import java.nio.charset.StandardCharsets
 import java.time.Duration
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.util.Try
 
 /**
@@ -29,11 +28,12 @@ import scala.util.Try
 class CohereClient(
   config: CohereConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop
-) extends LLMClient
+) extends BaseLifecycleLLMClient
     with MetricsRecording {
 
-  private val httpClient            = HttpClient.newHttpClient()
-  private val closed: AtomicBoolean = new AtomicBoolean(false)
+  private val httpClient = HttpClient.newHttpClient()
+
+  protected def clientDescription: String = s"Cohere client for model ${config.model}"
 
   override def complete(
     conversation: Conversation,
@@ -86,19 +86,10 @@ class CohereClient(
 
   override def getReserveCompletion(): Int = config.reserveCompletion
 
-  override def close(): Unit =
-    if (closed.compareAndSet(false, true)) {
-      (httpClient: Any) match {
-        case c: AutoCloseable => c.close()
-        case _                => ()
-      }
-    }
-
-  private def validateNotClosed: Result[Unit] =
-    if (closed.get()) {
-      Left(ConfigurationError(s"Cohere client for model ${config.model} is already closed"))
-    } else {
-      Right(())
+  override protected def releaseResources(): Unit =
+    (httpClient: Any) match {
+      case c: AutoCloseable => c.close()
+      case _                => ()
     }
 
   private def buildChatRequest(

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/DeepSeekClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/DeepSeekClient.scala
@@ -1,13 +1,13 @@
 package org.llm4s.llmconnect.provider
 
-import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.config.DeepSeekConfig
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator, StreamingToolArgumentParser }
 import org.llm4s.metrics.MetricsCollector
 import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.types.Result
-import org.llm4s.error.{ AuthenticationError, ConfigurationError, RateLimitError, ServiceError }
+import org.llm4s.error.{ AuthenticationError, RateLimitError, ServiceError }
 import org.llm4s.error.ThrowableOps._
 
 import java.net.URI
@@ -15,7 +15,6 @@ import java.net.http.{ HttpClient, HttpRequest, HttpResponse }
 import java.time.Duration
 import java.io.{ BufferedReader, InputStreamReader }
 import java.nio.charset.StandardCharsets
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.util.Try
 
 /**
@@ -33,11 +32,12 @@ import scala.util.Try
 class DeepSeekClient(
   config: DeepSeekConfig,
   protected val metrics: MetricsCollector = MetricsCollector.noop
-) extends LLMClient
+) extends BaseLifecycleLLMClient
     with MetricsRecording {
   private val httpClient = HttpClient.newHttpClient()
   private val logger     = org.slf4j.LoggerFactory.getLogger(getClass)
-  private val closed     = new AtomicBoolean(false)
+
+  protected def clientDescription: String = s"DeepSeek client for model ${config.model}"
 
   override def complete(
     conversation: Conversation,
@@ -320,19 +320,10 @@ class DeepSeekClient(
 
   override def getReserveCompletion(): Int = config.reserveCompletion
 
-  override def close(): Unit =
-    if (closed.compareAndSet(false, true)) {
-      (httpClient: Any) match {
-        case c: AutoCloseable => c.close()
-        case _                => ()
-      }
-    }
-
-  private def validateNotClosed: Result[Unit] =
-    if (closed.get()) {
-      Left(ConfigurationError(s"DeepSeek client for model ${config.model} is already closed"))
-    } else {
-      Right(())
+  override protected def releaseResources(): Unit =
+    (httpClient: Any) match {
+      case c: AutoCloseable => c.close()
+      case _                => ()
     }
 }
 

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/GeminiClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/GeminiClient.scala
@@ -1,10 +1,10 @@
 package org.llm4s.llmconnect.provider
 
 import org.llm4s.util.Redaction
-import org.llm4s.error.{ AuthenticationError, ConfigurationError, RateLimitError, ServiceError, ValidationError }
+import org.llm4s.error.{ AuthenticationError, RateLimitError, ServiceError, ValidationError }
 import org.llm4s.error.ThrowableOps._
 import org.llm4s.http.Llm4sHttpClient
-import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.config.GeminiConfig
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.streaming._
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory
 import java.io.{ BufferedReader, InputStreamReader }
 import java.nio.charset.StandardCharsets
 import java.util.UUID
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.util.Try
 
 /**
@@ -62,10 +61,11 @@ class GeminiClient(
   config: GeminiConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop,
   private[provider] val httpClient: Llm4sHttpClient = Llm4sHttpClient.create()
-) extends LLMClient
+) extends BaseLifecycleLLMClient
     with MetricsRecording {
-  private val logger                = LoggerFactory.getLogger(getClass)
-  private val closed: AtomicBoolean = new AtomicBoolean(false)
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  protected def clientDescription: String = s"Gemini client for model ${config.model}"
 
   override def complete(
     conversation: Conversation,
@@ -465,19 +465,10 @@ class GeminiClient(
     }
   }
 
-  override def close(): Unit =
-    if (closed.compareAndSet(false, true)) {
-      (httpClient: Any) match {
-        case c: AutoCloseable => c.close()
-        case _                => ()
-      }
-    }
-
-  private def validateNotClosed: Result[Unit] =
-    if (closed.get()) {
-      Left(ConfigurationError(s"Gemini client for model ${config.model} is already closed"))
-    } else {
-      Right(())
+  override protected def releaseResources(): Unit =
+    (httpClient: Any) match {
+      case c: AutoCloseable => c.close()
+      case _                => ()
     }
 }
 

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
@@ -2,7 +2,7 @@ package org.llm4s.llmconnect.provider
 
 import org.llm4s.error.{ AuthenticationError, ConfigurationError, RateLimitError, ServiceError, ValidationError }
 import org.llm4s.error.ThrowableOps._
-import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.config.MistralConfig
 import org.llm4s.llmconnect.model._
 import org.llm4s.types.Result
@@ -11,7 +11,6 @@ import java.net.URI
 import java.net.http.{ HttpClient, HttpRequest, HttpResponse }
 import java.nio.charset.StandardCharsets
 import java.time.Duration
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.util.Try
 
 /**
@@ -29,11 +28,12 @@ import scala.util.Try
 class MistralClient(
   config: MistralConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop
-) extends LLMClient
+) extends BaseLifecycleLLMClient
     with MetricsRecording {
 
-  private val httpClient            = HttpClient.newHttpClient()
-  private val closed: AtomicBoolean = new AtomicBoolean(false)
+  private val httpClient = HttpClient.newHttpClient()
+
+  protected def clientDescription: String = s"Mistral client for model ${config.model}"
 
   override def complete(
     conversation: Conversation,
@@ -85,18 +85,6 @@ class MistralClient(
   override def getContextWindow(): Int = config.contextWindow
 
   override def getReserveCompletion(): Int = config.reserveCompletion
-
-  override def close(): Unit =
-    if (closed.compareAndSet(false, true)) {
-      ()
-    }
-
-  private def validateNotClosed: Result[Unit] =
-    if (closed.get()) {
-      Left(ConfigurationError(s"Mistral client for model ${config.model} is already closed"))
-    } else {
-      Right(())
-    }
 
   private def buildChatRequest(
     conversation: Conversation,

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OllamaClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OllamaClient.scala
@@ -1,15 +1,8 @@
 package org.llm4s.llmconnect.provider
 
-import org.llm4s.error.{
-  AuthenticationError,
-  ConfigurationError,
-  ExecutionError,
-  NetworkError,
-  RateLimitError,
-  ServiceError
-}
+import org.llm4s.error.{ AuthenticationError, ExecutionError, NetworkError, RateLimitError, ServiceError }
 import org.llm4s.http.Llm4sHttpClient
-import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.config.OllamaConfig
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.streaming.StreamingAccumulator
@@ -17,7 +10,6 @@ import org.llm4s.types.{ Result, TryOps }
 
 import java.io.{ BufferedReader, IOException, InputStreamReader }
 import java.nio.charset.StandardCharsets
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.util.Try
 
 /**
@@ -55,9 +47,10 @@ class OllamaClient(
   config: OllamaConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop,
   private[provider] val httpClient: Llm4sHttpClient = Llm4sHttpClient.create()
-) extends LLMClient
+) extends BaseLifecycleLLMClient
     with MetricsRecording {
-  private val closed: AtomicBoolean = new AtomicBoolean(false)
+
+  protected def clientDescription: String = s"Ollama client for model ${config.model}"
 
   override def complete(
     conversation: Conversation,
@@ -254,19 +247,10 @@ class OllamaClient(
 
   override def getReserveCompletion(): Int = config.reserveCompletion
 
-  override def close(): Unit =
-    if (closed.compareAndSet(false, true)) {
-      (httpClient: Any) match {
-        case c: AutoCloseable => c.close()
-        case _                => ()
-      }
-    }
-
-  private def validateNotClosed: Result[Unit] =
-    if (closed.get()) {
-      Left(ConfigurationError(s"Ollama client for model ${config.model} is already closed"))
-    } else {
-      Right(())
+  override protected def releaseResources(): Unit =
+    (httpClient: Any) match {
+      case c: AutoCloseable => c.close()
+      case _                => ()
     }
 }
 

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenAIClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenAIClient.scala
@@ -4,9 +4,8 @@ import com.azure.ai.openai.models._
 import com.azure.ai.openai.{ OpenAIClientBuilder, OpenAIServiceVersion, OpenAIClient => AzureOpenAIClient }
 import com.azure.core.credential.{ AzureKeyCredential, KeyCredential }
 import com.azure.core.util.IterableStream
-import org.llm4s.error.ConfigurationError
 import org.llm4s.error.ThrowableOps._
-import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.config.{ AzureConfig, OpenAIConfig, ProviderConfig }
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.streaming._
@@ -15,7 +14,6 @@ import org.llm4s.toolapi.{ AzureToolHelper, ToolRegistry }
 import org.llm4s.types.Result
 import org.slf4j.{ Logger, LoggerFactory }
 
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
@@ -53,11 +51,12 @@ class OpenAIClient private (
   private val transport: OpenAIClientTransport,
   private val config: ProviderConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector
-) extends LLMClient
+) extends BaseLifecycleLLMClient
     with MetricsRecording {
 
-  private lazy val logger: Logger   = LoggerFactory.getLogger(getClass)
-  private val closed: AtomicBoolean = new AtomicBoolean(false)
+  private lazy val logger: Logger = LoggerFactory.getLogger(getClass)
+
+  protected def clientDescription: String = s"OpenAI client for model $model"
 
   /**
    * Creates an OpenAI client for direct OpenAI API access.
@@ -154,33 +153,8 @@ class OpenAIClient private (
     extractCost = (c: Completion) => c.estimatedCost
   )
 
-  override def close(): Unit =
-    // Mark client as closed to prevent further operations.
-    // Note: AzureOpenAIClient does not implement AutoCloseable,
-    // so we only track the logical closed state for thread-safety.
-    // The Azure SDK's HttpClient is managed externally or by the builder,
-    // and the client itself has no close() method to call.
-    if (closed.compareAndSet(false, true)) {
-      logger.debug(s"OpenAI client for model $model closed")
-    }
-
-  /**
-   * Validates that the client is not closed before performing operations.
-   *
-   * Note: There is an inherent TOCTOU (time-of-check to time-of-use) gap between
-   * this validation and the actual operation. This is acceptable because the
-   * underlying AzureOpenAIClient does not implement AutoCloseable, so we only
-   * track logical closed state. Operations may still succeed even if close()
-   * is called concurrently, but subsequent operations will fail validation.
-   *
-   * @return Right(()) if client is open, Left(ConfigurationError) if closed
-   */
-  private def validateNotClosed: Result[Unit] =
-    if (closed.get()) {
-      Left(ConfigurationError(s"OpenAI client for model $model is already closed"))
-    } else {
-      Right(())
-    }
+  override protected def releaseResources(): Unit =
+    logger.debug(s"OpenAI client for model $model closed")
 
   /**
    * Handles fake streaming for models that don't support native streaming.

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenRouterClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenRouterClient.scala
@@ -1,13 +1,13 @@
 package org.llm4s.llmconnect.provider
 
-import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.config.OpenAIConfig
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.serialization.OpenRouterToolCallDeserializer
 import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator, StreamingToolArgumentParser }
 import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.types.Result
-import org.llm4s.error.{ AuthenticationError, ConfigurationError, RateLimitError, ServiceError }
+import org.llm4s.error.{ AuthenticationError, RateLimitError, ServiceError }
 import org.llm4s.error.ThrowableOps._
 
 import java.net.URI
@@ -15,7 +15,6 @@ import java.net.http.{ HttpClient, HttpRequest, HttpResponse }
 import java.time.Duration
 import java.io.{ BufferedReader, InputStreamReader }
 import java.nio.charset.StandardCharsets
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.util.Try
 
 /**
@@ -59,10 +58,11 @@ import scala.util.Try
 class OpenRouterClient(
   config: OpenAIConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop
-) extends LLMClient
+) extends BaseLifecycleLLMClient
     with MetricsRecording {
-  private val httpClient            = HttpClient.newHttpClient()
-  private val closed: AtomicBoolean = new AtomicBoolean(false)
+  private val httpClient = HttpClient.newHttpClient()
+
+  protected def clientDescription: String = s"OpenRouter client for model ${config.model}"
 
   override def complete(
     conversation: Conversation,
@@ -420,19 +420,10 @@ class OpenRouterClient(
 
   override def getReserveCompletion(): Int = config.reserveCompletion
 
-  override def close(): Unit =
-    if (closed.compareAndSet(false, true)) {
-      (httpClient: Any) match {
-        case c: AutoCloseable => c.close()
-        case _                => ()
-      }
-    }
-
-  private def validateNotClosed: Result[Unit] =
-    if (closed.get()) {
-      Left(ConfigurationError(s"OpenRouter client for model ${config.model} is already closed"))
-    } else {
-      Right(())
+  override protected def releaseResources(): Unit =
+    (httpClient: Any) match {
+      case c: AutoCloseable => c.close()
+      case _                => ()
     }
 }
 

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/ZaiClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/ZaiClient.scala
@@ -1,13 +1,13 @@
 package org.llm4s.llmconnect.provider
 
 import org.llm4s.util.Redaction
-import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.config.ZaiConfig
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator, StreamingToolArgumentParser }
 import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.types.Result
-import org.llm4s.error.{ AuthenticationError, ConfigurationError, RateLimitError, ServiceError }
+import org.llm4s.error.{ AuthenticationError, RateLimitError, ServiceError }
 import org.llm4s.error.ThrowableOps._
 
 import java.net.URI
@@ -15,7 +15,6 @@ import java.net.http.{ HttpClient, HttpRequest, HttpResponse }
 import java.time.Duration
 import java.io.{ BufferedReader, InputStreamReader }
 import java.nio.charset.StandardCharsets
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.util.Try
 
 /**
@@ -37,11 +36,12 @@ import scala.util.Try
 class ZaiClient(
   config: ZaiConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop
-) extends LLMClient
+) extends BaseLifecycleLLMClient
     with MetricsRecording {
-  private val httpClient            = HttpClient.newHttpClient()
-  private val logger                = org.slf4j.LoggerFactory.getLogger(getClass)
-  private val closed: AtomicBoolean = new AtomicBoolean(false)
+  private val httpClient = HttpClient.newHttpClient()
+  private val logger     = org.slf4j.LoggerFactory.getLogger(getClass)
+
+  protected def clientDescription: String = s"Z.ai client for model ${config.model}"
 
   override def complete(
     conversation: Conversation,
@@ -361,19 +361,10 @@ class ZaiClient(
 
   override def getReserveCompletion(): Int = config.reserveCompletion
 
-  override def close(): Unit =
-    if (closed.compareAndSet(false, true)) {
-      (httpClient: Any) match {
-        case c: AutoCloseable => c.close()
-        case _                => ()
-      }
-    }
-
-  private def validateNotClosed: Result[Unit] =
-    if (closed.get()) {
-      Left(ConfigurationError(s"Z.ai client for model ${config.model} is already closed"))
-    } else {
-      Right(())
+  override protected def releaseResources(): Unit =
+    (httpClient: Any) match {
+      case c: AutoCloseable => c.close()
+      case _                => ()
     }
 }
 


### PR DESCRIPTION
## Summary
- Introduces `BaseLifecycleLLMClient` trait with shared `AtomicBoolean` closed flag, `validateNotClosed` method, and idempotent `close()` with a `releaseResources()` template method hook
- Updates all 9 LLM provider clients (OpenAI, Anthropic, Gemini, OpenRouter, Mistral, Ollama, DeepSeek, Cohere, Zai) to mix in the trait and remove duplicated lifecycle code
- Eliminates ~135 lines of duplication across providers with zero behavioral change

## Test plan
- [x] All 5481 existing tests pass on both Scala 2.13 and 3.x (`sbt +test`)
- [x] `sbt scalafmtAll` clean
- [x] Pre-commit hooks pass