### PR TITLE
Add analyzeImageAsync to ImageProcessingClient 

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/imageprocessing/ImageProcessing.scala
+++ b/modules/core/src/main/scala/org/llm4s/imageprocessing/ImageProcessing.scala
@@ -4,6 +4,7 @@ import org.llm4s.imageprocessing.config._
 import org.llm4s.imageprocessing.provider._
 import org.llm4s.imageprocessing.provider.anthropicclient.AnthropicVisionClient
 import org.llm4s.error.LLMError
+import scala.concurrent.{ ExecutionContext, Future, blocking }
 
 /**
  * Factory object for creating image processing clients.
@@ -71,6 +72,26 @@ trait ImageProcessingClient {
     imagePath: String,
     prompt: Option[String] = None
   ): Either[LLMError, ImageAnalysisResult]
+
+  /**
+   * Analyzes an image asynchronously, returning a Future.
+   * Uses Option A: wraps the existing blocking analyzeImage call in a Future
+   * with a configurable ExecutionContext.
+   *
+   * @param imagePath Path to the image file
+   * @param prompt Optional prompt to guide the analysis
+   * @param ec ExecutionContext to run the blocking call on
+   * @return Future of Either error or image analysis result
+   */
+  def analyzeImageAsync(
+    imagePath: String,
+    prompt: Option[String] = None
+  )(implicit ec: ExecutionContext): Future[Either[LLMError, ImageAnalysisResult]] =
+    Future {
+      blocking {
+        analyzeImage(imagePath, prompt)
+      }
+    }
 
   /**
    * Preprocesses an image with specified operations.

--- a/modules/core/src/main/scala/org/llm4s/imageprocessing/provider/LocalImageProcessor.scala
+++ b/modules/core/src/main/scala/org/llm4s/imageprocessing/provider/LocalImageProcessor.scala
@@ -9,6 +9,7 @@ import java.io.{ ByteArrayOutputStream, File }
 import javax.imageio.ImageIO
 import java.time.Instant
 import scala.util.Try
+import scala.concurrent.{ ExecutionContext, Future, blocking }
 
 /**
  * Local image processor that uses Java's built-in image processing capabilities.
@@ -44,6 +45,16 @@ class LocalImageProcessor extends org.llm4s.imageprocessing.ImageProcessingClien
           )
         }
       }
+
+  override def analyzeImageAsync(
+    imagePath: String,
+    prompt: Option[String] = None
+  )(implicit ec: ExecutionContext): Future[Either[LLMError, ImageAnalysisResult]] =
+    Future {
+      blocking {
+        analyzeImage(imagePath, prompt)
+      }
+    }
 
   override def preprocessImage(
     imagePath: String,

--- a/modules/core/src/main/scala/org/llm4s/imageprocessing/provider/OpenAIVisionClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/imageprocessing/provider/OpenAIVisionClient.scala
@@ -13,6 +13,7 @@ import java.time.{ Duration, Instant }
 import java.util.Base64
 import scala.util.Try
 import scala.util.control.NonFatal
+import scala.concurrent.{ ExecutionContext, Future, blocking }
 
 /**
  * OpenAI Vision client for AI-powered image analysis using GPT-4 Vision.
@@ -55,6 +56,16 @@ class OpenAIVisionClient(config: OpenAIVisionConfig) extends org.llm4s.imageproc
       visionResponse <- callOpenAIVisionAPI(base64Image, analysisPrompt, mediaType).toEither.left
         .map(e => LLMError.apiCallFailed("OpenAI", s"OpenAI Vision API call failed: ${e.getMessage}"))
     } yield parseVisionResponse(visionResponse, metadata)
+
+  override def analyzeImageAsync(
+    imagePath: String,
+    prompt: Option[String] = None
+  )(implicit ec: ExecutionContext): Future[Either[LLMError, ImageAnalysisResult]] =
+    Future {
+      blocking {
+        analyzeImage(imagePath, prompt)
+      }
+    }
 
   /**
    * Preprocesses an image by applying a sequence of operations.

--- a/modules/core/src/main/scala/org/llm4s/imageprocessing/provider/anthropicclient/AnthropicVisionClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/imageprocessing/provider/anthropicclient/AnthropicVisionClient.scala
@@ -14,6 +14,7 @@ import java.time.{ Duration, Instant }
 import java.util.Base64
 import scala.util.Try
 import scala.util.control.NonFatal
+import scala.concurrent.{ ExecutionContext, Future, blocking }
 
 /**
  * Anthropic Claude Vision client for AI-powered image analysis.
@@ -59,6 +60,16 @@ class AnthropicVisionClient(config: AnthropicVisionConfig) extends org.llm4s.ima
       visionResponse <- callAnthropicVisionAPI(base64Image, analysisPrompt, mediaType).toEither.left
         .map(e => LLMError.apiCallFailed("Anthropic", s"Anthropic Vision API call failed: ${e.getMessage}"))
     } yield parseVisionResponse(visionResponse, metadata) // Parse the response and extract structured information
+
+  override def analyzeImageAsync(
+    imagePath: String,
+    prompt: Option[String] = None
+  )(implicit ec: ExecutionContext): Future[Either[LLMError, ImageAnalysisResult]] =
+    Future {
+      blocking {
+        analyzeImage(imagePath, prompt)
+      }
+    }
 
   /**
    * Preprocesses an image by applying a sequence of operations.

--- a/modules/core/src/test/scala/org/llm4s/imageprocessing/provider/AnthropicVisionClientTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/imageprocessing/provider/AnthropicVisionClientTest.scala
@@ -10,6 +10,9 @@ import java.nio.file.Files
 import java.awt.image.BufferedImage
 import java.awt.Color
 import javax.imageio.ImageIO
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class AnthropicVisionClientTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
@@ -185,5 +188,33 @@ class AnthropicVisionClientTest extends AnyFlatSpec with Matchers with BeforeAnd
       Files.deleteIfExists(pngFile)
       Files.deleteIfExists(jpgFile)
     }
+  }
+
+  it should "analyzeImageAsync completes with Left for invalid API key" in {
+    val client = new AnthropicVisionClient(config)
+
+    val future = client.analyzeImageAsync(tempFile.toString, None)
+    val result = Await.result(future, 15.seconds)
+
+    // Will fail with API error since key is invalid — but must complete, not throw
+    result.isLeft shouldBe true
+  }
+
+  it should "analyzeImageAsync with prompt completes with Left for invalid API key" in {
+    val client = new AnthropicVisionClient(config)
+
+    val future = client.analyzeImageAsync(tempFile.toString, Some("Describe this image"))
+    val result = Await.result(future, 15.seconds)
+
+    result.isLeft shouldBe true
+  }
+
+  it should "analyzeImageAsync returns Left for non-existent file" in {
+    val client = new AnthropicVisionClient(config)
+
+    val future = client.analyzeImageAsync("/nonexistent/file.png", None)
+    val result = Await.result(future, 10.seconds)
+
+    result.isLeft shouldBe true
   }
 }

--- a/modules/core/src/test/scala/org/llm4s/imageprocessing/provider/LocalImageProcessorTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/imageprocessing/provider/LocalImageProcessorTest.scala
@@ -7,6 +7,9 @@ import java.nio.file.{ Files, Paths }
 import java.awt.image.BufferedImage
 import java.awt.Color
 import javax.imageio.ImageIO
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class LocalImageProcessorTest extends AnyFlatSpec with Matchers {
 
@@ -300,6 +303,58 @@ class LocalImageProcessorTest extends AnyFlatSpec with Matchers {
         processedImage.format shouldBe ImageFormat.WEBP
         // The actual file content would be PNG format
       }
+    } finally
+      Files.deleteIfExists(tempFile)
+  }
+
+  it should "analyzeImageAsync returns successful result for valid image" in {
+    val tempFile = Files.createTempFile("test", ".png")
+    try {
+      val testImage = createTestImage(100, 100)
+      saveTestImage(testImage, tempFile.toString)
+
+      val future = processor.analyzeImageAsync(tempFile.toString, None)
+      val result = Await.result(future, 10.seconds)
+
+      result.isRight shouldBe true
+      result.foreach { analysis =>
+        analysis.description should include("100x100")
+        analysis.confidence should be > 0.0
+      }
+    } finally
+      Files.deleteIfExists(tempFile)
+  }
+
+  it should "analyzeImageAsync with prompt returns successful result" in {
+    val tempFile = Files.createTempFile("test", ".png")
+    try {
+      val testImage = createTestImage(50, 50)
+      saveTestImage(testImage, tempFile.toString)
+
+      val future = processor.analyzeImageAsync(tempFile.toString, Some("Describe the colors"))
+      val result = Await.result(future, 10.seconds)
+
+      result.isRight shouldBe true
+    } finally
+      Files.deleteIfExists(tempFile)
+  }
+
+  it should "analyzeImageAsync returns Left for non-existent image" in {
+    val future = processor.analyzeImageAsync("/nonexistent/image.png", None)
+    val result = Await.result(future, 10.seconds)
+
+    result.isLeft shouldBe true
+  }
+
+  it should "analyzeImageAsync returns Left for invalid image file" in {
+    val tempFile = Files.createTempFile("notanimage", ".txt")
+    try {
+      Files.write(tempFile, "not an image".getBytes)
+
+      val future = processor.analyzeImageAsync(tempFile.toString, None)
+      val result = Await.result(future, 10.seconds)
+
+      result.isLeft shouldBe true
     } finally
       Files.deleteIfExists(tempFile)
   }

--- a/modules/core/src/test/scala/org/llm4s/imageprocessing/provider/OpenAIVisionClientTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/imageprocessing/provider/OpenAIVisionClientTest.scala
@@ -9,6 +9,9 @@ import java.nio.file.Files
 import java.awt.image.BufferedImage
 import java.awt.Color
 import javax.imageio.ImageIO
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class OpenAIVisionClientTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
@@ -172,6 +175,34 @@ class OpenAIVisionClientTest extends AnyFlatSpec with Matchers with BeforeAndAft
 
     // Test network error handling
     val result = client.analyzeImage(tempFile.toString, None)
+    result.isLeft shouldBe true
+  }
+
+  it should "analyzeImageAsync completes with Left for invalid API key" in {
+    val client = new OpenAIVisionClient(config)
+
+    val future = client.analyzeImageAsync(tempFile.toString, None)
+    val result = Await.result(future, 15.seconds)
+
+    // Will fail with API error since key is invalid — but must complete, not throw
+    result.isLeft shouldBe true
+  }
+
+  it should "analyzeImageAsync with prompt completes with Left for invalid API key" in {
+    val client = new OpenAIVisionClient(config)
+
+    val future = client.analyzeImageAsync(tempFile.toString, Some("Describe this image"))
+    val result = Await.result(future, 15.seconds)
+
+    result.isLeft shouldBe true
+  }
+
+  it should "analyzeImageAsync returns Left for non-existent file" in {
+    val client = new OpenAIVisionClient(config)
+
+    val future = client.analyzeImageAsync("/nonexistent/file.png", None)
+    val result = Await.result(future, 10.seconds)
+
     result.isLeft shouldBe true
   }
 }


### PR DESCRIPTION
Add async/Future-based analyzeImageAsync variant to ImageProcessingClient trait and all concrete implementations (OpenAIVisionClient, AnthropicVisionClient, LocalImageProcessor), completing the async API requested in issue #499.

Changes:
- ImageProcessing.scala: add default analyzeImageAsync method to trait using Future { blocking { analyzeImage(...) } } pattern
- OpenAIVisionClient.scala: add override for analyzeImageAsync
- AnthropicVisionClient.scala: add override for analyzeImageAsync
- LocalImageProcessor.scala: add override for analyzeImageAsync
- LocalImageProcessorTest.scala: add 4 async tests (success + error paths)
- OpenAIVisionClientTest.scala: add 3 async tests (invalid key + missing file)
- AnthropicVisionClientTest.scala: add 3 async tests (invalid key + missing file)

All 223 tests pass (131 imagegeneration + 92 imageprocessing).
 