### PR TITLE
fix: harden SSRF redirect handling with header stripping and method conversion

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/http/HTTPTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/http/HTTPTool.scala
@@ -125,7 +125,11 @@ object HTTPTool {
    */
   val toolSafe: Result[ToolFunction[Map[String, Any], HTTPResult]] = createSafe()
 
-  private[http] def makeRequest(
+  /** Headers that must be stripped when a redirect crosses to a different host. */
+  private val SensitiveHeaders: Set[String] =
+    Set("authorization", "cookie", "proxy-authorization")
+
+  private def makeRequest(
     urlStr: String,
     method: String,
     headers: Option[Map[String, String]],
@@ -148,63 +152,86 @@ object HTTPTool {
        *  4. If the response is 3xx and we still have hops left, extract
        *     the `Location` header, resolve it to an absolute URL, and loop.
        *
-       * This prevents the open-redirect SSRF bypass where an attacker
-       * supplies a "safe" initial URL that subsequently redirects to an
-       * internal address (e.g. 169.254.169.254).
+       * Security measures applied on each redirect:
+       *  - Sensitive headers (Authorization, Cookie) are stripped on cross-origin hops
+       *  - 301/302 convert POST→GET and drop the request body (per HTTP spec)
+       *  - 307/308 preserve the original method and body
        */
-      def go(currentUrlStr: String, hopsLeft: Int): Either[String, HTTPResult] =
+      def go(
+        currentUrlStr: String,
+        currentMethod: String,
+        currentHeaders: Option[Map[String, String]],
+        currentBody: Option[String],
+        previousHost: Option[String],
+        hopsLeft: Int
+      ): Either[String, HTTPResult] =
         Try(URI.create(currentUrlStr).toURL).toEither.left
           .map(e => s"Invalid URL: ${e.getMessage}")
           .flatMap { url =>
-            // Layer 1: scheme enforcement – only http and https are permitted.
-            // Rejecting alternative schemes (file, ftp, gopher, jar, mailto, …)
-            // prevents protocol-smuggling attacks even when a redirect is involved.
             val scheme = url.getProtocol.toLowerCase
             if (scheme != "http" && scheme != "https")
               Left(
                 s"UNSUPPORTED_PROTOCOL: Only http and https are allowed (got: '$scheme')"
               )
             else {
-              // Layer 2: SSRF domain/IP validation.
               val domain = Option(url.getHost).getOrElse("")
               if (domain.isEmpty)
                 Left("URL has no host")
               else if (!config.validateDomainWithSSRF(domain))
                 Left(s"SSRF_BLOCKED: domain '$domain' is not allowed")
-              else
-                executeRequest(url, currentUrlStr, method, headers, body, contentType, config).flatMap { result =>
-                  // Only treat standard redirect codes as redirects.
-                  // 304 (Not Modified) and other 3xx codes are not redirects.
-                  val isRedirect =
-                    Set(301, 302, 307, 308).contains(result.statusCode)
-                  if (config.followRedirects && isRedirect) {
-                    // Case-insensitive lookup – servers capitalise headers inconsistently.
-                    val locationOpt =
-                      result.headers
-                        .find { case (k, _) => k.equalsIgnoreCase("Location") }
-                        .map(_._2)
-                    locationOpt match {
-                      case None =>
-                        Right(result) // No Location header; return the redirect as-is.
-                      case Some(_) if hopsLeft <= 0 =>
-                        Left(
-                          s"TOO_MANY_REDIRECTS: Too many redirects (max ${config.maxRedirects})"
-                        )
-                      case Some(location) =>
-                        // Resolve relative Location values against the current URL so that
-                        // paths like "/callback" or "../other" are handled correctly.
-                        val absoluteLocation =
-                          Try(url.toURI.resolve(location).toString).getOrElse(location)
-                        go(absoluteLocation, hopsLeft - 1)
-                    }
-                  } else {
-                    Right(result)
-                  }
+              else {
+                // Strip sensitive headers when the redirect crosses to a different host.
+                val safeHeaders = previousHost match {
+                  case Some(prevHost) if !prevHost.equalsIgnoreCase(domain) =>
+                    currentHeaders.map(_.filterNot { case (k, _) =>
+                      SensitiveHeaders.contains(k.toLowerCase)
+                    })
+                  case _ => currentHeaders
                 }
+
+                executeRequest(url, currentUrlStr, currentMethod, safeHeaders, currentBody, contentType, config)
+                  .flatMap { result =>
+                    val isRedirect =
+                      Set(301, 302, 307, 308).contains(result.statusCode)
+                    if (config.followRedirects && isRedirect) {
+                      val locationOpt =
+                        result.headers
+                          .find { case (k, _) => k.equalsIgnoreCase("Location") }
+                          .map(_._2)
+                      locationOpt match {
+                        case None =>
+                          Right(result)
+                        case Some(_) if hopsLeft <= 0 =>
+                          Left(
+                            s"TOO_MANY_REDIRECTS: Too many redirects (max ${config.maxRedirects})"
+                          )
+                        case Some(location) =>
+                          val absoluteLocation =
+                            Try(url.toURI.resolve(location).toString).getOrElse(location)
+
+                          // Per HTTP spec: 301/302 convert POST→GET and drop the body.
+                          // 307/308 preserve the original method and body.
+                          val (nextMethod, nextBody) =
+                            if (
+                              Set(301, 302).contains(
+                                result.statusCode
+                              ) && currentMethod.toUpperCase != "GET" && currentMethod.toUpperCase != "HEAD"
+                            )
+                              ("GET", None)
+                            else
+                              (currentMethod, currentBody)
+
+                          go(absoluteLocation, nextMethod, currentHeaders, nextBody, Some(domain), hopsLeft - 1)
+                      }
+                    } else {
+                      Right(result)
+                    }
+                  }
+              }
             }
           }
 
-      go(urlStr, config.maxRedirects)
+      go(urlStr, method, headers, body, previousHost = None, config.maxRedirects)
     }
 
   private def executeRequest(

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/http/HttpConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/http/HttpConfig.scala
@@ -30,7 +30,7 @@ case class HttpConfig(
   blockInternalIPs: Boolean = true,
   maxResponseSize: Long = 10 * 1024 * 1024, // 10 MB
   timeoutMs: Int = 30000,                   // 30 seconds
-  followRedirects: Boolean = false,         // Secure default: redirects are followed only when explicitly opted-in,
+  followRedirects: Boolean = false,         // Secure default: redirects are followed only when explicitly opted-in.
   maxRedirects: Int = 5,
   allowedMethods: Seq[String] = Seq("GET", "HEAD"), // Safe default: read-only
   userAgent: String = "llm4s-http-tool/1.0"
@@ -105,6 +105,16 @@ case class HttpConfig(
    */
   def withInternalIPsAllowed: HttpConfig =
     copy(blockInternalIPs = false)
+
+  /**
+   * Create a copy with redirect following enabled.
+   *
+   * Each redirect hop is re-validated against the SSRF filter, sensitive headers
+   * (Authorization, Cookie) are stripped on cross-origin hops, and 301/302
+   * redirects convert POST to GET per the HTTP specification.
+   */
+  def withRedirectsEnabled: HttpConfig =
+    copy(followRedirects = true)
 }
 
 object HttpConfig {

--- a/modules/core/src/test/scala/org/llm4s/toolapi/builtin/http/HTTPToolSSRFSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/builtin/http/HTTPToolSSRFSpec.scala
@@ -1,11 +1,13 @@
 package org.llm4s.toolapi.builtin.http
 
 import com.sun.net.httpserver.{ HttpExchange, HttpServer }
+import org.llm4s.toolapi.SafeParameterExtractor
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
 
 /**
  * Test suite for SSRF protection and validated redirect handling in [[HTTPTool]].
@@ -136,6 +138,54 @@ class HTTPToolSSRFSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll 
       }
     )
 
+    // /echo-headers → 200 with JSON body echoing received request headers and method
+    server.createContext(
+      "/echo-headers",
+      { (ex: HttpExchange) =>
+        val authHeader    = Option(ex.getRequestHeaders.getFirst("Authorization")).getOrElse("")
+        val cookieHeader  = Option(ex.getRequestHeaders.getFirst("Cookie")).getOrElse("")
+        val customHeader  = Option(ex.getRequestHeaders.getFirst("X-Custom")).getOrElse("")
+        val requestMethod = ex.getRequestMethod
+        val requestBody   = new String(ex.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
+        val body =
+          s"""{"auth":"$authHeader","cookie":"$cookieHeader","custom":"$customHeader","method":"$requestMethod","body":"$requestBody"}"""
+        val bytes = body.getBytes("UTF-8")
+        ex.sendResponseHeaders(200, bytes.length.toLong)
+        ex.getResponseBody.write(bytes)
+        ex.close()
+      }
+    )
+
+    // /redirect-to-echo → 302 Location: /echo-headers (same host)
+    server.createContext(
+      "/redirect-to-echo",
+      { (ex: HttpExchange) =>
+        ex.getResponseHeaders.set("Location", s"http://127.0.0.1:$port/echo-headers")
+        ex.sendResponseHeaders(302, -1)
+        ex.close()
+      }
+    )
+
+    // /redirect-307-to-echo → 307 Location: /echo-headers (method-preserving)
+    server.createContext(
+      "/redirect-307-to-echo",
+      { (ex: HttpExchange) =>
+        ex.getResponseHeaders.set("Location", s"http://127.0.0.1:$port/echo-headers")
+        ex.sendResponseHeaders(307, -1)
+        ex.close()
+      }
+    )
+
+    // /redirect-301-to-echo → 301 Location: /echo-headers
+    server.createContext(
+      "/redirect-301-to-echo",
+      { (ex: HttpExchange) =>
+        ex.getResponseHeaders.set("Location", s"http://127.0.0.1:$port/echo-headers")
+        ex.sendResponseHeaders(301, -1)
+        ex.close()
+      }
+    )
+
     server.setExecutor(null)
     server.start()
   }
@@ -149,24 +199,37 @@ class HTTPToolSSRFSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll 
    * HttpConfig that allows 127.0.0.1 for the test server while keeping
    * 169.254.169.254 (cloud metadata) on the blocked list.
    */
-  def testConfig(followRedirects: Boolean = false, maxRedirects: Int = 5): HttpConfig =
+  def testConfig(
+    followRedirects: Boolean = false,
+    maxRedirects: Int = 5,
+    allowedMethods: Seq[String] = Seq("GET", "POST")
+  ): HttpConfig =
     HttpConfig(
       blockedDomains = Seq("169.254.169.254"),
       blockInternalIPs = false,
       followRedirects = followRedirects,
       maxRedirects = maxRedirects,
-      allowedMethods = Seq("GET")
+      allowedMethods = allowedMethods
     )
 
-  def invoke(config: HttpConfig, url: String): Either[String, HTTPResult] =
-    HTTPTool.makeRequest(
-      urlStr = url,
-      method = "GET",
-      headers = None,
-      body = None,
-      contentType = None,
-      config = config
-    )
+  /** Invoke HTTPTool through the public createSafe API. */
+  def invoke(
+    config: HttpConfig,
+    url: String,
+    method: String = "GET",
+    headers: Option[Map[String, String]] = None,
+    body: Option[String] = None
+  ): Either[String, HTTPResult] = {
+    val params = ujson.Obj("url" -> url, "method" -> method)
+    headers.foreach(h => params("headers") = ujson.Obj.from(h.map { case (k, v) => k -> ujson.Str(v) }))
+    body.foreach(b => params("body") = b)
+    HTTPTool
+      .createSafe(config)
+      .fold(
+        e => Left(s"Tool creation failed: ${e.formatted}"),
+        tool => tool.handler(SafeParameterExtractor(params))
+      )
+  }
 
   // ── SSRF: initial URL validation ──────────────────────────────────────────
 
@@ -222,7 +285,6 @@ class HTTPToolSSRFSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll 
   }
 
   it should "follow a multi-hop safe redirect chain to a final 200 response" in {
-    // /redirect-chain-1 → /redirect-chain-2 → /ok (2 hops, maxRedirects=5)
     val result = invoke(testConfig(followRedirects = true), s"http://127.0.0.1:$port/redirect-chain-1")
     result.isRight shouldBe true
     result.toOption.get.statusCode shouldBe 200
@@ -232,10 +294,6 @@ class HTTPToolSSRFSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll 
   // ── Per-hop SSRF validation (the core fix for Issue #788) ─────────────────
 
   it should "block a redirect that targets the cloud metadata IP (open-redirect SSRF bypass)" in {
-    // Scenario: attacker supplies a URL on a "trusted" host that subsequently
-    // redirects (via 302) to http://169.254.169.254/metadata.
-    // With the fix, the second hop is validated and rejected BEFORE the request
-    // to 169.254.169.254 is ever issued.
     val result = invoke(testConfig(followRedirects = true), s"http://127.0.0.1:$port/redirect-to-blocked")
     result.isLeft shouldBe true
     val err = result.swap.toOption.get
@@ -246,7 +304,6 @@ class HTTPToolSSRFSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll 
   // ── Redirect loop / DoS prevention ───────────────────────────────────────
 
   it should "stop following redirects and return an error after maxRedirects hops" in {
-    // /redirect-self → /redirect-self → … (infinite), maxRedirects=3
     val result = invoke(
       testConfig(followRedirects = true, maxRedirects = 3),
       s"http://127.0.0.1:$port/redirect-self"
@@ -258,7 +315,6 @@ class HTTPToolSSRFSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll 
   }
 
   it should "succeed when the number of hops is exactly maxRedirects" in {
-    // Chain of 2 hops (/chain-1 → /chain-2 → /ok) with maxRedirects=2
     val result = invoke(
       testConfig(followRedirects = true, maxRedirects = 2),
       s"http://127.0.0.1:$port/redirect-chain-1"
@@ -268,7 +324,6 @@ class HTTPToolSSRFSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll 
   }
 
   it should "fail when the number of hops exceeds maxRedirects" in {
-    // Chain of 2 hops but maxRedirects=1: the second redirect is one too many
     val result = invoke(
       testConfig(followRedirects = true, maxRedirects = 1),
       s"http://127.0.0.1:$port/redirect-chain-1"
@@ -280,8 +335,6 @@ class HTTPToolSSRFSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll 
   // ── Case-insensitive Location header ─────────────────────────────────────
 
   it should "follow a redirect when the Location header name is lowercase" in {
-    // The server sends 'location: /ok' (lowercase). Our equalsIgnoreCase lookup
-    // must find it regardless of capitalisation.
     val result = invoke(testConfig(followRedirects = true), s"http://127.0.0.1:$port/redirect-lowercase")
     result.isRight shouldBe true
     result.toOption.get.statusCode shouldBe 200
@@ -307,8 +360,6 @@ class HTTPToolSSRFSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll 
   }
 
   it should "block a redirect that switches to the file:// scheme (protocol smuggling)" in {
-    // Server at /redirect-to-file sends: 302 Location: file:///etc/passwd
-    // The scheme check on the redirect target must fire BEFORE any connection is opened.
     val result = invoke(testConfig(followRedirects = true), s"http://127.0.0.1:$port/redirect-to-file")
     result.isLeft shouldBe true
     val err = result.swap.toOption.get
@@ -329,5 +380,82 @@ class HTTPToolSSRFSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll 
     )
     result.isLeft shouldBe true
     result.swap.toOption.get should include("TOO_MANY_REDIRECTS")
+  }
+
+  // ── 301/302 method conversion (POST → GET per HTTP spec) ──────────────────
+
+  "HTTPTool redirect method handling" should "convert POST to GET on 302 redirect" in {
+    val result = invoke(
+      testConfig(followRedirects = true),
+      s"http://127.0.0.1:$port/redirect-to-echo",
+      method = "POST",
+      body = Some("""{"data":"test"}""")
+    )
+    result.isRight shouldBe true
+    val responseBody = result.toOption.get.body
+    responseBody should include(""""method":"GET"""")
+    responseBody should include(""""body":""""") // body should be empty after conversion
+  }
+
+  it should "convert POST to GET on 301 redirect" in {
+    val result = invoke(
+      testConfig(followRedirects = true),
+      s"http://127.0.0.1:$port/redirect-301-to-echo",
+      method = "POST",
+      body = Some("""{"data":"test"}""")
+    )
+    result.isRight shouldBe true
+    result.toOption.get.body should include(""""method":"GET"""")
+  }
+
+  it should "preserve POST method on 307 redirect" in {
+    val result = invoke(
+      testConfig(followRedirects = true),
+      s"http://127.0.0.1:$port/redirect-307-to-echo",
+      method = "POST",
+      body = Some("""{"data":"test"}""")
+    )
+    result.isRight shouldBe true
+    val responseBody = result.toOption.get.body
+    responseBody should include(""""method":"POST"""")
+  }
+
+  it should "keep GET as GET on 302 redirect" in {
+    val result = invoke(
+      testConfig(followRedirects = true),
+      s"http://127.0.0.1:$port/redirect-to-echo"
+    )
+    result.isRight shouldBe true
+    result.toOption.get.body should include(""""method":"GET"""")
+  }
+
+  // ── Cross-origin sensitive header stripping ───────────────────────────────
+
+  "HTTPTool cross-origin header stripping" should "preserve all headers on same-host redirect" in {
+    val hdrs = Some(Map("Authorization" -> "Bearer secret", "X-Custom" -> "keep-me"))
+    val result = invoke(
+      testConfig(followRedirects = true),
+      s"http://127.0.0.1:$port/redirect-to-echo",
+      headers = hdrs
+    )
+    result.isRight shouldBe true
+    val responseBody = result.toOption.get.body
+    // Same host redirect: Authorization should be preserved
+    responseBody should include(""""auth":"Bearer secret"""")
+    responseBody should include(""""custom":"keep-me"""")
+  }
+
+  // ── withRedirectsEnabled convenience method ────────────────────────────────
+
+  "HttpConfig.withRedirectsEnabled" should "enable redirect following" in {
+    val config = HttpConfig().withRedirectsEnabled
+    config.followRedirects shouldBe true
+  }
+
+  it should "preserve other settings" in {
+    val config = HttpConfig(maxRedirects = 10, timeoutMs = 5000).withRedirectsEnabled
+    config.followRedirects shouldBe true
+    config.maxRedirects shouldBe 10
+    config.timeoutMs shouldBe 5000
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #808 (SSRF open-redirect fix), addressing review items:

- **Strip sensitive headers on cross-origin redirects**: Authorization, Cookie, and Proxy-Authorization headers are removed when a redirect crosses to a different host, preventing credential leakage
- **301/302 method conversion**: POST is converted to GET and the request body is dropped on 301/302 redirects per HTTP spec; 307/308 preserve the original method and body
- **`withRedirectsEnabled` convenience method**: Added to `HttpConfig` for discoverability
- **Revert `makeRequest` visibility**: Changed back from `private[http]` to `private`; tests now exercise the public `createSafe` API
- **Fix trailing comma in comment**: Minor doc fix in `HttpConfig`

## Test plan

- [x] All 5527 tests pass (21 SSRF tests including 7 new ones)
- [x] 301/302 POST→GET conversion verified (3 tests)
- [x] 307 method preservation verified (1 test)
- [x] Same-host header preservation on redirect verified (1 test)
- [x] `withRedirectsEnabled` convenience method verified (2 tests)
- [x] All existing SSRF tests continue to pass through public API