### PR TITLE
fix: update line indexing in schema properties from 0-indexed to 1-indexed

### DIFF
--- a/modules/workspace/workspaceClient/src/main/scala/org/llm4s/toolapi/WorkspaceTools.scala
+++ b/modules/workspace/workspaceClient/src/main/scala/org/llm4s/toolapi/WorkspaceTools.scala
@@ -80,14 +80,14 @@ object WorkspaceTools {
         .withProperty(
           Schema.property(
             "start_line",
-            Schema.integer("Start line for reading (0-indexed)"),
+            Schema.integer("Start line for reading (1-indexed)"),
             required = false
           )
         )
         .withProperty(
           Schema.property(
             "end_line",
-            Schema.integer("End line for reading (0-indexed)"),
+            Schema.integer("End line for reading (1-indexed)"),
             required = false
           )
         )
@@ -273,10 +273,10 @@ object WorkspaceTools {
         )
       )
       .withProperty(
-        Schema.property("start_line", Schema.integer("Start line for the operation (0-indexed)"))
+        Schema.property("start_line", Schema.integer("Start line for the operation (1-indexed)"))
       )
       .withProperty(
-        Schema.property("end_line", Schema.integer("End line for the operation (0-indexed)"))
+        Schema.property("end_line", Schema.integer("End line for the operation (1-indexed)"))
       )
       .withProperty(
         Schema.property(


### PR DESCRIPTION
What does this PR do

This change resolves a long‑standing mismatch between the documentation/schema and the actual implementation of workspace tools. Schemas and docs advertised 0‑indexed line numbers for read/modify/search operations, while the runner treated them as 1‑indexed. That resulted in off‑by‑one reads, incorrect modifications and misleading search results.
Everything is now consistently 1‑indexed, with clear comments, updated schemas, docs and tests.

Related issue
fixes: https://github.com/llm4s/llm4s/issues/717

How was this tested?
->Added/updated unit tests across `workspaceRunner` ,` workspaceShared` , and `workspaceClient`:
-Range reading tests, clamping, invalid ranges, insert `behaviour`.
-Search line numbering assertion.
-Schema validation via new `WorkspaceToolsSpec`.
-Serialization tests remained valid with explanatory comments.
->Manual verification by calling `readFile`/`modifyFile` with 0‑indexed parameters.
->Documentation review and examples updated.
