### PR TITLE
refactor: extract shared metrics wrapping into BaseLifecycleLLMClient

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/BaseLifecycleLLMClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/BaseLifecycleLLMClient.scala
@@ -1,24 +1,36 @@
 package org.llm4s.llmconnect
 
 import org.llm4s.error.ConfigurationError
+import org.llm4s.llmconnect.model.Completion
+import org.llm4s.llmconnect.provider.MetricsRecording
 import org.llm4s.types.Result
 
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Mixin trait providing standard lifecycle management for [[LLMClient]] implementations.
+ * Mixin trait providing standard lifecycle management and metrics wrapping
+ * for [[LLMClient]] implementations.
  *
  * Tracks whether the client has been closed via an `AtomicBoolean` and provides:
  *  - `validateNotClosed` — a pre-check returning `Left(ConfigurationError)` once closed.
  *  - `close()` — an idempotent close that delegates to `releaseResources()` exactly once.
+ *  - `completeWithMetrics` — combines lifecycle validation with metrics recording for
+ *    [[Completion]] results, eliminating boilerplate in `complete` / `streamComplete`.
  *
- * Concrete clients mix in this trait and optionally override `releaseResources()` to
- * free provider-specific resources (HTTP clients, SDK connections, etc.).
+ * Concrete clients mix in this trait, supply `providerName` and `modelName`,
+ * and optionally override `releaseResources()` to free provider-specific
+ * resources (HTTP clients, SDK connections, etc.).
  */
-trait BaseLifecycleLLMClient extends LLMClient {
+trait BaseLifecycleLLMClient extends LLMClient with MetricsRecording {
 
   /** Human-readable label used in the "already closed" error message. */
   protected def clientDescription: String
+
+  /** Metrics label for this provider (e.g. `"openai"`, `"anthropic"`). */
+  protected def providerName: String
+
+  /** The model identifier forwarded to the metrics collector. */
+  protected def modelName: String
 
   /**
    * Hook for releasing provider-specific resources.
@@ -34,4 +46,24 @@ trait BaseLifecycleLLMClient extends LLMClient {
 
   override def close(): Unit =
     if (closed.compareAndSet(false, true)) releaseResources()
+
+  /**
+   * Validates that the client is open, executes the operation, and records
+   * standard completion metrics (latency, token usage, estimated cost).
+   *
+   * Use this in `complete` and `streamComplete` implementations to avoid
+   * repeating the lifecycle-check + metrics-wrapping boilerplate.
+   *
+   * @param operation The provider-specific completion logic to execute.
+   *                  Called only when the client is open.
+   * @return The completion result with metrics recorded as a side-effect.
+   */
+  protected def completeWithMetrics(operation: => Result[Completion]): Result[Completion] =
+    withMetrics(
+      provider = providerName,
+      model = modelName,
+      operation = validateNotClosed.flatMap(_ => operation),
+      extractUsage = (c: Completion) => c.usage,
+      extractCost = (c: Completion) => c.estimatedCost
+    )
 }

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
@@ -69,8 +69,7 @@ import scala.util.Try
 class AnthropicClient(
   config: AnthropicConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop
-) extends BaseLifecycleLLMClient
-    with MetricsRecording {
+) extends BaseLifecycleLLMClient {
   // Store config for budget calculations
   private val providerConfig: ProviderConfig = config
 
@@ -82,65 +81,61 @@ class AnthropicClient(
     .build()
 
   protected def clientDescription: String = s"Anthropic client for model ${config.model}"
+  protected def providerName: String      = "anthropic"
+  protected def modelName: String         = config.model
 
   override def complete(
     conversation: Conversation,
     options: CompletionOptions
-  ): Result[Completion] = withMetrics(
-    provider = "anthropic",
-    model = config.model,
-    operation = validateNotClosed.flatMap { _ =>
-      // Transform options and messages for model-specific constraints
-      TransformationResult.transform(config.model, options, conversation.messages, dropUnsupported = true).flatMap {
-        transformed =>
-          val transformedConversation = conversation.copy(messages = transformed.messages)
+  ): Result[Completion] = completeWithMetrics {
+    // Transform options and messages for model-specific constraints
+    TransformationResult.transform(config.model, options, conversation.messages, dropUnsupported = true).flatMap {
+      transformed =>
+        val transformedConversation = conversation.copy(messages = transformed.messages)
 
-          // Create message parameters builder
-          val paramsBuilder = MessageCreateParams
-            .builder()
-            .model(config.model)
-            .temperature(transformed.options.temperature.floatValue())
-            .topP(transformed.options.topP.floatValue())
+        // Create message parameters builder
+        val paramsBuilder = MessageCreateParams
+          .builder()
+          .model(config.model)
+          .temperature(transformed.options.temperature.floatValue())
+          .topP(transformed.options.topP.floatValue())
 
-          // Add max tokens if specified
-          // max tokens is required by the api
-          val maxTokens = transformed.options.maxTokens.getOrElse(2048)
-          paramsBuilder.maxTokens(maxTokens)
+        // Add max tokens if specified
+        // max tokens is required by the api
+        val maxTokens = transformed.options.maxTokens.getOrElse(2048)
+        paramsBuilder.maxTokens(maxTokens)
 
-          // Add extended thinking configuration if requested
-          // Minimum budget is 1024 tokens, must be less than max_tokens
-          transformed.options.effectiveBudgetTokens.foreach { budgetTokens =>
-            val effectiveBudget = clampBudgetTokens(budgetTokens, maxTokens)
-            paramsBuilder.thinking(
-              ThinkingConfigEnabled.builder().budgetTokens(effectiveBudget.toLong).build()
-            )
-          }
+        // Add extended thinking configuration if requested
+        // Minimum budget is 1024 tokens, must be less than max_tokens
+        transformed.options.effectiveBudgetTokens.foreach { budgetTokens =>
+          val effectiveBudget = clampBudgetTokens(budgetTokens, maxTokens)
+          paramsBuilder.thinking(
+            ThinkingConfigEnabled.builder().budgetTokens(effectiveBudget.toLong).build()
+          )
+        }
 
-          // Add tools if specified
-          if (transformed.options.tools.nonEmpty) {
-            transformed.options.tools.foreach(tool => paramsBuilder.addTool(convertToolToAnthropicTool(tool)))
-          }
+        // Add tools if specified
+        if (transformed.options.tools.nonEmpty) {
+          transformed.options.tools.foreach(tool => paramsBuilder.addTool(convertToolToAnthropicTool(tool)))
+        }
 
-          // Add messages from conversation
-          addMessagesToParams(transformedConversation, paramsBuilder)
+        // Add messages from conversation
+        addMessagesToParams(transformedConversation, paramsBuilder)
 
-          // Build the parameters
-          val messageParams = paramsBuilder.build()
+        // Build the parameters
+        val messageParams = paramsBuilder.build()
 
-          val messageService = client.messages()
-          // Make API call
-          val attempt = Try(messageService.create(messageParams)).toEither.left.map {
-            case e: com.anthropic.errors.UnauthorizedException         => AuthenticationError("anthropic", e.getMessage)
-            case _: com.anthropic.errors.RateLimitException            => RateLimitError("anthropic")
-            case e: com.anthropic.errors.AnthropicInvalidDataException => ValidationError("input", e.getMessage)
-            case e: Exception                                          => e.toLLMError
-          }
-          attempt.map(convertFromAnthropicResponse) // Convert response to our model
-      }
-    },
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
+        val messageService = client.messages()
+        // Make API call
+        val attempt = Try(messageService.create(messageParams)).toEither.left.map {
+          case e: com.anthropic.errors.UnauthorizedException         => AuthenticationError("anthropic", e.getMessage)
+          case _: com.anthropic.errors.RateLimitException            => RateLimitError("anthropic")
+          case e: com.anthropic.errors.AnthropicInvalidDataException => ValidationError("input", e.getMessage)
+          case e: Exception                                          => e.toLLMError
+        }
+        attempt.map(convertFromAnthropicResponse) // Convert response to our model
+    }
+  }
 
   /*
 curl https://api.anthropic.com/v1/messages \
@@ -170,179 +165,171 @@ curl https://api.anthropic.com/v1/messages \
     conversation: Conversation,
     options: CompletionOptions = CompletionOptions(),
     onChunk: StreamedChunk => Unit
-  ): Result[Completion] = withMetrics(
-    provider = "anthropic",
-    model = config.model,
-    operation = {
-      validateNotClosed.flatMap { _ =>
-        // Transform options and messages for model-specific constraints
-        TransformationResult.transform(config.model, options, conversation.messages, dropUnsupported = true).flatMap {
-          transformed =>
-            val transformedConversation = conversation.copy(messages = transformed.messages)
+  ): Result[Completion] = completeWithMetrics {
+    // Transform options and messages for model-specific constraints
+    TransformationResult.transform(config.model, options, conversation.messages, dropUnsupported = true).flatMap {
+      transformed =>
+        val transformedConversation = conversation.copy(messages = transformed.messages)
 
-            // Build parameters
-            val paramsBuilder = MessageCreateParams
-              .builder()
-              .model(config.model)
-              .temperature(transformed.options.temperature.floatValue())
-              .topP(transformed.options.topP.floatValue())
+        // Build parameters
+        val paramsBuilder = MessageCreateParams
+          .builder()
+          .model(config.model)
+          .temperature(transformed.options.temperature.floatValue())
+          .topP(transformed.options.topP.floatValue())
 
-            // Add max tokens if specified (required by the API)
-            val maxTokens = transformed.options.maxTokens.getOrElse(2048)
-            paramsBuilder.maxTokens(maxTokens)
+        // Add max tokens if specified (required by the API)
+        val maxTokens = transformed.options.maxTokens.getOrElse(2048)
+        paramsBuilder.maxTokens(maxTokens)
 
-            // Add extended thinking configuration if requested
-            transformed.options.effectiveBudgetTokens.foreach { budgetTokens =>
-              val effectiveBudget = clampBudgetTokens(budgetTokens, maxTokens)
-              paramsBuilder.thinking(
-                ThinkingConfigEnabled.builder().budgetTokens(effectiveBudget.toLong).build()
-              )
-            }
+        // Add extended thinking configuration if requested
+        transformed.options.effectiveBudgetTokens.foreach { budgetTokens =>
+          val effectiveBudget = clampBudgetTokens(budgetTokens, maxTokens)
+          paramsBuilder.thinking(
+            ThinkingConfigEnabled.builder().budgetTokens(effectiveBudget.toLong).build()
+          )
+        }
 
-            // Add tools if specified
-            if (transformed.options.tools.nonEmpty)
-              transformed.options.tools.foreach(t => paramsBuilder.addTool(convertToolToAnthropicTool(t)))
-            // Add messages from conversation
-            addMessagesToParams(transformedConversation, paramsBuilder)
-            // Build the parameters
-            val messageParams = paramsBuilder.build()
+        // Add tools if specified
+        if (transformed.options.tools.nonEmpty)
+          transformed.options.tools.foreach(t => paramsBuilder.addTool(convertToolToAnthropicTool(t)))
+        // Add messages from conversation
+        addMessagesToParams(transformedConversation, paramsBuilder)
+        // Build the parameters
+        val messageParams = paramsBuilder.build()
 
-            // Create accumulator for building the final completion
-            val accumulator                      = StreamingAccumulator.create()
-            var currentMessageId: Option[String] = None
+        // Create accumulator for building the final completion
+        val accumulator                      = StreamingAccumulator.create()
+        var currentMessageId: Option[String] = None
 
-            // Process the stream
-            val attempt = Try {
-              val messageService = client.messages()
-              val streamResponse = messageService.createStreaming(messageParams)
+        // Process the stream
+        val attempt = Try {
+          val messageService = client.messages()
+          val streamResponse = messageService.createStreaming(messageParams)
 
-              import scala.jdk.StreamConverters._
-              val stream: Iterator[RawMessageStreamEvent] = streamResponse.stream().toScala(Iterator)
-              val loopTry = Try {
-                stream.foreach { event =>
-                  // Process different event types using the event's accessor methods
-                  // Check for message start event
-                  val messageStartOpt = event.messageStart()
-                  if (messageStartOpt != null && messageStartOpt.isPresent) {
-                    val msgStart = messageStartOpt.get()
-                    currentMessageId = Some(msgStart.message().id())
-                  }
+          import scala.jdk.StreamConverters._
+          val stream: Iterator[RawMessageStreamEvent] = streamResponse.stream().toScala(Iterator)
+          val loopTry = Try {
+            stream.foreach { event =>
+              // Process different event types using the event's accessor methods
+              // Check for message start event
+              val messageStartOpt = event.messageStart()
+              if (messageStartOpt != null && messageStartOpt.isPresent) {
+                val msgStart = messageStartOpt.get()
+                currentMessageId = Some(msgStart.message().id())
+              }
 
-                  // Check for content block delta event
-                  val contentDeltaOpt = event.contentBlockDelta()
-                  if (contentDeltaOpt != null && contentDeltaOpt.isPresent) {
-                    val contentDelta = contentDeltaOpt.get()
-                    val delta        = contentDelta.delta()
+              // Check for content block delta event
+              val contentDeltaOpt = event.contentBlockDelta()
+              if (contentDeltaOpt != null && contentDeltaOpt.isPresent) {
+                val contentDelta = contentDeltaOpt.get()
+                val delta        = contentDelta.delta()
 
-                    // Handle text content delta
-                    Try(delta.text()).foreach { textOpt =>
-                      if (textOpt != null && textOpt.isPresent) {
-                        val textDelta = textOpt.get()
-                        val text      = textDelta.text()
-                        if (text != null && text.nonEmpty) {
-                          val chunk = StreamedChunk(
-                            id = currentMessageId.getOrElse(""),
-                            content = Some(text),
-                            toolCall = None,
-                            finishReason = None
-                          )
-                          accumulator.addChunk(chunk)
-                          onChunk(chunk)
-                        }
-                      }
-                    }
-
-                    // Handle thinking content delta
-                    Try(delta.thinking()).foreach { thinkingOpt =>
-                      if (thinkingOpt != null && thinkingOpt.isPresent) {
-                        val thinkingDelta = thinkingOpt.get()
-                        val thinkingText  = thinkingDelta.thinking()
-                        if (thinkingText != null && thinkingText.nonEmpty) {
-                          val chunk = StreamedChunk(
-                            id = currentMessageId.getOrElse(""),
-                            content = None,
-                            toolCall = None,
-                            finishReason = None,
-                            thinkingDelta = Some(thinkingText)
-                          )
-                          accumulator.addChunk(chunk)
-                          onChunk(chunk)
-                        }
-                      }
-                    }
-                  }
-
-                  val contentStartOpt = event.contentBlockStart()
-                  if (contentStartOpt != null && contentStartOpt.isPresent) {
-                    val contentStart = contentStartOpt.get()
-                    val block        = contentStart.contentBlock()
-                    if (block.isToolUse) {
-                      val toolUse = block.asToolUse()
+                // Handle text content delta
+                Try(delta.text()).foreach { textOpt =>
+                  if (textOpt != null && textOpt.isPresent) {
+                    val textDelta = textOpt.get()
+                    val text      = textDelta.text()
+                    if (text != null && text.nonEmpty) {
                       val chunk = StreamedChunk(
                         id = currentMessageId.getOrElse(""),
-                        content = None,
-                        toolCall = Some(ToolCall(id = toolUse.id(), name = toolUse.name(), arguments = ujson.Obj())),
+                        content = Some(text),
+                        toolCall = None,
                         finishReason = None
                       )
                       accumulator.addChunk(chunk)
                       onChunk(chunk)
                     }
                   }
+                }
 
-                  val messageStopOpt = event.messageStop()
-                  if (messageStopOpt != null && messageStopOpt.isPresent) {
-                    val chunk = StreamedChunk(
-                      id = currentMessageId.getOrElse(""),
-                      content = None,
-                      toolCall = None,
-                      finishReason = Some("stop")
-                    )
-                    accumulator.addChunk(chunk)
-                    onChunk(chunk)
-                  }
-
-                  val messageDeltaOpt = event.messageDelta()
-                  if (messageDeltaOpt != null && messageDeltaOpt.isPresent) {
-                    val msgDelta = messageDeltaOpt.get()
-                    Try(msgDelta.usage()).foreach { usage =>
-                      if (usage != null) {
-                        val inputTokens = Option(usage.inputTokens()) match {
-                          case Some(opt: java.util.Optional[_]) if opt.isPresent =>
-                            Option(opt.get())
-                              .collect { case n: java.lang.Number => n.intValue() }
-                              .getOrElse(0)
-                          case _ => 0
-                        }
-                        val outputTokens = Option(usage.outputTokens()).map(_.toInt).getOrElse(0)
-                        if (inputTokens > 0 || outputTokens > 0) accumulator.updateTokens(inputTokens, outputTokens)
-                      }
+                // Handle thinking content delta
+                Try(delta.thinking()).foreach { thinkingOpt =>
+                  if (thinkingOpt != null && thinkingOpt.isPresent) {
+                    val thinkingDelta = thinkingOpt.get()
+                    val thinkingText  = thinkingDelta.thinking()
+                    if (thinkingText != null && thinkingText.nonEmpty) {
+                      val chunk = StreamedChunk(
+                        id = currentMessageId.getOrElse(""),
+                        content = None,
+                        toolCall = None,
+                        finishReason = None,
+                        thinkingDelta = Some(thinkingText)
+                      )
+                      accumulator.addChunk(chunk)
+                      onChunk(chunk)
                     }
                   }
                 }
               }
-              Try(streamResponse.close());
-              loopTry.get
-            }.toEither.left
-              .map {
-                case e: com.anthropic.errors.UnauthorizedException => AuthenticationError("anthropic", e.getMessage)
-                case _: com.anthropic.errors.RateLimitException    => RateLimitError("anthropic")
-                case e: com.anthropic.errors.AnthropicInvalidDataException => ValidationError("input", e.getMessage)
-                case e: Exception                                          => e.toLLMError
+
+              val contentStartOpt = event.contentBlockStart()
+              if (contentStartOpt != null && contentStartOpt.isPresent) {
+                val contentStart = contentStartOpt.get()
+                val block        = contentStart.contentBlock()
+                if (block.isToolUse) {
+                  val toolUse = block.asToolUse()
+                  val chunk = StreamedChunk(
+                    id = currentMessageId.getOrElse(""),
+                    content = None,
+                    toolCall = Some(ToolCall(id = toolUse.id(), name = toolUse.name(), arguments = ujson.Obj())),
+                    finishReason = None
+                  )
+                  accumulator.addChunk(chunk)
+                  onChunk(chunk)
+                }
               }
 
-            // Return the accumulated completion
-            attempt.flatMap(_ =>
-              accumulator.toCompletion.map { c =>
-                val cost = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
-                c.copy(model = config.model, estimatedCost = cost)
+              val messageStopOpt = event.messageStop()
+              if (messageStopOpt != null && messageStopOpt.isPresent) {
+                val chunk = StreamedChunk(
+                  id = currentMessageId.getOrElse(""),
+                  content = None,
+                  toolCall = None,
+                  finishReason = Some("stop")
+                )
+                accumulator.addChunk(chunk)
+                onChunk(chunk)
               }
-            )
-        }
-      }
-    },
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
+
+              val messageDeltaOpt = event.messageDelta()
+              if (messageDeltaOpt != null && messageDeltaOpt.isPresent) {
+                val msgDelta = messageDeltaOpt.get()
+                Try(msgDelta.usage()).foreach { usage =>
+                  if (usage != null) {
+                    val inputTokens = Option(usage.inputTokens()) match {
+                      case Some(opt: java.util.Optional[_]) if opt.isPresent =>
+                        Option(opt.get())
+                          .collect { case n: java.lang.Number => n.intValue() }
+                          .getOrElse(0)
+                      case _ => 0
+                    }
+                    val outputTokens = Option(usage.outputTokens()).map(_.toInt).getOrElse(0)
+                    if (inputTokens > 0 || outputTokens > 0) accumulator.updateTokens(inputTokens, outputTokens)
+                  }
+                }
+              }
+            }
+          }
+          Try(streamResponse.close());
+          loopTry.get
+        }.toEither.left
+          .map {
+            case e: com.anthropic.errors.UnauthorizedException         => AuthenticationError("anthropic", e.getMessage)
+            case _: com.anthropic.errors.RateLimitException            => RateLimitError("anthropic")
+            case e: com.anthropic.errors.AnthropicInvalidDataException => ValidationError("input", e.getMessage)
+            case e: Exception                                          => e.toLLMError
+          }
+
+        // Return the accumulated completion
+        attempt.flatMap(_ =>
+          accumulator.toCompletion.map { c =>
+            val cost = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
+            c.copy(model = config.model, estimatedCost = cost)
+          }
+        )
+    }
+  }
 
   override def getContextWindow(): Int = providerConfig.contextWindow
 

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/CohereClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/CohereClient.scala
@@ -28,48 +28,42 @@ import scala.util.Try
 class CohereClient(
   config: CohereConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop
-) extends BaseLifecycleLLMClient
-    with MetricsRecording {
+) extends BaseLifecycleLLMClient {
 
   private val httpClient = HttpClient.newHttpClient()
 
   protected def clientDescription: String = s"Cohere client for model ${config.model}"
+  protected def providerName: String      = "cohere"
+  protected def modelName: String         = config.model
 
   override def complete(
     conversation: Conversation,
     options: CompletionOptions
-  ): Result[Completion] =
-    withMetrics(
-      provider = "cohere",
-      model = config.model,
-      operation = validateNotClosed.flatMap { _ =>
-        buildChatRequest(conversation, options).flatMap { requestBody =>
-          val request = HttpRequest
-            .newBuilder()
-            .uri(URI.create(s"${config.baseUrl}/v2/chat"))
-            .header("Content-Type", "application/json")
-            .header("Authorization", s"Bearer ${config.apiKey}")
-            .timeout(Duration.ofMinutes(2))
-            .POST(HttpRequest.BodyPublishers.ofString(requestBody.render(), StandardCharsets.UTF_8))
-            .build()
+  ): Result[Completion] = completeWithMetrics {
+    buildChatRequest(conversation, options).flatMap { requestBody =>
+      val request = HttpRequest
+        .newBuilder()
+        .uri(URI.create(s"${config.baseUrl}/v2/chat"))
+        .header("Content-Type", "application/json")
+        .header("Authorization", s"Bearer ${config.apiKey}")
+        .timeout(Duration.ofMinutes(2))
+        .POST(HttpRequest.BodyPublishers.ofString(requestBody.render(), StandardCharsets.UTF_8))
+        .build()
 
-          val attempt = Try {
-            httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
-          }.toEither.left.map(_.toLLMError)
+      val attempt = Try {
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
+      }.toEither.left.map(_.toLLMError)
 
-          attempt.flatMap { response =>
-            val status = response.statusCode()
-            if (status >= 200 && status < 300) {
-              parseChatResponse(response.body())
-            } else {
-              handleErrorResponse(status, response.body())
-            }
-          }
+      attempt.flatMap { response =>
+        val status = response.statusCode()
+        if (status >= 200 && status < 300) {
+          parseChatResponse(response.body())
+        } else {
+          handleErrorResponse(status, response.body())
         }
-      },
-      extractUsage = (c: Completion) => c.usage,
-      extractCost = (c: Completion) => c.estimatedCost
-    )
+      }
+    }
+  }
 
   override def streamComplete(
     conversation: Conversation,

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/DeepSeekClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/DeepSeekClient.scala
@@ -32,132 +32,121 @@ import scala.util.Try
 class DeepSeekClient(
   config: DeepSeekConfig,
   protected val metrics: MetricsCollector = MetricsCollector.noop
-) extends BaseLifecycleLLMClient
-    with MetricsRecording {
+) extends BaseLifecycleLLMClient {
   private val httpClient = HttpClient.newHttpClient()
   private val logger     = org.slf4j.LoggerFactory.getLogger(getClass)
 
   protected def clientDescription: String = s"DeepSeek client for model ${config.model}"
+  protected def providerName: String      = "deepseek"
+  protected def modelName: String         = config.model
 
   override def complete(
     conversation: Conversation,
     options: CompletionOptions
-  ): Result[Completion] = withMetrics(
-    provider = "deepseek",
-    model = config.model,
-    operation = validateNotClosed.flatMap { _ =>
-      val requestBody = createRequestBody(conversation, options)
+  ): Result[Completion] = completeWithMetrics {
+    val requestBody = createRequestBody(conversation, options)
 
-      logger.debug(s"Sending request to DeepSeek API at ${config.baseUrl}/chat/completions")
+    logger.debug(s"Sending request to DeepSeek API at ${config.baseUrl}/chat/completions")
 
-      val attempt =
-        Try {
-          val request = HttpRequest
-            .newBuilder()
-            .uri(URI.create(s"${config.baseUrl}/chat/completions"))
-            .header("Content-Type", "application/json")
-            .header("Authorization", s"Bearer ${config.apiKey}")
-            .header("User-Agent", "llm4s/1.0")
-            .POST(HttpRequest.BodyPublishers.ofString(requestBody.render()))
-            .build()
-
-          val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
-
-          logger.debug(s"Response status: ${response.statusCode()}")
-
-          response
-        }.toEither.left
-          .map(_.toLLMError)
-
-      attempt.flatMap { response =>
-        response.statusCode() match {
-          case 200 =>
-            Try {
-              val responseJson = ujson.read(response.body())
-              parseCompletion(responseJson)
-            }.toEither.left.map(_.toLLMError)
-          case 401    => Left(AuthenticationError("deepseek", "Invalid API key"))
-          case 429    => Left(RateLimitError("deepseek"))
-          case status => Left(ServiceError(status, "deepseek", s"DeepSeek API error: ${response.body()}"))
-        }
-      }
-    },
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
-
-  override def streamComplete(
-    conversation: Conversation,
-    options: CompletionOptions = CompletionOptions(),
-    onChunk: StreamedChunk => Unit
-  ): Result[Completion] = withMetrics(
-    provider = "deepseek",
-    model = config.model,
-    operation = validateNotClosed.flatMap { _ =>
-      val requestBody = createRequestBody(conversation, options)
-      requestBody("stream") = true
-
-      val accumulator = StreamingAccumulator.create()
-
-      val requestResult = Try {
+    val attempt =
+      Try {
         val request = HttpRequest
           .newBuilder()
           .uri(URI.create(s"${config.baseUrl}/chat/completions"))
           .header("Content-Type", "application/json")
           .header("Authorization", s"Bearer ${config.apiKey}")
           .header("User-Agent", "llm4s/1.0")
-          .timeout(Duration.ofMinutes(5))
           .POST(HttpRequest.BodyPublishers.ofString(requestBody.render()))
           .build()
 
-        httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
-      }.toEither.left.map(_.toLLMError)
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
 
-      requestResult.flatMap { response =>
-        if (response.statusCode() != 200) {
-          val errorBody = new String(response.body().readAllBytes(), StandardCharsets.UTF_8)
-          Try(response.body().close()) // Ensure stream is closed on error path
-          response.statusCode() match {
-            case 401    => Left(AuthenticationError("deepseek", "Invalid API key"))
-            case 429    => Left(RateLimitError("deepseek"))
-            case status => Left(ServiceError(status, "deepseek", s"DeepSeek API error: $errorBody"))
-          }
-        } else {
-          val sseParser = SSEParser.createStreamingParser()
-          val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
-          val loopTry = Try {
-            Iterator.continually(reader.readLine()).takeWhile(_ != null).foreach { line =>
-              sseParser.addChunk(line + "\n")
-              while (sseParser.hasEvents)
-                sseParser.nextEvent().foreach { event =>
-                  event.data.foreach { data =>
-                    if (data != "[DONE]") {
-                      val json   = ujson.read(data)
-                      val chunks = parseStreamingChunks(json)
-                      chunks.foreach { c =>
-                        accumulator.addChunk(c)
-                        onChunk(c)
-                      }
+        logger.debug(s"Response status: ${response.statusCode()}")
+
+        response
+      }.toEither.left
+        .map(_.toLLMError)
+
+    attempt.flatMap { response =>
+      response.statusCode() match {
+        case 200 =>
+          Try {
+            val responseJson = ujson.read(response.body())
+            parseCompletion(responseJson)
+          }.toEither.left.map(_.toLLMError)
+        case 401    => Left(AuthenticationError("deepseek", "Invalid API key"))
+        case 429    => Left(RateLimitError("deepseek"))
+        case status => Left(ServiceError(status, "deepseek", s"DeepSeek API error: ${response.body()}"))
+      }
+    }
+  }
+
+  override def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions(),
+    onChunk: StreamedChunk => Unit
+  ): Result[Completion] = completeWithMetrics {
+    val requestBody = createRequestBody(conversation, options)
+    requestBody("stream") = true
+
+    val accumulator = StreamingAccumulator.create()
+
+    val requestResult = Try {
+      val request = HttpRequest
+        .newBuilder()
+        .uri(URI.create(s"${config.baseUrl}/chat/completions"))
+        .header("Content-Type", "application/json")
+        .header("Authorization", s"Bearer ${config.apiKey}")
+        .header("User-Agent", "llm4s/1.0")
+        .timeout(Duration.ofMinutes(5))
+        .POST(HttpRequest.BodyPublishers.ofString(requestBody.render()))
+        .build()
+
+      httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
+    }.toEither.left.map(_.toLLMError)
+
+    requestResult.flatMap { response =>
+      if (response.statusCode() != 200) {
+        val errorBody = new String(response.body().readAllBytes(), StandardCharsets.UTF_8)
+        Try(response.body().close()) // Ensure stream is closed on error path
+        response.statusCode() match {
+          case 401    => Left(AuthenticationError("deepseek", "Invalid API key"))
+          case 429    => Left(RateLimitError("deepseek"))
+          case status => Left(ServiceError(status, "deepseek", s"DeepSeek API error: $errorBody"))
+        }
+      } else {
+        val sseParser = SSEParser.createStreamingParser()
+        val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
+        val loopTry = Try {
+          Iterator.continually(reader.readLine()).takeWhile(_ != null).foreach { line =>
+            sseParser.addChunk(line + "\n")
+            while (sseParser.hasEvents)
+              sseParser.nextEvent().foreach { event =>
+                event.data.foreach { data =>
+                  if (data != "[DONE]") {
+                    val json   = ujson.read(data)
+                    val chunks = parseStreamingChunks(json)
+                    chunks.foreach { c =>
+                      accumulator.addChunk(c)
+                      onChunk(c)
                     }
                   }
                 }
-            }
-          }
-          Try(reader.close()); Try(response.body().close())
-          loopTry.toEither.left
-            .map(_.toLLMError)
-            .flatMap(_ =>
-              accumulator.toCompletion.map { c =>
-                val cost = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
-                c.copy(model = config.model, estimatedCost = cost)
               }
-            )
+          }
         }
+        Try(reader.close()); Try(response.body().close())
+        loopTry.toEither.left
+          .map(_.toLLMError)
+          .flatMap(_ =>
+            accumulator.toCompletion.map { c =>
+              val cost = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
+              c.copy(model = config.model, estimatedCost = cost)
+            }
+          )
       }
-    },
-    extractUsage = { (c: Completion) => c.usage },
-    extractCost = { (c: Completion) => c.estimatedCost }
-  )
+    }
+  }
 
   private def parseStreamingChunks(json: ujson.Value): Seq[StreamedChunk] = {
     val choices = json("choices").arr

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/GeminiClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/GeminiClient.scala
@@ -61,123 +61,112 @@ class GeminiClient(
   config: GeminiConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop,
   private[provider] val httpClient: Llm4sHttpClient = Llm4sHttpClient.create()
-) extends BaseLifecycleLLMClient
-    with MetricsRecording {
+) extends BaseLifecycleLLMClient {
   private val logger = LoggerFactory.getLogger(getClass)
 
   protected def clientDescription: String = s"Gemini client for model ${config.model}"
+  protected def providerName: String      = "gemini"
+  protected def modelName: String         = config.model
 
   override def complete(
     conversation: Conversation,
     options: CompletionOptions
-  ): Result[Completion] = withMetrics(
-    provider = "gemini",
-    model = config.model,
-    operation = validateNotClosed.flatMap { _ =>
-      TransformationResult.transform(config.model, options, conversation.messages, dropUnsupported = true).flatMap {
-        transformed =>
-          val transformedConversation = conversation.copy(messages = transformed.messages)
-          val requestBody             = buildRequestBody(transformedConversation, transformed.options)
-          val url                     = s"${config.baseUrl}/models/${config.model}:generateContent?key=${config.apiKey}"
+  ): Result[Completion] = completeWithMetrics {
+    TransformationResult.transform(config.model, options, conversation.messages, dropUnsupported = true).flatMap {
+      transformed =>
+        val transformedConversation = conversation.copy(messages = transformed.messages)
+        val requestBody             = buildRequestBody(transformedConversation, transformed.options)
+        val url                     = s"${config.baseUrl}/models/${config.model}:generateContent?key=${config.apiKey}"
 
-          // Note: URL contains API key as query param - do not log full URL
-          logger.debug(s"[Gemini] Sending request to ${config.baseUrl}/models/${config.model}:generateContent")
-          logger.debug(s"[Gemini] Request body: ${Redaction.redactForLogging(requestBody.render())}")
+        // Note: URL contains API key as query param - do not log full URL
+        logger.debug(s"[Gemini] Sending request to ${config.baseUrl}/models/${config.model}:generateContent")
+        logger.debug(s"[Gemini] Request body: ${Redaction.redactForLogging(requestBody.render())}")
 
-          val headers = Map("Content-Type" -> "application/json")
+        val headers = Map("Content-Type" -> "application/json")
 
-          val attempt = Try {
-            val response = httpClient.post(url, headers, requestBody.render(), timeout = 120000)
+        val attempt = Try {
+          val response = httpClient.post(url, headers, requestBody.render(), timeout = 120000)
 
-            if (response.statusCode >= 200 && response.statusCode < 300) {
-              parseCompletionResponse(response.body)
-            } else {
-              handleErrorResponse(response.statusCode, response.body)
-            }
-          }.toEither.left
-            .map(e => e.toLLMError)
-            .flatten
+          if (response.statusCode >= 200 && response.statusCode < 300) {
+            parseCompletionResponse(response.body)
+          } else {
+            handleErrorResponse(response.statusCode, response.body)
+          }
+        }.toEither.left
+          .map(e => e.toLLMError)
+          .flatten
 
-          attempt
-      }
-    },
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
+        attempt
+    }
+  }
 
   override def streamComplete(
     conversation: Conversation,
     options: CompletionOptions = CompletionOptions(),
     onChunk: StreamedChunk => Unit
-  ): Result[Completion] = withMetrics(
-    provider = "gemini",
-    model = config.model,
-    operation = validateNotClosed.flatMap { _ =>
-      TransformationResult.transform(config.model, options, conversation.messages, dropUnsupported = true).flatMap {
-        transformed =>
-          val transformedConversation = conversation.copy(messages = transformed.messages)
-          val requestBody             = buildRequestBody(transformedConversation, transformed.options)
-          val url = s"${config.baseUrl}/models/${config.model}:streamGenerateContent?key=${config.apiKey}&alt=sse"
+  ): Result[Completion] = completeWithMetrics {
+    TransformationResult.transform(config.model, options, conversation.messages, dropUnsupported = true).flatMap {
+      transformed =>
+        val transformedConversation = conversation.copy(messages = transformed.messages)
+        val requestBody             = buildRequestBody(transformedConversation, transformed.options)
+        val url = s"${config.baseUrl}/models/${config.model}:streamGenerateContent?key=${config.apiKey}&alt=sse"
 
-          // Note: URL contains API key as query param - do not log full URL
-          logger.debug(s"[Gemini] Starting stream to ${config.baseUrl}/models/${config.model}:streamGenerateContent")
+        // Note: URL contains API key as query param - do not log full URL
+        logger.debug(s"[Gemini] Starting stream to ${config.baseUrl}/models/${config.model}:streamGenerateContent")
 
-          val headers  = Map("Content-Type" -> "application/json")
-          val response = httpClient.postStream(url, headers, requestBody.render(), timeout = 600000)
+        val headers  = Map("Content-Type" -> "application/json")
+        val response = httpClient.postStream(url, headers, requestBody.render(), timeout = 600000)
 
-          if (response.statusCode < 200 || response.statusCode >= 300) {
-            val err = new String(response.body.readAllBytes(), StandardCharsets.UTF_8)
-            response.body.close()
-            handleErrorResponse(response.statusCode, err)
-          } else {
-            val accumulator = StreamingAccumulator.create()
-            val messageId   = UUID.randomUUID().toString
-            val reader      = new BufferedReader(new InputStreamReader(response.body, StandardCharsets.UTF_8))
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          val err = new String(response.body.readAllBytes(), StandardCharsets.UTF_8)
+          response.body.close()
+          handleErrorResponse(response.statusCode, err)
+        } else {
+          val accumulator = StreamingAccumulator.create()
+          val messageId   = UUID.randomUUID().toString
+          val reader      = new BufferedReader(new InputStreamReader(response.body, StandardCharsets.UTF_8))
 
-            Try {
-              try {
-                var line: String = null
-                while ({ line = reader.readLine(); line != null }) {
-                  val trimmed = line.trim
-                  // SSE format: lines starting with "data: " contain JSON
-                  if (trimmed.startsWith("data: ")) {
-                    val jsonStr = trimmed.stripPrefix("data: ").trim
-                    if (jsonStr.nonEmpty) {
-                      Try(ujson.read(jsonStr)).foreach { json =>
-                        parseStreamChunk(json, messageId).foreach { chunk =>
-                          accumulator.addChunk(chunk)
-                          onChunk(chunk)
-                        }
-                        // Extract token usage from usageMetadata if present
-                        for {
-                          usage      <- Try(json("usageMetadata")).toOption
-                          prompt     <- Try(usage("promptTokenCount").num.toInt).toOption
-                          completion <- Try(usage("candidatesTokenCount").num.toInt).toOption
-                        } accumulator.updateTokens(prompt, completion)
+          Try {
+            try {
+              var line: String = null
+              while ({ line = reader.readLine(); line != null }) {
+                val trimmed = line.trim
+                // SSE format: lines starting with "data: " contain JSON
+                if (trimmed.startsWith("data: ")) {
+                  val jsonStr = trimmed.stripPrefix("data: ").trim
+                  if (jsonStr.nonEmpty) {
+                    Try(ujson.read(jsonStr)).foreach { json =>
+                      parseStreamChunk(json, messageId).foreach { chunk =>
+                        accumulator.addChunk(chunk)
+                        onChunk(chunk)
                       }
+                      // Extract token usage from usageMetadata if present
+                      for {
+                        usage      <- Try(json("usageMetadata")).toOption
+                        prompt     <- Try(usage("promptTokenCount").num.toInt).toOption
+                        completion <- Try(usage("candidatesTokenCount").num.toInt).toOption
+                      } accumulator.updateTokens(prompt, completion)
                     }
                   }
                 }
-
-                // Close resources INSIDE Try block
-              } finally {
-                Try(reader.close())
-                Try(response.body.close())
               }
-            }.toEither.left
-              .map(_.toLLMError)
-              .flatMap(_ =>
-                accumulator.toCompletion.map { c =>
-                  val cost = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
-                  c.copy(model = config.model, estimatedCost = cost)
-                }
-              )
-          }
-      }
-    },
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
+
+              // Close resources INSIDE Try block
+            } finally {
+              Try(reader.close())
+              Try(response.body.close())
+            }
+          }.toEither.left
+            .map(_.toLLMError)
+            .flatMap(_ =>
+              accumulator.toCompletion.map { c =>
+                val cost = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
+                c.copy(model = config.model, estimatedCost = cost)
+              }
+            )
+        }
+    }
+  }
 
   override def getContextWindow(): Int = config.contextWindow
 

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
@@ -28,48 +28,42 @@ import scala.util.Try
 class MistralClient(
   config: MistralConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop
-) extends BaseLifecycleLLMClient
-    with MetricsRecording {
+) extends BaseLifecycleLLMClient {
 
   private val httpClient = HttpClient.newHttpClient()
 
   protected def clientDescription: String = s"Mistral client for model ${config.model}"
+  protected def providerName: String      = "mistral"
+  protected def modelName: String         = config.model
 
   override def complete(
     conversation: Conversation,
     options: CompletionOptions
-  ): Result[Completion] =
-    withMetrics(
-      provider = "mistral",
-      model = config.model,
-      operation = validateNotClosed.flatMap { _ =>
-        buildChatRequest(conversation, options).flatMap { requestBody =>
-          val request = HttpRequest
-            .newBuilder()
-            .uri(URI.create(s"${config.baseUrl}/v1/chat/completions"))
-            .header("Content-Type", "application/json")
-            .header("Authorization", s"Bearer ${config.apiKey}")
-            .timeout(Duration.ofMinutes(2))
-            .POST(HttpRequest.BodyPublishers.ofString(requestBody.render(), StandardCharsets.UTF_8))
-            .build()
+  ): Result[Completion] = completeWithMetrics {
+    buildChatRequest(conversation, options).flatMap { requestBody =>
+      val request = HttpRequest
+        .newBuilder()
+        .uri(URI.create(s"${config.baseUrl}/v1/chat/completions"))
+        .header("Content-Type", "application/json")
+        .header("Authorization", s"Bearer ${config.apiKey}")
+        .timeout(Duration.ofMinutes(2))
+        .POST(HttpRequest.BodyPublishers.ofString(requestBody.render(), StandardCharsets.UTF_8))
+        .build()
 
-          val attempt = Try {
-            httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
-          }.toEither.left.map(_.toLLMError)
+      val attempt = Try {
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
+      }.toEither.left.map(_.toLLMError)
 
-          attempt.flatMap { response =>
-            val status = response.statusCode()
-            if (status >= 200 && status < 300) {
-              parseChatResponse(response.body())
-            } else {
-              handleErrorResponse(status, response.body())
-            }
-          }
+      attempt.flatMap { response =>
+        val status = response.statusCode()
+        if (status >= 200 && status < 300) {
+          parseChatResponse(response.body())
+        } else {
+          handleErrorResponse(status, response.body())
         }
-      },
-      extractUsage = (c: Completion) => c.usage,
-      extractCost = (c: Completion) => c.estimatedCost
-    )
+      }
+    }
+  }
 
   override def streamComplete(
     conversation: Conversation,

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OllamaClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OllamaClient.scala
@@ -47,21 +47,18 @@ class OllamaClient(
   config: OllamaConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop,
   private[provider] val httpClient: Llm4sHttpClient = Llm4sHttpClient.create()
-) extends BaseLifecycleLLMClient
-    with MetricsRecording {
+) extends BaseLifecycleLLMClient {
 
   protected def clientDescription: String = s"Ollama client for model ${config.model}"
+  protected def providerName: String      = "ollama"
+  protected def modelName: String         = config.model
 
   override def complete(
     conversation: Conversation,
     options: CompletionOptions
-  ): Result[Completion] = withMetrics(
-    provider = "ollama",
-    model = config.model,
-    operation = validateNotClosed.flatMap(_ => connect(conversation, options)),
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
+  ): Result[Completion] = completeWithMetrics {
+    connect(conversation, options)
+  }
 
   private def connect(conversation: Conversation, options: CompletionOptions): Result[Completion] = {
     val requestBody = createRequestBody(conversation, options, stream = false)
@@ -100,93 +97,87 @@ class OllamaClient(
     conversation: Conversation,
     options: CompletionOptions = CompletionOptions(),
     onChunk: StreamedChunk => Unit
-  ): Result[Completion] = withMetrics(
-    provider = "ollama",
-    model = config.model,
-    operation = validateNotClosed.flatMap { _ =>
-      val requestBody = createRequestBody(conversation, options, stream = true)
-      val url         = s"${config.baseUrl}/api/chat"
-      val headers     = Map("Content-Type" -> "application/json")
+  ): Result[Completion] = completeWithMetrics {
+    val requestBody = createRequestBody(conversation, options, stream = true)
+    val url         = s"${config.baseUrl}/api/chat"
+    val headers     = Map("Content-Type" -> "application/json")
 
-      try {
-        val response = httpClient.postStream(url, headers, requestBody.render(), timeout = 600000)
-        if (response.statusCode != 200) {
-          val err = new String(response.body.readAllBytes(), StandardCharsets.UTF_8)
-          response.body.close()
-          response.statusCode match {
-            case 401 => Left(AuthenticationError("ollama", "Unauthorized"))
-            case 429 => Left(RateLimitError("ollama"))
-            case s   => Left(ServiceError(s, "ollama", s"Ollama error: $err"))
-          }
-        } else {
-          val accumulator = StreamingAccumulator.create()
-          val reader      = new BufferedReader(new InputStreamReader(response.body, StandardCharsets.UTF_8))
-          val processEither = Try {
-            try {
-              var line: String = null
-              while ({ line = reader.readLine(); line != null }) {
-                val trimmed = line.trim
-                if (trimmed.nonEmpty) {
-                  val json = ujson.read(trimmed)
-                  // Ollama streams incremental content in json lines
-                  val done = json.obj.get("done").exists(_.bool)
-                  val contentOpt = json.obj
-                    .get("message")
-                    .flatMap(_.obj.get("content"))
-                    .flatMap(_.strOpt)
-                    .filter(_.nonEmpty)
+    try {
+      val response = httpClient.postStream(url, headers, requestBody.render(), timeout = 600000)
+      if (response.statusCode != 200) {
+        val err = new String(response.body.readAllBytes(), StandardCharsets.UTF_8)
+        response.body.close()
+        response.statusCode match {
+          case 401 => Left(AuthenticationError("ollama", "Unauthorized"))
+          case 429 => Left(RateLimitError("ollama"))
+          case s   => Left(ServiceError(s, "ollama", s"Ollama error: $err"))
+        }
+      } else {
+        val accumulator = StreamingAccumulator.create()
+        val reader      = new BufferedReader(new InputStreamReader(response.body, StandardCharsets.UTF_8))
+        val processEither = Try {
+          try {
+            var line: String = null
+            while ({ line = reader.readLine(); line != null }) {
+              val trimmed = line.trim
+              if (trimmed.nonEmpty) {
+                val json = ujson.read(trimmed)
+                // Ollama streams incremental content in json lines
+                val done = json.obj.get("done").exists(_.bool)
+                val contentOpt = json.obj
+                  .get("message")
+                  .flatMap(_.obj.get("content"))
+                  .flatMap(_.strOpt)
+                  .filter(_.nonEmpty)
 
-                  val chunk = StreamedChunk(
-                    id = json.obj.get("id").flatMap(_.strOpt).getOrElse(""),
-                    content = contentOpt,
-                    toolCall = None,
-                    finishReason = if (done) Some("stop") else None
-                  )
+                val chunk = StreamedChunk(
+                  id = json.obj.get("id").flatMap(_.strOpt).getOrElse(""),
+                  content = contentOpt,
+                  toolCall = None,
+                  finishReason = if (done) Some("stop") else None
+                )
 
-                  accumulator.addChunk(chunk)
-                  onChunk(chunk)
+                accumulator.addChunk(chunk)
+                onChunk(chunk)
 
-                  // token counts (if present) only appear at the end
-                  if (done) {
-                    val prompt = json.obj.get("prompt_eval_count").flatMap(_.numOpt).map(_.toInt).getOrElse(0)
-                    val comp   = json.obj.get("eval_count").flatMap(_.numOpt).map(_.toInt).getOrElse(0)
-                    if (prompt > 0 || comp > 0) accumulator.updateTokens(prompt, comp)
-                  }
+                // token counts (if present) only appear at the end
+                if (done) {
+                  val prompt = json.obj.get("prompt_eval_count").flatMap(_.numOpt).map(_.toInt).getOrElse(0)
+                  val comp   = json.obj.get("eval_count").flatMap(_.numOpt).map(_.toInt).getOrElse(0)
+                  if (prompt > 0 || comp > 0) accumulator.updateTokens(prompt, comp)
                 }
               }
-            } finally {
-              Try(reader.close())
-              Try(response.body.close())
             }
-          }.toEither
-          processEither.left.foreach(_ => ())
-
-          accumulator.toCompletion.map { c =>
-            val cost = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
-            c.copy(model = config.model, estimatedCost = cost)
+          } finally {
+            Try(reader.close())
+            Try(response.body.close())
           }
+        }.toEither
+        processEither.left.foreach(_ => ())
+
+        accumulator.toCompletion.map { c =>
+          val cost = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
+          c.copy(model = config.model, estimatedCost = cost)
         }
-      } catch {
-        case e: InterruptedException =>
-          Thread.currentThread().interrupt()
-          Left(
-            ExecutionError(
-              s"Ollama streaming request interrupted: ${e.getMessage}",
-              operation = "ollama.stream",
-              exitCode = None,
-              cause = Some(e),
-              context = Map.empty
-            )
-          )
-        case e: IOException =>
-          Left(NetworkError("Failed to connect to Ollama stream", Some(e), config.baseUrl))
-        case scala.util.control.NonFatal(e) =>
-          Left(ServiceError(500, "ollama", s"Unexpected streaming error: ${e.getMessage}"))
       }
-    },
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
+    } catch {
+      case e: InterruptedException =>
+        Thread.currentThread().interrupt()
+        Left(
+          ExecutionError(
+            s"Ollama streaming request interrupted: ${e.getMessage}",
+            operation = "ollama.stream",
+            exitCode = None,
+            cause = Some(e),
+            context = Map.empty
+          )
+        )
+      case e: IOException =>
+        Left(NetworkError("Failed to connect to Ollama stream", Some(e), config.baseUrl))
+      case scala.util.control.NonFatal(e) =>
+        Left(ServiceError(500, "ollama", s"Unexpected streaming error: ${e.getMessage}"))
+    }
+  }
 
   private[provider] def createRequestBody(
     conversation: Conversation,

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenAIClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenAIClient.scala
@@ -51,12 +51,13 @@ class OpenAIClient private (
   private val transport: OpenAIClientTransport,
   private val config: ProviderConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector
-) extends BaseLifecycleLLMClient
-    with MetricsRecording {
+) extends BaseLifecycleLLMClient {
 
   private lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
   protected def clientDescription: String = s"OpenAI client for model $model"
+  protected def providerName: String      = "openai"
+  protected def modelName: String         = model
 
   /**
    * Creates an OpenAI client for direct OpenAI API access.
@@ -98,60 +99,48 @@ class OpenAIClient private (
   override def complete(
     conversation: Conversation,
     options: CompletionOptions
-  ): Result[Completion] = withMetrics(
-    provider = "openai",
-    model = model,
-    operation = validateNotClosed.flatMap { _ =>
-      // Transform options and messages for model-specific constraints
-      for {
-        transformed <- TransformationResult.transform(
-          model,
-          options,
-          conversation.messages,
-          dropUnsupported = true
-        )
-        transformedConversation = conversation.copy(messages = transformed.messages)
-        chatOptions = prepareChatOptions(
-          transformedConversation,
-          transformed.options,
-          transformed.requiresMaxCompletionTokens
-        )
-        completions <- Try(transport.getChatCompletions(model, chatOptions)).toEither.left
-          .map { e =>
-            logger.error(s"OpenAI completion failed for model $model", e)
-            e.toLLMError
-          }
-      } yield convertFromOpenAIFormat(completions)
-    },
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
+  ): Result[Completion] = completeWithMetrics {
+    // Transform options and messages for model-specific constraints
+    for {
+      transformed <- TransformationResult.transform(
+        model,
+        options,
+        conversation.messages,
+        dropUnsupported = true
+      )
+      transformedConversation = conversation.copy(messages = transformed.messages)
+      chatOptions = prepareChatOptions(
+        transformedConversation,
+        transformed.options,
+        transformed.requiresMaxCompletionTokens
+      )
+      completions <- Try(transport.getChatCompletions(model, chatOptions)).toEither.left
+        .map { e =>
+          logger.error(s"OpenAI completion failed for model $model", e)
+          e.toLLMError
+        }
+    } yield convertFromOpenAIFormat(completions)
+  }
 
   override def streamComplete(
     conversation: Conversation,
     options: CompletionOptions = CompletionOptions(),
     onChunk: StreamedChunk => Unit
-  ): Result[Completion] = withMetrics(
-    provider = "openai",
-    model = model,
-    operation = validateNotClosed.flatMap { _ =>
-      // Transform options and messages for model-specific constraints
-      TransformationResult.transform(model, options, conversation.messages, dropUnsupported = true).flatMap {
-        transformed =>
-          val transformedConversation = conversation.copy(messages = transformed.messages)
-          val chatOptions =
-            prepareChatOptions(transformedConversation, transformed.options, transformed.requiresMaxCompletionTokens)
+  ): Result[Completion] = completeWithMetrics {
+    // Transform options and messages for model-specific constraints
+    TransformationResult.transform(model, options, conversation.messages, dropUnsupported = true).flatMap {
+      transformed =>
+        val transformedConversation = conversation.copy(messages = transformed.messages)
+        val chatOptions =
+          prepareChatOptions(transformedConversation, transformed.options, transformed.requiresMaxCompletionTokens)
 
-          if (transformed.requiresFakeStreaming) {
-            executeFakeStreaming(chatOptions, onChunk)
-          } else {
-            executeNativeStreaming(chatOptions, onChunk)
-          }
-      }
-    },
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
+        if (transformed.requiresFakeStreaming) {
+          executeFakeStreaming(chatOptions, onChunk)
+        } else {
+          executeNativeStreaming(chatOptions, onChunk)
+        }
+    }
+  }
 
   override protected def releaseResources(): Unit =
     logger.debug(s"OpenAI client for model $model closed")

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenRouterClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/OpenRouterClient.scala
@@ -58,139 +58,128 @@ import scala.util.Try
 class OpenRouterClient(
   config: OpenAIConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop
-) extends BaseLifecycleLLMClient
-    with MetricsRecording {
+) extends BaseLifecycleLLMClient {
   private val httpClient = HttpClient.newHttpClient()
 
   protected def clientDescription: String = s"OpenRouter client for model ${config.model}"
+  protected def providerName: String      = "openrouter"
+  protected def modelName: String         = config.model
 
   override def complete(
     conversation: Conversation,
     options: CompletionOptions
-  ): Result[Completion] = withMetrics(
-    provider = "openrouter",
-    model = config.model,
-    operation = validateNotClosed.flatMap { _ =>
-      // Convert conversation to OpenRouter format
-      val requestBody = createRequestBody(conversation, options)
+  ): Result[Completion] = completeWithMetrics {
+    // Convert conversation to OpenRouter format
+    val requestBody = createRequestBody(conversation, options)
 
-      // Make API call safely (no try/catch)
-      val attempt =
-        Try {
-          val request = HttpRequest
-            .newBuilder()
-            .uri(URI.create(s"${config.baseUrl}/chat/completions"))
-            .header("Content-Type", "application/json")
-            .header("Authorization", s"Bearer ${config.apiKey}")
-            .header("HTTP-Referer", "https://github.com/llm4s/llm4s") // Required by OpenRouter
-            .header("X-Title", "LLM4S")                               // Required by OpenRouter
-            .POST(HttpRequest.BodyPublishers.ofString(requestBody.render()))
-            .build()
-
-          httpClient.send(request, HttpResponse.BodyHandlers.ofString())
-        }.toEither.left
-          .map(_.toLLMError)
-
-      attempt.flatMap { response =>
-        // Handle response status
-        response.statusCode() match {
-          case 200 =>
-            val responseJson = ujson.read(response.body())
-            Right(parseCompletion(responseJson))
-          case 401    => Left(AuthenticationError("openrouter", "Invalid API key"))
-          case 429    => Left(RateLimitError("openrouter"))
-          case status => Left(ServiceError(status, "openrouter", s"OpenRouter API error: ${response.body()}"))
-        }
-      }
-    },
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
-
-  override def streamComplete(
-    conversation: Conversation,
-    options: CompletionOptions = CompletionOptions(),
-    onChunk: StreamedChunk => Unit
-  ): Result[Completion] = withMetrics(
-    provider = "openrouter",
-    model = config.model,
-    operation = validateNotClosed.flatMap { _ =>
-      val requestBody = createRequestBody(conversation, options)
-      requestBody("stream") = true
-
-      val accumulator = StreamingAccumulator.create()
-
-      // Send the HTTP request, converting transport exceptions to Left
-      val responseOrError = Try {
+    // Make API call safely (no try/catch)
+    val attempt =
+      Try {
         val request = HttpRequest
           .newBuilder()
           .uri(URI.create(s"${config.baseUrl}/chat/completions"))
           .header("Content-Type", "application/json")
           .header("Authorization", s"Bearer ${config.apiKey}")
-          .header("HTTP-Referer", "https://github.com/llm4s/llm4s")
-          .header("X-Title", "LLM4S")
-          .timeout(Duration.ofMinutes(5))
+          .header("HTTP-Referer", "https://github.com/llm4s/llm4s") // Required by OpenRouter
+          .header("X-Title", "LLM4S")                               // Required by OpenRouter
           .POST(HttpRequest.BodyPublishers.ofString(requestBody.render()))
           .build()
 
-        httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
-      }.toEither.left.map(_.toLLMError)
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+      }.toEither.left
+        .map(_.toLLMError)
 
-      // Check HTTP status, returning typed errors for known failure codes
-      val streamOrError = responseOrError.flatMap { response =>
-        if (response.statusCode() == 200) {
-          Right(response)
-        } else {
-          val errorBody = Try(new String(response.body().readAllBytes(), StandardCharsets.UTF_8))
-            .getOrElse("<error body unreadable>")
-          response.statusCode() match {
-            case 401    => Left(AuthenticationError("openrouter", "Invalid API key"))
-            case 429    => Left(RateLimitError("openrouter"))
-            case status => Left(ServiceError(status, "openrouter", s"OpenRouter API error: $errorBody"))
-          }
+    attempt.flatMap { response =>
+      // Handle response status
+      response.statusCode() match {
+        case 200 =>
+          val responseJson = ujson.read(response.body())
+          Right(parseCompletion(responseJson))
+        case 401    => Left(AuthenticationError("openrouter", "Invalid API key"))
+        case 429    => Left(RateLimitError("openrouter"))
+        case status => Left(ServiceError(status, "openrouter", s"OpenRouter API error: ${response.body()}"))
+      }
+    }
+  }
+
+  override def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions(),
+    onChunk: StreamedChunk => Unit
+  ): Result[Completion] = completeWithMetrics {
+    val requestBody = createRequestBody(conversation, options)
+    requestBody("stream") = true
+
+    val accumulator = StreamingAccumulator.create()
+
+    // Send the HTTP request, converting transport exceptions to Left
+    val responseOrError = Try {
+      val request = HttpRequest
+        .newBuilder()
+        .uri(URI.create(s"${config.baseUrl}/chat/completions"))
+        .header("Content-Type", "application/json")
+        .header("Authorization", s"Bearer ${config.apiKey}")
+        .header("HTTP-Referer", "https://github.com/llm4s/llm4s")
+        .header("X-Title", "LLM4S")
+        .timeout(Duration.ofMinutes(5))
+        .POST(HttpRequest.BodyPublishers.ofString(requestBody.render()))
+        .build()
+
+      httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
+    }.toEither.left.map(_.toLLMError)
+
+    // Check HTTP status, returning typed errors for known failure codes
+    val streamOrError = responseOrError.flatMap { response =>
+      if (response.statusCode() == 200) {
+        Right(response)
+      } else {
+        val errorBody = Try(new String(response.body().readAllBytes(), StandardCharsets.UTF_8))
+          .getOrElse("<error body unreadable>")
+        response.statusCode() match {
+          case 401    => Left(AuthenticationError("openrouter", "Invalid API key"))
+          case 429    => Left(RateLimitError("openrouter"))
+          case status => Left(ServiceError(status, "openrouter", s"OpenRouter API error: $errorBody"))
         }
       }
+    }
 
-      // Process the SSE stream, converting any I/O exceptions to Left
-      val attempt = streamOrError.flatMap { response =>
-        Try {
-          val sseParser = SSEParser.createStreamingParser()
-          val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
-          try {
-            var line: String = null
-            while ({ line = reader.readLine(); line != null }) {
-              sseParser.addChunk(line + "\n")
-              while (sseParser.hasEvents)
-                sseParser.nextEvent().foreach { event =>
-                  event.data.foreach { data =>
-                    if (data != "[DONE]") {
-                      val json   = ujson.read(data)
-                      val chunks = parseStreamingChunks(json)
-                      chunks.foreach { c =>
-                        accumulator.addChunk(c)
-                        onChunk(c)
-                      }
+    // Process the SSE stream, converting any I/O exceptions to Left
+    val attempt = streamOrError.flatMap { response =>
+      Try {
+        val sseParser = SSEParser.createStreamingParser()
+        val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
+        try {
+          var line: String = null
+          while ({ line = reader.readLine(); line != null }) {
+            sseParser.addChunk(line + "\n")
+            while (sseParser.hasEvents)
+              sseParser.nextEvent().foreach { event =>
+                event.data.foreach { data =>
+                  if (data != "[DONE]") {
+                    val json   = ujson.read(data)
+                    val chunks = parseStreamingChunks(json)
+                    chunks.foreach { c =>
+                      accumulator.addChunk(c)
+                      onChunk(c)
                     }
                   }
                 }
-            }
-          } finally {
-            Try(reader.close())
-            Try(response.body().close())
+              }
           }
-        }.toEither.left.map(_.toLLMError)
-      }
-
-      attempt.flatMap(_ =>
-        accumulator.toCompletion.map { c =>
-          val cost = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
-          c.copy(model = config.model, estimatedCost = cost)
+        } finally {
+          Try(reader.close())
+          Try(response.body().close())
         }
-      )
-    },
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
+      }.toEither.left.map(_.toLLMError)
+    }
+
+    attempt.flatMap(_ =>
+      accumulator.toCompletion.map { c =>
+        val cost = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
+        c.copy(model = config.model, estimatedCost = cost)
+      }
+    )
+  }
 
   private def parseStreamingChunks(json: ujson.Value): Seq[StreamedChunk] = {
     val choices = json("choices").arr

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/ZaiClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/ZaiClient.scala
@@ -36,145 +36,134 @@ import scala.util.Try
 class ZaiClient(
   config: ZaiConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop
-) extends BaseLifecycleLLMClient
-    with MetricsRecording {
+) extends BaseLifecycleLLMClient {
   private val httpClient = HttpClient.newHttpClient()
   private val logger     = org.slf4j.LoggerFactory.getLogger(getClass)
 
   protected def clientDescription: String = s"Z.ai client for model ${config.model}"
+  protected def providerName: String      = "zai"
+  protected def modelName: String         = config.model
 
   override def complete(
     conversation: Conversation,
     options: CompletionOptions
-  ): Result[Completion] = withMetrics(
-    provider = "zai",
-    model = config.model,
-    operation = validateNotClosed.flatMap { _ =>
-      val requestBody = createRequestBody(conversation, options)
+  ): Result[Completion] = completeWithMetrics {
+    val requestBody = createRequestBody(conversation, options)
 
-      logger.debug(s"Sending request to Z.ai API at ${config.baseUrl}/chat/completions")
-      logger.debug(s"Request body: ${Redaction.redactForLogging(requestBody.render())}")
+    logger.debug(s"Sending request to Z.ai API at ${config.baseUrl}/chat/completions")
+    logger.debug(s"Request body: ${Redaction.redactForLogging(requestBody.render())}")
 
-      val attempt =
-        Try {
-          val request = HttpRequest
-            .newBuilder()
-            .uri(URI.create(s"${config.baseUrl}/chat/completions"))
-            .header("Content-Type", "application/json")
-            .header("Authorization", s"Bearer ${config.apiKey}")
-            .header("User-Agent", "llm4s-coding-assistant/1.0")
-            .POST(HttpRequest.BodyPublishers.ofString(requestBody.render()))
-            .build()
-
-          val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
-
-          logger.debug(s"Response status: ${response.statusCode()}")
-          logger.debug(s"Response body: ${Redaction.redactForLogging(response.body())}")
-
-          response
-        }.toEither.left
-          .map(_.toLLMError)
-
-      attempt.flatMap { response =>
-        response.statusCode() match {
-          case 200 =>
-            val responseJson = ujson.read(response.body())
-            Right(parseCompletion(responseJson))
-          case 401 => Left(AuthenticationError("zai", "Invalid API key"))
-          case 429 => Left(RateLimitError("zai"))
-          case status =>
-            Left(
-              ServiceError(
-                status,
-                "zai",
-                s"Z.ai API error: ${org.llm4s.util.Redaction.truncateForLog(response.body())}"
-              )
-            )
-        }
-      }
-    },
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
-
-  override def streamComplete(
-    conversation: Conversation,
-    options: CompletionOptions = CompletionOptions(),
-    onChunk: StreamedChunk => Unit
-  ): Result[Completion] = withMetrics(
-    provider = "zai",
-    model = config.model,
-    operation = validateNotClosed.flatMap { _ =>
-      val requestBody = createRequestBody(conversation, options)
-      requestBody("stream") = true
-
-      val accumulator = StreamingAccumulator.create()
-
-      val requestResult = Try {
+    val attempt =
+      Try {
         val request = HttpRequest
           .newBuilder()
           .uri(URI.create(s"${config.baseUrl}/chat/completions"))
           .header("Content-Type", "application/json")
           .header("Authorization", s"Bearer ${config.apiKey}")
           .header("User-Agent", "llm4s-coding-assistant/1.0")
-          .timeout(Duration.ofMinutes(5))
           .POST(HttpRequest.BodyPublishers.ofString(requestBody.render()))
           .build()
 
-        httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
-      }.toEither.left.map(_.toLLMError)
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
 
-      requestResult.flatMap { response =>
-        if (response.statusCode() != 200) {
-          val errorBody = new String(response.body().readAllBytes(), StandardCharsets.UTF_8)
-          response.statusCode() match {
-            case 401 => Left(AuthenticationError("zai", "Invalid API key"))
-            case 429 => Left(RateLimitError("zai"))
-            case status =>
-              Left(
-                ServiceError(status, "zai", s"Z.ai API error: ${org.llm4s.util.Redaction.truncateForLog(errorBody)}")
-              )
-          }
-        } else {
-          val streamResult = Try {
-            val sseParser = SSEParser.createStreamingParser()
-            val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
-            try {
-              var line: String = null
-              while ({ line = reader.readLine(); line != null }) {
-                sseParser.addChunk(line + "\n")
-                while (sseParser.hasEvents)
-                  sseParser.nextEvent().foreach { event =>
-                    event.data.foreach { data =>
-                      if (data != "[DONE]") {
-                        val json   = ujson.read(data)
-                        val chunks = parseStreamingChunks(json)
-                        chunks.foreach { c =>
-                          accumulator.addChunk(c)
-                          onChunk(c)
-                        }
+        logger.debug(s"Response status: ${response.statusCode()}")
+        logger.debug(s"Response body: ${Redaction.redactForLogging(response.body())}")
+
+        response
+      }.toEither.left
+        .map(_.toLLMError)
+
+    attempt.flatMap { response =>
+      response.statusCode() match {
+        case 200 =>
+          val responseJson = ujson.read(response.body())
+          Right(parseCompletion(responseJson))
+        case 401 => Left(AuthenticationError("zai", "Invalid API key"))
+        case 429 => Left(RateLimitError("zai"))
+        case status =>
+          Left(
+            ServiceError(
+              status,
+              "zai",
+              s"Z.ai API error: ${org.llm4s.util.Redaction.truncateForLog(response.body())}"
+            )
+          )
+      }
+    }
+  }
+
+  override def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions(),
+    onChunk: StreamedChunk => Unit
+  ): Result[Completion] = completeWithMetrics {
+    val requestBody = createRequestBody(conversation, options)
+    requestBody("stream") = true
+
+    val accumulator = StreamingAccumulator.create()
+
+    val requestResult = Try {
+      val request = HttpRequest
+        .newBuilder()
+        .uri(URI.create(s"${config.baseUrl}/chat/completions"))
+        .header("Content-Type", "application/json")
+        .header("Authorization", s"Bearer ${config.apiKey}")
+        .header("User-Agent", "llm4s-coding-assistant/1.0")
+        .timeout(Duration.ofMinutes(5))
+        .POST(HttpRequest.BodyPublishers.ofString(requestBody.render()))
+        .build()
+
+      httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
+    }.toEither.left.map(_.toLLMError)
+
+    requestResult.flatMap { response =>
+      if (response.statusCode() != 200) {
+        val errorBody = new String(response.body().readAllBytes(), StandardCharsets.UTF_8)
+        response.statusCode() match {
+          case 401 => Left(AuthenticationError("zai", "Invalid API key"))
+          case 429 => Left(RateLimitError("zai"))
+          case status =>
+            Left(
+              ServiceError(status, "zai", s"Z.ai API error: ${org.llm4s.util.Redaction.truncateForLog(errorBody)}")
+            )
+        }
+      } else {
+        val streamResult = Try {
+          val sseParser = SSEParser.createStreamingParser()
+          val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
+          try {
+            var line: String = null
+            while ({ line = reader.readLine(); line != null }) {
+              sseParser.addChunk(line + "\n")
+              while (sseParser.hasEvents)
+                sseParser.nextEvent().foreach { event =>
+                  event.data.foreach { data =>
+                    if (data != "[DONE]") {
+                      val json   = ujson.read(data)
+                      val chunks = parseStreamingChunks(json)
+                      chunks.foreach { c =>
+                        accumulator.addChunk(c)
+                        onChunk(c)
                       }
                     }
                   }
-              }
-            } finally {
-              Try(reader.close())
-              Try(response.body().close())
+                }
             }
-          }.toEither.left.map(_.toLLMError)
+          } finally {
+            Try(reader.close())
+            Try(response.body().close())
+          }
+        }.toEither.left.map(_.toLLMError)
 
-          streamResult.flatMap(_ =>
-            accumulator.toCompletion.map { c =>
-              val cost = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
-              c.copy(model = config.model, estimatedCost = cost)
-            }
-          )
-        }
+        streamResult.flatMap(_ =>
+          accumulator.toCompletion.map { c =>
+            val cost = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
+            c.copy(model = config.model, estimatedCost = cost)
+          }
+        )
       }
-    },
-    extractUsage = (c: Completion) => c.usage,
-    extractCost = (c: Completion) => c.estimatedCost
-  )
+    }
+  }
 
   private def parseStreamingChunks(json: ujson.Value): Seq[StreamedChunk] = {
     val choices = json("choices").arr


### PR DESCRIPTION
## Summary

- Add `completeWithMetrics` convenience method to `BaseLifecycleLLMClient` that combines lifecycle validation (`validateNotClosed`) with metrics recording (`withMetrics`) and standard `Completion` extractors
- `BaseLifecycleLLMClient` now mixes in `MetricsRecording` directly, so individual providers no longer need `with MetricsRecording`
- New abstract members `providerName` and `modelName` supply metrics labels, replacing repeated string literals across all providers
- All 9 provider clients updated: `complete()` and `streamComplete()` now delegate to `completeWithMetrics { ... }` instead of repeating identical boilerplate

Net reduction of ~57 lines across 10 files with zero behavioral change.

Addresses Issue 2.3 from the strategic report.

## Test plan

- [x] All 5481 existing tests pass on both Scala 2.13 and 3.x (`sbt +test`)
- [x] `sbt scalafmtAll` applied
- [x] Pre-commit hooks pass
- [x] Verified no remaining `withMetrics(` calls in provider files (only in `BaseLifecycleLLMClient`)
- [x] Verified no remaining `with MetricsRecording` in provider files