### PR TITLE
docs(knowledge-graph): add ScalaDoc @example tags to all public APIs

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/KnowledgeGraph.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/KnowledgeGraph.scala
@@ -6,6 +6,12 @@ import org.llm4s.error.ProcessingError
 /**
  * Represents a node (entity) in the knowledge graph.
  *
+ * @example
+ * {{{
+ * val person = Node("alice", "Person", Map("name" -> ujson.Str("Alice Smith")))
+ * val org = Node("acme", "Organization")
+ * }}}
+ *
  * @param id Unique identifier for the node
  * @param label The type or category of the entity (e.g., "Person", "Organization")
  * @param properties Additional attributes of the entity (preserves JSON types)
@@ -18,6 +24,12 @@ case class Node(
 
 /**
  * Represents an edge (relationship) between two nodes.
+ *
+ * @example
+ * {{{
+ * val worksFor = Edge("alice", "acme", "WORKS_FOR")
+ * val located = Edge("acme", "sf", "LOCATED_IN", Map("since" -> ujson.Str("2020")))
+ * }}}
  *
  * @param source The ID of the source node
  * @param target The ID of the target node
@@ -33,6 +45,21 @@ case class Edge(
 
 /**
  * Represents a Knowledge Graph containing nodes and edges.
+ *
+ * @example
+ * {{{
+ * val alice = Node("alice", "Person", Map("name" -> ujson.Str("Alice")))
+ * val acme = Node("acme", "Organization", Map("name" -> ujson.Str("Acme Corp")))
+ * val edge = Edge("alice", "acme", "WORKS_FOR")
+ *
+ * val graph = Graph.empty
+ *   .addNode(alice)
+ *   .addNode(acme)
+ *   .addEdge(edge)
+ *
+ * graph.getNeighbors("alice") // Set(acme)
+ * graph.findNodesByLabel("Person") // List(alice)
+ * }}}
  *
  * @param nodes Map of Node ID to Node object
  * @param edges List of Edges in the graph
@@ -72,17 +99,26 @@ case class Graph(
   }
 
   /**
-   * Adds a node to the graph.
+   * Adds a node to the graph. If a node with the same ID exists, it is replaced.
+   *
+   * @param node The node to add
+   * @return A new graph with the node added
    */
   def addNode(node: Node): Graph = copy(nodes = nodes + (node.id -> node))
 
   /**
    * Adds an edge to the graph.
+   *
+   * @param edge The edge to add
+   * @return A new graph with the edge appended
    */
   def addEdge(edge: Edge): Graph = copy(edges = edges :+ edge)
 
   /**
-   * Merges another graph into this one.
+   * Merges another graph into this one. Nodes are merged by ID; duplicate edges are removed.
+   *
+   * @param other The graph to merge in
+   * @return A new graph containing nodes and edges from both graphs
    */
   def merge(other: Graph): Graph =
     Graph(
@@ -92,24 +128,36 @@ case class Graph(
 
   /**
    * Gets outgoing edges from a node.
+   *
+   * @param nodeId The ID of the source node
+   * @return All edges originating from the specified node
    */
   def getOutgoingEdges(nodeId: String): List[Edge] =
     edges.filter(_.source == nodeId)
 
   /**
    * Gets incoming edges to a node.
+   *
+   * @param nodeId The ID of the target node
+   * @return All edges pointing to the specified node
    */
   def getIncomingEdges(nodeId: String): List[Edge] =
     edges.filter(_.target == nodeId)
 
   /**
    * Gets all edges connected to a node (both incoming and outgoing).
+   *
+   * @param nodeId The ID of the node
+   * @return All edges where the node is either source or target
    */
   def getConnectedEdges(nodeId: String): List[Edge] =
     edges.filter(e => e.source == nodeId || e.target == nodeId)
 
   /**
    * Gets neighbor nodes (both incoming and outgoing).
+   *
+   * @param nodeId The ID of the node
+   * @return All nodes directly connected to the specified node
    */
   def getNeighbors(nodeId: String): Set[Node] = {
     val neighborIds = getConnectedEdges(nodeId).flatMap { e =>
@@ -122,11 +170,19 @@ case class Graph(
 
   /**
    * Checks if a node exists in the graph.
+   *
+   * @param nodeId The ID of the node to check
+   * @return True if a node with the given ID exists
    */
   def hasNode(nodeId: String): Boolean = nodes.contains(nodeId)
 
   /**
    * Checks if an edge exists between two nodes.
+   *
+   * @param source The source node ID
+   * @param target The target node ID
+   * @param relationship Optional relationship type filter
+   * @return True if a matching edge exists
    */
   def hasEdge(source: String, target: String, relationship: Option[String] = None): Boolean =
     relationship match {
@@ -136,6 +192,9 @@ case class Graph(
 
   /**
    * Finds nodes by label.
+   *
+   * @param label The label to match (e.g., "Person")
+   * @return All nodes with the given label
    */
   def findNodesByLabel(label: String): List[Node] =
     nodes.values.filter(_.label == label).toList
@@ -156,5 +215,7 @@ case class Graph(
 }
 
 object Graph {
+
+  /** Creates an empty graph with no nodes or edges. */
   def empty: Graph = Graph(Map.empty, List.empty)
 }

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/engine/GraphEngine.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/engine/GraphEngine.scala
@@ -7,6 +7,20 @@ import scala.annotation.tailrec
 /**
  * Engine for traversing and querying the Knowledge Graph.
  *
+ * @example
+ * {{{
+ * val graph = Graph.empty
+ *   .addNode(Node("a", "Person"))
+ *   .addNode(Node("b", "Person"))
+ *   .addNode(Node("c", "Person"))
+ *   .addEdge(Edge("a", "b", "KNOWS"))
+ *   .addEdge(Edge("b", "c", "KNOWS"))
+ *
+ * val engine = new GraphEngine(graph)
+ * val reachable = engine.traverse("a", maxDepth = 2) // Set(a, b, c)
+ * val path = engine.findShortestPath("a", "c") // Some(List(a->b, b->c))
+ * }}}
+ *
  * @param graph The graph to traverse
  */
 class GraphEngine(graph: Graph) {

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/CoreferenceResolver.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/CoreferenceResolver.scala
@@ -13,6 +13,13 @@ import org.slf4j.LoggerFactory
  * "its founder") with explicit entity names. This pre-processing step reduces duplicate
  * nodes that would otherwise be created when the extractor encounters unresolved references.
  *
+ * @example
+ * {{{
+ * val resolver = new CoreferenceResolver(llmClient)
+ * val resolved = resolver.resolve("Alice works at Acme. She is the CEO.")
+ * // resolved: Right("Alice works at Acme. Alice is the CEO.")
+ * }}}
+ *
  * @param llmClient The LLM client to use for coreference resolution
  */
 class CoreferenceResolver(llmClient: LLMClient) {

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/DocumentSource.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/DocumentSource.scala
@@ -54,6 +54,17 @@ case class ValidationResult(
  * each node and edge. The underlying `Graph` remains a pure data structure;
  * provenance is tracked externally.
  *
+ * @example
+ * {{{
+ * val doc = DocumentSource("doc1", "Annual Report")
+ * val graph = Graph.empty
+ *   .addNode(Node("alice", "Person"))
+ *   .addEdge(Edge("alice", "acme", "WORKS_FOR"))
+ *
+ * val tracked = SourceTrackedGraph.fromGraph(graph, doc)
+ * tracked.getNodeSources("alice") // Set(doc)
+ * }}}
+ *
  * @param graph The underlying knowledge graph
  * @param sources All document sources that contributed to this graph
  * @param nodeSources Mapping of node ID to the set of source document IDs that contributed it

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/EntityLinker.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/EntityLinker.scala
@@ -17,6 +17,17 @@ import scala.util.Try
  *  2. LLM-assisted disambiguation (optional): ambiguous clusters (e.g., "Jobs" vs
  *     "Steve Jobs") are sent to the LLM to confirm or reject merges.
  *
+ * @example
+ * {{{
+ * // Deterministic linking only
+ * val linker = new EntityLinker(None)
+ * val deduped = linker.link(graphWithDuplicates)
+ *
+ * // With LLM-assisted disambiguation
+ * val smartLinker = new EntityLinker(Some(llmClient))
+ * val result = smartLinker.link(graphWithAmbiguousEntities)
+ * }}}
+ *
  * @param llmClient Optional LLM client for disambiguation. If None, only deterministic merging is performed.
  */
 class EntityLinker(llmClient: Option[LLMClient] = None) {

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/KnowledgeGraphGenerator.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/KnowledgeGraphGenerator.scala
@@ -9,6 +9,16 @@ import org.llm4s.types.Result
 /**
  * Generates a Knowledge Graph from unstructured text using an LLM and writes it to a GraphStore.
  *
+ * @example
+ * {{{
+ * val generator = new KnowledgeGraphGenerator(llmClient, graphStore)
+ * val result = generator.extract(
+ *   text = "Alice works at Acme Corp in San Francisco.",
+ *   entityTypes = List("Person", "Organization", "Location")
+ * )
+ * // result: Right(Graph) with nodes for Alice, Acme Corp, San Francisco
+ * }}}
+ *
  * @param llmClient The LLM client to use for extraction
  * @param graphStore The graph store to write extracted entities and relationships to
  */

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/MultiDocumentGraphBuilder.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/MultiDocumentGraphBuilder.scala
@@ -8,6 +8,15 @@ import org.slf4j.LoggerFactory
 /**
  * Configuration for multi-document graph extraction.
  *
+ * @example
+ * {{{
+ * val config = ExtractionConfig(
+ *   schema = Some(ExtractionSchema.simple(Seq("Person", "Org"), Seq("WORKS_FOR"))),
+ *   enableCoreference = true,
+ *   enableEntityLinking = true
+ * )
+ * }}}
+ *
  * @param schema Optional schema to constrain extraction. When absent, free-form extraction is used.
  * @param enableCoreference Whether to run coreference resolution on each document before extraction
  * @param enableEntityLinking Whether to run entity linking (deduplication) after merging documents
@@ -29,6 +38,18 @@ case class ExtractionConfig(
  *
  * Supports incremental building: pass an existing `SourceTrackedGraph` to add new documents
  * without re-extracting from previously processed ones.
+ *
+ * @example
+ * {{{
+ * val builder = new MultiDocumentGraphBuilder(llmClient, ExtractionConfig(
+ *   schema = Some(ExtractionSchema.simple(Seq("Person", "Org"), Seq("WORKS_FOR")))
+ * ))
+ * val docs = Seq(
+ *   ("Alice works at Acme.", DocumentSource("doc1", "Report 1")),
+ *   ("Bob works at Acme.", DocumentSource("doc2", "Report 2"))
+ * )
+ * val result = builder.extractDocuments(docs)
+ * }}}
  *
  * @param llmClient The LLM client used by all pipeline components
  * @param config Configuration controlling which pipeline stages are enabled

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/SchemaGuidedExtractor.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/SchemaGuidedExtractor.scala
@@ -13,6 +13,16 @@ import org.llm4s.types.Result
  * from an `ExtractionSchema`. The LLM output is still parsed as JSON but the prompt
  * strongly constrains what types are produced.
  *
+ * @example
+ * {{{
+ * val schema = ExtractionSchema.simple(
+ *   entityTypes = Seq("Person", "Organization"),
+ *   relationshipTypes = Seq("WORKS_FOR", "MANAGES")
+ * )
+ * val extractor = new SchemaGuidedExtractor(llmClient)
+ * val result = extractor.extract("Alice manages Bob at Acme Corp.", schema)
+ * }}}
+ *
  * @param llmClient The LLM client to use for extraction
  */
 class SchemaGuidedExtractor(llmClient: LLMClient) {

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/SchemaValidator.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/extraction/SchemaValidator.scala
@@ -9,6 +9,17 @@ import org.llm4s.knowledgegraph.{ Edge, Graph }
  * sets, and reports specific constraint violations such as relationship endpoint type
  * mismatches.
  *
+ * @example
+ * {{{
+ * val schema = ExtractionSchema.simple(
+ *   entityTypes = Seq("Person", "Organization"),
+ *   relationshipTypes = Seq("WORKS_FOR")
+ * )
+ * val validator = new SchemaValidator(schema)
+ * val result = validator.validate(extractedGraph)
+ * if (result.isFullyValid) println("Graph conforms to schema")
+ * }}}
+ *
  * @param schema The extraction schema to validate against
  */
 class SchemaValidator(schema: ExtractionSchema) {

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/GraphQAConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/GraphQAConfig.scala
@@ -3,6 +3,17 @@ package org.llm4s.knowledgegraph.query
 /**
  * Configuration for the graph-guided question answering pipeline.
  *
+ * @example
+ * {{{
+ * val config = GraphQAConfig(
+ *   maxHops = 3,
+ *   useRanking = true,
+ *   rankingAlgorithm = RankingAlgorithm.PageRank,
+ *   includeCitations = true
+ * )
+ * val pipeline = new GraphQAPipeline(llmClient, graphStore, config)
+ * }}}
+ *
  * @param maxHops Maximum number of hops for graph traversal during context gathering
  * @param maxContextNodes Maximum number of nodes to include in LLM context
  * @param maxContextEdges Maximum number of edges to include in LLM context

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/GraphQAPipeline.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/GraphQAPipeline.scala
@@ -17,6 +17,16 @@ import scala.util.Try
  * Multi-hop traversal follows relationship chains to gather evidence beyond direct neighbors.
  * Citations track which nodes and edges contributed to the answer.
  *
+ * @example
+ * {{{
+ * val pipeline = new GraphQAPipeline(llmClient, graphStore)
+ * val result: Result[GraphQAResult] = pipeline.ask("Who does Alice work with?")
+ * result.foreach { r =>
+ *   println(r.answer)
+ *   r.citations.foreach(c => println(s"Source: ${c.nodeLabel} ${c.nodeId}"))
+ * }
+ * }}}
+ *
  * @param llmClient The LLM client for entity identification and answer generation
  * @param graphStore The graph store containing the knowledge graph
  * @param config Pipeline configuration

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/GraphQuery.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/GraphQuery.scala
@@ -11,6 +11,21 @@ import org.llm4s.knowledgegraph.storage.Direction
  *
  * This approach is engine-agnostic — the same query ADT works with in-memory stores,
  * JSON-backed stores, or future external graph database implementations.
+ *
+ * @example
+ * {{{
+ * // Find all Person nodes
+ * val findPeople = GraphQuery.FindNodes(label = Some("Person"))
+ *
+ * // Find neighbors of a specific node
+ * val neighbors = GraphQuery.FindNeighbors(nodeId = "alice", maxDepth = 2)
+ *
+ * // Find path between two nodes
+ * val path = GraphQuery.FindPath(fromNodeId = "alice", toNodeId = "bob")
+ *
+ * // Compose multiple queries
+ * val composite = GraphQuery.CompositeQuery(Seq(findPeople, neighbors))
+ * }}}
  */
 sealed trait GraphQuery
 

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/GraphQueryExecutor.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/GraphQueryExecutor.scala
@@ -11,6 +11,14 @@ import org.llm4s.types.Result
  * storage layer, translating each query variant into the appropriate
  * `GraphStore` and `GraphEngine` calls.
  *
+ * @example
+ * {{{
+ * val executor = new GraphQueryExecutor(graphStore)
+ * val query = GraphQuery.FindNodes(label = Some("Person"))
+ * val result = executor.execute(query)
+ * // result: Right(GraphQueryResult(nodes = Seq(...), edges = Seq(...)))
+ * }}}
+ *
  * @param graphStore The graph store to query against
  */
 class GraphQueryExecutor(graphStore: GraphStore) {

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/GraphQueryTranslator.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/GraphQueryTranslator.scala
@@ -14,6 +14,13 @@ import scala.util.Try
  * The translator provides the LLM with a summary of the graph's schema (node labels,
  * relationship types, sample properties) so it can generate appropriate query operations.
  *
+ * @example
+ * {{{
+ * val translator = new GraphQueryTranslator(llmClient, graphStore)
+ * val query = translator.translate("Who are Alice's coworkers?")
+ * // query: Right(GraphQuery.FindNeighbors(nodeId = "alice", ...))
+ * }}}
+ *
  * @param llmClient The LLM client to use for translation
  * @param graphStore The graph store whose schema is used as context
  */

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/GraphRanking.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/GraphRanking.scala
@@ -12,6 +12,19 @@ import scala.annotation.tailrec
  *
  * These scores are used by [[GraphQAPipeline]] to prioritize which entities
  * to include in LLM context when the result set exceeds context limits.
+ *
+ * @example
+ * {{{
+ * val graph = Graph.empty
+ *   .addNode(Node("a", "Person"))
+ *   .addNode(Node("b", "Person"))
+ *   .addNode(Node("c", "Person"))
+ *   .addEdge(Edge("a", "b", "KNOWS"))
+ *   .addEdge(Edge("b", "c", "KNOWS"))
+ *
+ * val scores = GraphRanking.pageRank(graph)
+ * val centrality = GraphRanking.degreeCentrality(graph)
+ * }}}
  */
 object GraphRanking {
 

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/NativeQueryGenerator.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/query/NativeQueryGenerator.scala
@@ -41,6 +41,16 @@ case class NativeQuery(
  * The primary query path uses [[GraphQueryExecutor]] against the `GraphStore` trait;
  * this generator provides an alternative for engines where native queries are more efficient.
  *
+ * @example
+ * {{{
+ * val generator = new NativeQueryGenerator(llmClient)
+ * val result = generator.generate(
+ *   question = "Find all people who work at Acme",
+ *   language = QueryLanguage.Cypher
+ * )
+ * // result: Right(NativeQuery(Cypher, "MATCH (p:Person)-[:WORKS_FOR]->(o {name:'Acme'}) RETURN p", ...))
+ * }}}
+ *
  * @param llmClient The LLM client to use for query generation
  */
 class NativeQueryGenerator(llmClient: LLMClient) {

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/storage/GraphStore.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/storage/GraphStore.scala
@@ -77,6 +77,17 @@ case class EdgeNodePair(edge: Edge, node: Node)
  * This trait is designed to be engine-agnostic, allowing implementations
  * for various graph databases (Neo4j, TinkerPop, SPARQL, etc.) while
  * maintaining a consistent interface.
+ *
+ * @example
+ * {{{
+ * val store: GraphStore = new InMemoryGraphStore()
+ * for {
+ *   _ <- store.upsertNode(Node("alice", "Person", Map("name" -> ujson.Str("Alice"))))
+ *   _ <- store.upsertNode(Node("acme", "Organization"))
+ *   _ <- store.upsertEdge(Edge("alice", "acme", "WORKS_FOR"))
+ *   neighbors <- store.getNeighbors("alice")
+ * } yield neighbors
+ * }}}
  */
 trait GraphStore {
 

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/storage/InMemoryGraphStore.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/storage/InMemoryGraphStore.scala
@@ -15,6 +15,17 @@ import scala.annotation.tailrec
  * Performance: Optimal for testing and small to medium graphs (<100k nodes).
  * Not suitable for graphs requiring persistence.
  *
+ * @example
+ * {{{
+ * val store = new InMemoryGraphStore()
+ * for {
+ *   _ <- store.upsertNode(Node("n1", "Person", Map("name" -> ujson.Str("Alice"))))
+ *   _ <- store.upsertNode(Node("n2", "Organization", Map("name" -> ujson.Str("Acme"))))
+ *   _ <- store.upsertEdge(Edge("n1", "n2", "WORKS_FOR"))
+ *   stats <- store.stats()
+ * } yield stats // GraphStats(nodeCount=2, edgeCount=1, ...)
+ * }}}
+ *
  * @param initialGraph Optional initial graph state (defaults to empty)
  */
 class InMemoryGraphStore(initialGraph: Graph = Graph.empty) extends GraphStore {

--- a/modules/core/src/main/scala/org/llm4s/knowledgegraph/storage/JsonGraphStore.scala
+++ b/modules/core/src/main/scala/org/llm4s/knowledgegraph/storage/JsonGraphStore.scala
@@ -10,10 +10,21 @@ import java.nio.charset.StandardCharsets
 import scala.util.Try
 
 /**
- * JSON-based implementation of GraphStore.
+ * JSON-based implementation of GraphStore that persists graphs as JSON files.
  *
  * Thread-safety note: This implementation is NOT thread-safe.
  * For concurrent access, wrap with synchronization or use a thread-safe alternative.
+ *
+ * @example
+ * {{{
+ * val store = new JsonGraphStore(java.nio.file.Paths.get("/tmp/graph.json"))
+ * for {
+ *   _ <- store.upsertNode(Node("n1", "Person", Map("name" -> ujson.Str("Alice"))))
+ *   _ <- store.upsertNode(Node("n2", "Organization"))
+ *   _ <- store.upsertEdge(Edge("n1", "n2", "WORKS_FOR"))
+ *   graph <- store.loadAll()
+ * } yield graph
+ * }}}
  *
  * @param path The file path to save/load the graph
  */


### PR DESCRIPTION
## Summary

- Add `@example` code blocks with `{{{ }}}` to all major public classes, traits, and objects across the knowledge graph package (19 files, 266 lines added)
- Fill in missing `@param` and `@return` tags on `Graph` methods (`addNode`, `addEdge`, `merge`, `getOutgoingEdges`, `getIncomingEdges`, `getConnectedEdges`, `getNeighbors`, `hasNode`, `hasEdge`, `findNodesByLabel`)
- Add ScalaDoc to `Graph.empty` companion object method

Addresses Issue 4.1: [DOCS] Add ScalaDoc to knowledge graph public APIs.

### Files updated

| Package | Files | @example added to |
|---|---|---|
| root | `KnowledgeGraph.scala` | `Node`, `Edge`, `Graph` |
| engine | `GraphEngine.scala` | `GraphEngine` |
| storage | `GraphStore.scala`, `InMemoryGraphStore.scala`, `JsonGraphStore.scala` | All three |
| query | `GraphQuery.scala`, `GraphQAConfig.scala`, `GraphQAPipeline.scala`, `GraphQueryExecutor.scala`, `GraphQueryTranslator.scala`, `GraphRanking.scala`, `NativeQueryGenerator.scala` | All seven |
| extraction | `KnowledgeGraphGenerator.scala`, `SchemaGuidedExtractor.scala`, `MultiDocumentGraphBuilder.scala`, `ExtractionConfig`, `DocumentSource.scala` (`SourceTrackedGraph`), `EntityLinker.scala`, `CoreferenceResolver.scala`, `SchemaValidator.scala` | All eight |

### Acceptance criteria

- [x] All public classes/traits/objects have ScalaDoc
- [x] At least one `@example` per major API (20+ examples added)
- [x] Compiles without warnings on both Scala 2.13 and 3.x
- [x] All 5481 tests pass

## Test plan

- [x] `sbt scalafmtAll` — no formatting changes needed
- [x] `sbt "+test"` — 5481 tests passed, 0 failures, both Scala versions