### PR TITLE
feat: integrate image generation with cost tracking and metrics (#501)

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/ImageGeneration.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/ImageGeneration.scala
@@ -13,6 +13,8 @@ import org.llm4s.imagegeneration.provider.{
 import scala.annotation.unused
 import scala.util.Try
 import scala.concurrent.{ Future, ExecutionContext }
+import org.llm4s.metrics.MetricsCollector
+import org.llm4s.trace.Tracing
 
 // ===== ERROR HANDLING =====
 
@@ -344,23 +346,34 @@ object ImageGeneration {
   def client(
     config: ImageGenerationConfig
   ): Either[ImageGenerationError, ImageGenerationClient] =
-    // metrics and tracing are ignored in this PR 1 version as instrumentation is added in a later PR
-    config match {
-      case sdConfig: StableDiffusionConfig =>
-        val httpClient = HttpClient.create()
-        Right(new StableDiffusionClient(sdConfig, httpClient))
-      case hfConfig: HuggingFaceConfig =>
-        val httpClient = HttpClient.create()
-        Right(new HuggingFaceClient(hfConfig, httpClient))
-      case openAIConfig: OpenAIConfig =>
-        val httpClient = HttpClient.create()
-        Right(new OpenAIImageClient(openAIConfig, httpClient))
-      case stabilityAIConfig: StabilityAIConfig =>
-        val httpClient = HttpClient.create()
-        Right(new StabilityAIClient(stabilityAIConfig, httpClient))
-      case _ =>
-        Left(UnsupportedOperation(s"Provider ${config.provider} is not supported."))
-    }
+    createBaseClient(config)
+
+  /** Factory method for getting an instrumented client with metrics and tracing */
+  def client(
+    config: ImageGenerationConfig,
+    metrics: MetricsCollector,
+    tracing: Tracing
+  ): Either[ImageGenerationError, ImageGenerationClient] =
+    createBaseClient(config).map(c => new InstrumentedImageGenerationClient(c, config, metrics, tracing))
+
+  private def createBaseClient(
+    config: ImageGenerationConfig
+  ): Either[ImageGenerationError, ImageGenerationClient] = config match {
+    case sdConfig: StableDiffusionConfig =>
+      val httpClient = HttpClient.create()
+      Right(new StableDiffusionClient(sdConfig, httpClient))
+    case hfConfig: HuggingFaceConfig =>
+      val httpClient = HttpClient.create()
+      Right(new HuggingFaceClient(hfConfig, httpClient))
+    case openAIConfig: OpenAIConfig =>
+      val httpClient = HttpClient.create()
+      Right(new OpenAIImageClient(openAIConfig, httpClient))
+    case stabilityAIConfig: StabilityAIConfig =>
+      val httpClient = HttpClient.create()
+      Right(new StabilityAIClient(stabilityAIConfig, httpClient))
+    case _ =>
+      Left(UnsupportedOperation(s"Provider ${config.provider} is not supported."))
+  }
 
   /** Convenience method for quick image generation */
   def generateImage(

--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/ImagePricingRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/ImagePricingRegistry.scala
@@ -34,6 +34,12 @@ object ImagePricingRegistry {
    *
    * Prices are approximate and may change. For the most accurate pricing,
    * consult the provider's pricing page.
+   *
+   * Note: Cost estimation uses the requested size, not the actual provider-billed
+   * dimensions. For models like dall-e-3 that normalize non-standard sizes to
+   * their nearest supported size, actual billing may differ.
+   *
+   * Last verified: July 2025
    */
   private val pricingTable: Map[(String, String, String), Double] = Map(
     // gpt-image-1

--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/ImagePricingRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/ImagePricingRegistry.scala
@@ -1,0 +1,126 @@
+package org.llm4s.imagegeneration
+
+/**
+ * Registry of image generation model pricing.
+ *
+ * Provides per-image cost lookup for supported image generation models.
+ * Costs are in USD per image and vary by model, size, and quality.
+ *
+ * Pricing sources:
+ *  - OpenAI: https://openai.com/api/pricing/
+ *  - Stability AI: https://platform.stability.ai/pricing
+ *
+ * @see [[org.llm4s.model.ModelPricing]] for LLM token-based pricing
+ */
+object ImagePricingRegistry {
+
+  /**
+   * Pricing entry for an image generation model configuration.
+   *
+   * @param costPerImage Cost in USD per generated image
+   * @param model Model identifier
+   * @param quality Quality level (e.g., "standard", "hd")
+   * @param size Image size descriptor (e.g., "1024x1024")
+   */
+  case class ImagePricingEntry(
+    costPerImage: Double,
+    model: String,
+    quality: String,
+    size: String
+  )
+
+  /**
+   * Known pricing entries for image generation models.
+   *
+   * Prices are approximate and may change. For the most accurate pricing,
+   * consult the provider's pricing page.
+   */
+  private val pricingTable: Map[(String, String, String), Double] = Map(
+    // gpt-image-1
+    ("gpt-image-1", "low", "1024x1024")    -> 0.011,
+    ("gpt-image-1", "low", "1536x1024")    -> 0.016,
+    ("gpt-image-1", "low", "1024x1536")    -> 0.016,
+    ("gpt-image-1", "low", "auto")         -> 0.011,
+    ("gpt-image-1", "medium", "1024x1024") -> 0.042,
+    ("gpt-image-1", "medium", "1536x1024") -> 0.063,
+    ("gpt-image-1", "medium", "1024x1536") -> 0.063,
+    ("gpt-image-1", "medium", "auto")      -> 0.042,
+    ("gpt-image-1", "high", "1024x1024")   -> 0.167,
+    ("gpt-image-1", "high", "1536x1024")   -> 0.250,
+    ("gpt-image-1", "high", "1024x1536")   -> 0.250,
+    ("gpt-image-1", "high", "auto")        -> 0.167,
+    // dall-e-3
+    ("dall-e-3", "standard", "1024x1024") -> 0.040,
+    ("dall-e-3", "standard", "1024x1792") -> 0.080,
+    ("dall-e-3", "standard", "1792x1024") -> 0.080,
+    ("dall-e-3", "hd", "1024x1024")       -> 0.080,
+    ("dall-e-3", "hd", "1024x1792")       -> 0.120,
+    ("dall-e-3", "hd", "1792x1024")       -> 0.120,
+    // dall-e-2
+    ("dall-e-2", "standard", "1024x1024") -> 0.020,
+    ("dall-e-2", "standard", "512x512")   -> 0.018,
+    ("dall-e-2", "standard", "256x256")   -> 0.016,
+    // stability-ai defaults
+    ("stable-diffusion-xl-1024-v1-0", "standard", "1024x1024") -> 0.002
+  )
+
+  /**
+   * Look up the cost per image for a given model, quality, and size.
+   *
+   * @param model Model name (e.g., "gpt-image-1", "dall-e-3")
+   * @param quality Quality level (e.g., "standard", "hd", "low", "medium", "high")
+   * @param size Image size as "WxH" string (e.g., "1024x1024")
+   * @return Cost in USD per image, or None if pricing is unknown
+   */
+  def costPerImage(model: String, quality: String, size: String): Option[Double] =
+    pricingTable.get((model, quality, size))
+
+  /**
+   * Look up the cost per image with automatic quality defaulting.
+   *
+   * Uses "standard" as the default quality if the provided quality is empty or not found.
+   *
+   * @param model Model name
+   * @param quality Quality level (defaults to "standard" if None or empty)
+   * @param size Image size as "WxH" string
+   * @return Cost in USD per image, or None if pricing is unknown
+   */
+  def costPerImageWithDefaults(
+    model: String,
+    quality: Option[String],
+    size: ImageSize
+  ): Option[Double] = {
+    val q       = quality.filter(_.nonEmpty).getOrElse("standard")
+    val sizeStr = sizeToString(size)
+    costPerImage(model, q, sizeStr)
+  }
+
+  /**
+   * Estimate total cost for generating multiple images.
+   *
+   * @param model Model name
+   * @param quality Quality level
+   * @param size Image size
+   * @param count Number of images to generate
+   * @return Total estimated cost in USD, or None if pricing is unknown
+   */
+  def estimateCost(
+    model: String,
+    quality: Option[String],
+    size: ImageSize,
+    count: Int
+  ): Option[Double] =
+    costPerImageWithDefaults(model, quality, size).map(_ * count)
+
+  /**
+   * List all known models in the pricing registry.
+   */
+  def knownModels: Set[String] =
+    pricingTable.keys.map(_._1).toSet
+
+  private def sizeToString(size: ImageSize): String = size match {
+    case ImageSize.Auto         => "auto"
+    case ImageSize.Custom(w, h) => s"${w}x$h"
+    case s                      => s"${s.width}x${s.height}"
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/InstrumentedImageGenerationClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/InstrumentedImageGenerationClient.scala
@@ -4,7 +4,6 @@ import org.llm4s.metrics.{ MetricsCollector, Outcome, ErrorKind }
 import org.llm4s.trace.{ Tracing, TraceEvent }
 
 import java.nio.file.Path
-import scala.annotation.unused
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 
@@ -16,7 +15,12 @@ import scala.concurrent.duration._
  *  - `observeImageGeneration` for every generate/edit call (success or failure)
  *  - `recordImageGenerationCost` when pricing is available via [[ImagePricingRegistry]]
  *  - `TraceEvent.ImageGenerationCompleted` for observability
- *  - `TraceEvent.CostRecorded` when cost is estimated
+ *
+ * Note: Cost estimation uses the requested size, not the actual provider-billed
+ * dimensions. For models like dall-e-3 that normalize sizes (e.g., mapping
+ * non-standard requested sizes to their nearest supported size), the estimate
+ * may differ from actual billing. When size is unknown (e.g., edit operations
+ * without an explicit size), cost estimation is skipped.
  *
  * @param delegate   The underlying client to delegate actual generation to
  * @param config     Image generation configuration (provides model/provider info)
@@ -45,7 +49,7 @@ class InstrumentedImageGenerationClient(
     val result     = delegate.generateImage(prompt, options)
     val duration   = Duration.fromNanos(System.nanoTime() - startNanos).toMillis
 
-    recordMetricsAndTrace("generate", result.map(Seq(_)), options, 1, duration)
+    recordMetricsAndTrace("generate", result.map(Seq(_)), Some(options.size), options.quality, duration)
     result
   }
 
@@ -58,7 +62,7 @@ class InstrumentedImageGenerationClient(
     val result     = delegate.generateImages(prompt, count, options)
     val duration   = Duration.fromNanos(System.nanoTime() - startNanos).toMillis
 
-    recordMetricsAndTrace("generate", result, options, count, duration)
+    recordMetricsAndTrace("generate", result, Some(options.size), options.quality, duration)
     result
   }
 
@@ -72,10 +76,7 @@ class InstrumentedImageGenerationClient(
     val result     = delegate.editImage(imagePath, prompt, maskPath, options)
     val duration   = Duration.fromNanos(System.nanoTime() - startNanos).toMillis
 
-    val genOptions = ImageGenerationOptions(
-      size = options.size.getOrElse(ImageSize.Square512)
-    )
-    recordMetricsAndTrace("edit", result, genOptions, options.n, duration)
+    recordMetricsAndTrace("edit", result, options.size, None, duration)
     result
   }
 
@@ -86,7 +87,7 @@ class InstrumentedImageGenerationClient(
     val startNanos = System.nanoTime()
     delegate.generateImageAsync(prompt, options).map { result =>
       val duration = Duration.fromNanos(System.nanoTime() - startNanos).toMillis
-      recordMetricsAndTrace("generate", result.map(Seq(_)), options, 1, duration)
+      recordMetricsAndTrace("generate", result.map(Seq(_)), Some(options.size), options.quality, duration)
       result
     }
   }
@@ -99,7 +100,7 @@ class InstrumentedImageGenerationClient(
     val startNanos = System.nanoTime()
     delegate.generateImagesAsync(prompt, count, options).map { result =>
       val duration = Duration.fromNanos(System.nanoTime() - startNanos).toMillis
-      recordMetricsAndTrace("generate", result, options, count, duration)
+      recordMetricsAndTrace("generate", result, Some(options.size), options.quality, duration)
       result
     }
   }
@@ -113,10 +114,7 @@ class InstrumentedImageGenerationClient(
     val startNanos = System.nanoTime()
     delegate.editImageAsync(imagePath, prompt, maskPath, options).map { result =>
       val duration = Duration.fromNanos(System.nanoTime() - startNanos).toMillis
-      val genOptions = ImageGenerationOptions(
-        size = options.size.getOrElse(ImageSize.Square512)
-      )
-      recordMetricsAndTrace("edit", result, genOptions, options.n, duration)
+      recordMetricsAndTrace("edit", result, options.size, None, duration)
       result
     }
   }
@@ -124,34 +122,50 @@ class InstrumentedImageGenerationClient(
   override def health(): Either[ImageGenerationError, ServiceStatus] =
     delegate.health()
 
+  private def errorKindFromImageError(err: ImageGenerationError): ErrorKind = err match {
+    case _: AuthenticationError        => ErrorKind.Authentication
+    case _: RateLimitError             => ErrorKind.RateLimit
+    case _: ServiceError               => ErrorKind.ServiceError
+    case _: ValidationError            => ErrorKind.Validation
+    case _: InvalidPromptError         => ErrorKind.Validation
+    case _: InsufficientResourcesError => ErrorKind.ServiceError
+    case _: UnsupportedOperation       => ErrorKind.Validation
+    case _: UnknownError               => ErrorKind.Unknown
+  }
+
   private def recordMetricsAndTrace(
     operation: String,
     result: Either[ImageGenerationError, Seq[GeneratedImage]],
-    options: ImageGenerationOptions,
-    @unused requestedCount: Int,
+    size: Option[ImageSize],
+    quality: Option[String],
     durationMs: Long
   ): Unit = {
     val durationFD = FiniteDuration(durationMs, MILLISECONDS)
-    val quality    = options.quality.getOrElse("standard")
-    val sizeStr    = options.size.description
+    val qualityStr = quality.getOrElse("standard")
+    val sizeStr    = size.map(_.description).getOrElse("unknown")
     val model      = config.model
     val imageCount = result.map(_.size).getOrElse(0)
 
     val outcome = result match {
-      case Right(_) => Outcome.Success
-      case Left(_)  => Outcome.Error(ErrorKind.Unknown)
+      case Right(_)  => Outcome.Success
+      case Left(err) => Outcome.Error(errorKindFromImageError(err))
     }
 
     metrics.observeImageGeneration(providerName, model, operation, outcome, durationFD, imageCount)
 
+    // Cost estimation uses the requested size, not the actual provider-billed dimensions.
+    // For models like dall-e-3 that normalize sizes, the estimate may differ from actual billing.
+    // When size is unknown (e.g., edit without explicit size), cost estimation is skipped.
     val costUsd = result match {
       case Right(_) =>
-        val cost = ImagePricingRegistry.estimateCost(model, options.quality, options.size, imageCount)
-        cost.foreach { c =>
-          metrics.recordImageGenerationCost(providerName, model, c, imageCount)
-          metrics.recordCost(providerName, model, c)
+        size.flatMap { s =>
+          val cost = ImagePricingRegistry.estimateCost(model, quality, s, imageCount)
+          cost.foreach { c =>
+            metrics.recordImageGenerationCost(providerName, model, c, imageCount)
+            metrics.recordCost(providerName, model, c)
+          }
+          cost
         }
-        cost
       case Left(_) => None
     }
 
@@ -161,14 +175,12 @@ class InstrumentedImageGenerationClient(
       operation = operation,
       imageCount = imageCount,
       size = sizeStr,
-      quality = quality,
+      quality = qualityStr,
       durationMs = durationMs,
       costUsd = costUsd,
       success = result.isRight,
       errorMessage = result.left.toOption.map(_.message)
     )
     tracing.traceEvent(event)
-
-    costUsd.foreach(c => tracing.traceCost(c, model, "image_generation", 0, "image_generation"))
   }
 }

--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/InstrumentedImageGenerationClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/InstrumentedImageGenerationClient.scala
@@ -1,0 +1,174 @@
+package org.llm4s.imagegeneration
+
+import org.llm4s.metrics.{ MetricsCollector, Outcome, ErrorKind }
+import org.llm4s.trace.{ Tracing, TraceEvent }
+
+import java.nio.file.Path
+import scala.annotation.unused
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.duration._
+
+/**
+ * Decorator that wraps an [[ImageGenerationClient]] with metrics collection
+ * and trace event emission.
+ *
+ * Records:
+ *  - `observeImageGeneration` for every generate/edit call (success or failure)
+ *  - `recordImageGenerationCost` when pricing is available via [[ImagePricingRegistry]]
+ *  - `TraceEvent.ImageGenerationCompleted` for observability
+ *  - `TraceEvent.CostRecorded` when cost is estimated
+ *
+ * @param delegate   The underlying client to delegate actual generation to
+ * @param config     Image generation configuration (provides model/provider info)
+ * @param metrics    Metrics collector for Prometheus counters/histograms
+ * @param tracing    Tracing backend for structured event emission
+ */
+class InstrumentedImageGenerationClient(
+  delegate: ImageGenerationClient,
+  config: ImageGenerationConfig,
+  metrics: MetricsCollector,
+  tracing: Tracing
+) extends ImageGenerationClient {
+
+  private val providerName: String = config.provider match {
+    case ImageGenerationProvider.StableDiffusion => "stable-diffusion"
+    case ImageGenerationProvider.DALLE           => "openai"
+    case ImageGenerationProvider.HuggingFace     => "huggingface"
+    case ImageGenerationProvider.StabilityAI     => "stability-ai"
+  }
+
+  override def generateImage(
+    prompt: String,
+    options: ImageGenerationOptions
+  ): Either[ImageGenerationError, GeneratedImage] = {
+    val startNanos = System.nanoTime()
+    val result     = delegate.generateImage(prompt, options)
+    val duration   = Duration.fromNanos(System.nanoTime() - startNanos).toMillis
+
+    recordMetricsAndTrace("generate", result.map(Seq(_)), options, 1, duration)
+    result
+  }
+
+  override def generateImages(
+    prompt: String,
+    count: Int,
+    options: ImageGenerationOptions
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+    val startNanos = System.nanoTime()
+    val result     = delegate.generateImages(prompt, count, options)
+    val duration   = Duration.fromNanos(System.nanoTime() - startNanos).toMillis
+
+    recordMetricsAndTrace("generate", result, options, count, duration)
+    result
+  }
+
+  override def editImage(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path],
+    options: ImageEditOptions
+  ): Either[ImageGenerationError, Seq[GeneratedImage]] = {
+    val startNanos = System.nanoTime()
+    val result     = delegate.editImage(imagePath, prompt, maskPath, options)
+    val duration   = Duration.fromNanos(System.nanoTime() - startNanos).toMillis
+
+    val genOptions = ImageGenerationOptions(
+      size = options.size.getOrElse(ImageSize.Square512)
+    )
+    recordMetricsAndTrace("edit", result, genOptions, options.n, duration)
+    result
+  }
+
+  override def generateImageAsync(
+    prompt: String,
+    options: ImageGenerationOptions
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, GeneratedImage]] = {
+    val startNanos = System.nanoTime()
+    delegate.generateImageAsync(prompt, options).map { result =>
+      val duration = Duration.fromNanos(System.nanoTime() - startNanos).toMillis
+      recordMetricsAndTrace("generate", result.map(Seq(_)), options, 1, duration)
+      result
+    }
+  }
+
+  override def generateImagesAsync(
+    prompt: String,
+    count: Int,
+    options: ImageGenerationOptions
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] = {
+    val startNanos = System.nanoTime()
+    delegate.generateImagesAsync(prompt, count, options).map { result =>
+      val duration = Duration.fromNanos(System.nanoTime() - startNanos).toMillis
+      recordMetricsAndTrace("generate", result, options, count, duration)
+      result
+    }
+  }
+
+  override def editImageAsync(
+    imagePath: Path,
+    prompt: String,
+    maskPath: Option[Path],
+    options: ImageEditOptions
+  )(implicit ec: ExecutionContext): Future[Either[ImageGenerationError, Seq[GeneratedImage]]] = {
+    val startNanos = System.nanoTime()
+    delegate.editImageAsync(imagePath, prompt, maskPath, options).map { result =>
+      val duration = Duration.fromNanos(System.nanoTime() - startNanos).toMillis
+      val genOptions = ImageGenerationOptions(
+        size = options.size.getOrElse(ImageSize.Square512)
+      )
+      recordMetricsAndTrace("edit", result, genOptions, options.n, duration)
+      result
+    }
+  }
+
+  override def health(): Either[ImageGenerationError, ServiceStatus] =
+    delegate.health()
+
+  private def recordMetricsAndTrace(
+    operation: String,
+    result: Either[ImageGenerationError, Seq[GeneratedImage]],
+    options: ImageGenerationOptions,
+    @unused requestedCount: Int,
+    durationMs: Long
+  ): Unit = {
+    val durationFD = FiniteDuration(durationMs, MILLISECONDS)
+    val quality    = options.quality.getOrElse("standard")
+    val sizeStr    = options.size.description
+    val model      = config.model
+    val imageCount = result.map(_.size).getOrElse(0)
+
+    val outcome = result match {
+      case Right(_) => Outcome.Success
+      case Left(_)  => Outcome.Error(ErrorKind.Unknown)
+    }
+
+    metrics.observeImageGeneration(providerName, model, operation, outcome, durationFD, imageCount)
+
+    val costUsd = result match {
+      case Right(_) =>
+        val cost = ImagePricingRegistry.estimateCost(model, options.quality, options.size, imageCount)
+        cost.foreach { c =>
+          metrics.recordImageGenerationCost(providerName, model, c, imageCount)
+          metrics.recordCost(providerName, model, c)
+        }
+        cost
+      case Left(_) => None
+    }
+
+    val event = TraceEvent.ImageGenerationCompleted(
+      model = model,
+      provider = providerName,
+      operation = operation,
+      imageCount = imageCount,
+      size = sizeStr,
+      quality = quality,
+      durationMs = durationMs,
+      costUsd = costUsd,
+      success = result.isRight,
+      errorMessage = result.left.toOption.map(_.message)
+    )
+    tracing.traceEvent(event)
+
+    costUsd.foreach(c => tracing.traceCost(c, model, "image_generation", 0, "image_generation"))
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/metrics/MetricsCollector.scala
+++ b/modules/core/src/main/scala/org/llm4s/metrics/MetricsCollector.scala
@@ -102,6 +102,40 @@ trait MetricsCollector {
     errorKind: ErrorKind,
     provider: String
   ): Unit = () // Default no-op
+
+  /**
+   * Record an image generation operation.
+   *
+   * @param provider Provider name (e.g., "openai", "stability-ai")
+   * @param model Model name (e.g., "gpt-image-1", "dall-e-3")
+   * @param operation Operation type: "generate" or "edit"
+   * @param outcome Success or Error with error kind
+   * @param duration Request duration
+   * @param imageCount Number of images generated
+   */
+  def observeImageGeneration(
+    provider: String,
+    model: String,
+    operation: String,
+    outcome: Outcome,
+    duration: FiniteDuration,
+    imageCount: Int
+  ): Unit = () // Default no-op
+
+  /**
+   * Record estimated image generation cost in USD.
+   *
+   * @param provider Provider name
+   * @param model Model name
+   * @param costUsd Estimated cost in USD
+   * @param imageCount Number of images
+   */
+  def recordImageGenerationCost(
+    provider: String,
+    model: String,
+    costUsd: Double,
+    imageCount: Int
+  ): Unit = () // Default no-op
 }
 
 object MetricsCollector {

--- a/modules/core/src/main/scala/org/llm4s/metrics/PrometheusMetrics.scala
+++ b/modules/core/src/main/scala/org/llm4s/metrics/PrometheusMetrics.scala
@@ -77,6 +77,39 @@ final class PrometheusMetrics(
     .classicUpperBounds(0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0)
     .register(registry)
 
+  // Image generation counter
+  private val imageGenerationsTotal = Counter
+    .builder()
+    .name("llm4s_image_generations_total")
+    .help("Total number of image generation operations")
+    .labelNames("provider", "model", "operation", "status")
+    .register(registry)
+
+  // Image count counter
+  private val imagesGeneratedTotal = Counter
+    .builder()
+    .name("llm4s_images_generated_total")
+    .help("Total number of images generated")
+    .labelNames("provider", "model")
+    .register(registry)
+
+  // Image generation duration histogram
+  private val imageGenerationDuration = Histogram
+    .builder()
+    .name("llm4s_image_generation_duration_seconds")
+    .help("Image generation duration in seconds")
+    .labelNames("provider", "model", "operation")
+    .classicUpperBounds(1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0)
+    .register(registry)
+
+  // Image generation cost counter
+  private val imageGenerationCostUsdTotal = Counter
+    .builder()
+    .name("llm4s_image_generation_cost_usd_total")
+    .help("Total estimated image generation cost in USD")
+    .labelNames("provider", "model")
+    .register(registry)
+
   /**
    * Record an LLM request with its outcome and duration.
    *
@@ -143,6 +176,62 @@ final class PrometheusMetrics(
       costUsdTotal.labelValues(provider, model).inc(costUsd)
     }.recover { case e: Exception =>
       logger.warn(s"Failed to record cost metrics: ${e.getMessage}")
+    }
+
+  /**
+   * Record an image generation operation.
+   *
+   * Safe: catches and logs any Prometheus errors without propagating.
+   */
+  override def observeImageGeneration(
+    provider: String,
+    model: String,
+    operation: String,
+    outcome: Outcome,
+    duration: FiniteDuration,
+    imageCount: Int
+  ): Unit =
+    Try {
+      val status = outcome match {
+        case Outcome.Success => "success"
+        case Outcome.Error(errorKind) =>
+          val kindStr   = errorKind.toString
+          val snakeCase = kindStr.replaceAll("([A-Z])", "_$1").toLowerCase.drop(1)
+          s"error_$snakeCase"
+      }
+
+      imageGenerationsTotal.labelValues(provider, model, operation, status).inc()
+      imageGenerationDuration.labelValues(provider, model, operation).observe(duration.toMillis / 1000.0)
+
+      if (outcome == Outcome.Success && imageCount > 0) {
+        imagesGeneratedTotal.labelValues(provider, model).inc(imageCount.toDouble)
+      }
+
+      outcome match {
+        case Outcome.Error(errorKind) =>
+          val errorLabel = errorKind.toString.toLowerCase
+          errorsTotal.labelValues(provider, errorLabel).inc()
+        case _ =>
+      }
+    }.recover { case e: Exception =>
+      logger.warn(s"Failed to record image generation metrics: ${e.getMessage}")
+    }
+
+  /**
+   * Record estimated image generation cost in USD.
+   *
+   * Safe: catches and logs any Prometheus errors without propagating.
+   */
+  override def recordImageGenerationCost(
+    provider: String,
+    model: String,
+    costUsd: Double,
+    imageCount: Int
+  ): Unit =
+    Try {
+      imageGenerationCostUsdTotal.labelValues(provider, model).inc(costUsd)
+    }.recover { case e: Exception =>
+      logger.warn(s"Failed to record image generation cost metrics: ${e.getMessage}")
     }
 }
 

--- a/modules/core/src/main/scala/org/llm4s/metrics/PrometheusMetrics.scala
+++ b/modules/core/src/main/scala/org/llm4s/metrics/PrometheusMetrics.scala
@@ -110,6 +110,21 @@ final class PrometheusMetrics(
     .labelNames("provider", "model")
     .register(registry)
 
+  // Image generation error counter (Issue #501 requirement)
+  private val imageGenerationErrorsTotal = Counter
+    .builder()
+    .name("llm4s_image_generation_errors_total")
+    .help("Total number of image generation errors")
+    .labelNames("provider", "model", "operation", "error_type")
+    .register(registry)
+
+  /** Convert ErrorKind to a stable snake_case label for metrics. */
+  private def errorKindToLabel(errorKind: ErrorKind): String = {
+    val kindStr   = errorKind.toString
+    val snakeCase = kindStr.replaceAll("([A-Z])", "_$1").toLowerCase.drop(1)
+    snakeCase
+  }
+
   /**
    * Record an LLM request with its outcome and duration.
    *
@@ -124,11 +139,7 @@ final class PrometheusMetrics(
     Try {
       val status = outcome match {
         case Outcome.Success          => "success"
-        case Outcome.Error(errorKind) =>
-          // Convert PascalCase to snake_case: RateLimit -> rate_limit
-          val kindStr   = errorKind.toString
-          val snakeCase = kindStr.replaceAll("([A-Z])", "_$1").toLowerCase.drop(1)
-          s"error_$snakeCase"
+        case Outcome.Error(errorKind) => s"error_${errorKindToLabel(errorKind)}"
       }
 
       requestsTotal.labelValues(provider, model, status).inc()
@@ -136,8 +147,7 @@ final class PrometheusMetrics(
 
       outcome match {
         case Outcome.Error(errorKind) =>
-          val errorLabel = errorKind.toString.toLowerCase
-          errorsTotal.labelValues(provider, errorLabel).inc()
+          errorsTotal.labelValues(provider, errorKindToLabel(errorKind)).inc()
         case _ => // No additional action for success
       }
     }.recover { case e: Exception =>
@@ -193,11 +203,8 @@ final class PrometheusMetrics(
   ): Unit =
     Try {
       val status = outcome match {
-        case Outcome.Success => "success"
-        case Outcome.Error(errorKind) =>
-          val kindStr   = errorKind.toString
-          val snakeCase = kindStr.replaceAll("([A-Z])", "_$1").toLowerCase.drop(1)
-          s"error_$snakeCase"
+        case Outcome.Success          => "success"
+        case Outcome.Error(errorKind) => s"error_${errorKindToLabel(errorKind)}"
       }
 
       imageGenerationsTotal.labelValues(provider, model, operation, status).inc()
@@ -209,8 +216,9 @@ final class PrometheusMetrics(
 
       outcome match {
         case Outcome.Error(errorKind) =>
-          val errorLabel = errorKind.toString.toLowerCase
+          val errorLabel = errorKindToLabel(errorKind)
           errorsTotal.labelValues(provider, errorLabel).inc()
+          imageGenerationErrorsTotal.labelValues(provider, model, operation, errorLabel).inc()
         case _ =>
       }
     }.recover { case e: Exception =>

--- a/modules/core/src/main/scala/org/llm4s/trace/ConsoleTracing.scala
+++ b/modules/core/src/main/scala/org/llm4s/trace/ConsoleTracing.scala
@@ -163,6 +163,22 @@ class ConsoleTracing extends Tracing {
           println(s"${YELLOW}Reason: ${e.reason.value}$RESET")
           println()
 
+        case e: TraceEvent.ImageGenerationCompleted =>
+          println()
+          printSubHeader("IMAGE GENERATION COMPLETED", if (e.success) GREEN else RED)
+          println(s"${GRAY}Timestamp: ${e.timestamp}$RESET")
+          println(s"${GREEN}Model: ${e.model}$RESET")
+          println(s"${GREEN}Provider: ${e.provider}$RESET")
+          println(s"${GREEN}Operation: ${e.operation}$RESET")
+          println(s"${GREEN}Images: ${e.imageCount}$RESET")
+          println(s"${GREEN}Size: ${e.size}$RESET")
+          println(s"${GREEN}Quality: ${e.quality}$RESET")
+          println(s"${GREEN}Duration: ${e.durationMs}ms$RESET")
+          println(s"${GREEN}Success: ${e.success}$RESET")
+          e.costUsd.foreach(c => println(s"${YELLOW}Cost (USD): $$${f"$c%.6f"}$RESET"))
+          e.errorMessage.foreach(m => println(s"${RED}Error: $m$RESET"))
+          println()
+
         case e: TraceEvent.RAGOperationCompleted =>
           println()
           printSubHeader("RAG OPERATION COMPLETED", CYAN)

--- a/modules/core/src/main/scala/org/llm4s/trace/LangfuseTracing.scala
+++ b/modules/core/src/main/scala/org/llm4s/trace/LangfuseTracing.scala
@@ -426,6 +426,40 @@ class LangfuseTracing(
           )
         )
 
+      case e: TraceEvent.ImageGenerationCompleted =>
+        val outputObj = ujson.Obj(
+          "model"       -> e.model,
+          "provider"    -> e.provider,
+          "operation"   -> e.operation,
+          "image_count" -> e.imageCount,
+          "size"        -> e.size,
+          "quality"     -> e.quality,
+          "duration_ms" -> e.durationMs,
+          "success"     -> e.success
+        )
+        e.costUsd.foreach(c => outputObj("cost_usd") = c)
+        e.errorMessage.foreach(m => outputObj("error_message") = m)
+
+        ujson.Obj(
+          "id"        -> uuid,
+          "timestamp" -> now,
+          "type"      -> "span-create",
+          "body" -> ujson.Obj(
+            "id"        -> uuid,
+            "timestamp" -> now,
+            "name"      -> "Image Generation",
+            "level"     -> (if (e.success) "DEFAULT" else "ERROR"),
+            "input" -> ujson.Obj(
+              "model"     -> e.model,
+              "operation" -> e.operation,
+              "size"      -> e.size,
+              "quality"   -> e.quality
+            ),
+            "output"   -> outputObj,
+            "metadata" -> outputObj
+          )
+        )
+
       case e: TraceEvent.RAGOperationCompleted =>
         val outputObj = ujson.Obj(
           "operation"   -> e.operation,

--- a/modules/core/src/main/scala/org/llm4s/trace/TraceCollector.scala
+++ b/modules/core/src/main/scala/org/llm4s/trace/TraceCollector.scala
@@ -336,6 +336,44 @@ class TraceCollectorTracing[F[_]](
             "hit"    -> SpanValue.BooleanValue(false)
           )
         )
+
+      case TraceEvent.ImageGenerationCompleted(
+            model,
+            provider,
+            operation,
+            imageCount,
+            size,
+            quality,
+            durationMs,
+            costUsd,
+            success,
+            errorMessage,
+            ts
+          ) =>
+        val baseAttrs: Map[String, SpanValue] = Map(
+          "model"       -> SpanValue.StringValue(model),
+          "provider"    -> SpanValue.StringValue(provider),
+          "operation"   -> SpanValue.StringValue(operation),
+          "image_count" -> SpanValue.LongValue(imageCount.toLong),
+          "size"        -> SpanValue.StringValue(size),
+          "quality"     -> SpanValue.StringValue(quality),
+          "duration_ms" -> SpanValue.LongValue(durationMs),
+          "success"     -> SpanValue.BooleanValue(success)
+        )
+        val costAttr  = costUsd.map(v => "cost_usd" -> SpanValue.DoubleValue(v))
+        val errorAttr = errorMessage.map(v => "error_message" -> SpanValue.StringValue(v))
+        val attrs     = baseAttrs ++ costAttr ++ errorAttr
+        Span(
+          spanId = SpanId.generate(),
+          traceId = traceId,
+          parentSpanId = None,
+          name = spanName,
+          kind = SpanKind.Internal,
+          startTime = ts.minusMillis(durationMs),
+          endTime = Some(ts),
+          status = if (success) SpanStatus.Ok else SpanStatus.Error(errorMessage.getOrElse("Image generation failed")),
+          attributes = attrs
+        )
     }
   }
 }

--- a/modules/core/src/main/scala/org/llm4s/trace/TraceEvent.scala
+++ b/modules/core/src/main/scala/org/llm4s/trace/TraceEvent.scala
@@ -296,6 +296,53 @@ object TraceEvent {
     )
 
   /**
+   * Tracks completion of an image generation operation.
+   *
+   * @param model Image generation model name (e.g., "gpt-image-1", "dall-e-3")
+   * @param provider Provider name (e.g., "openai", "stability-ai")
+   * @param operation Type of operation: "generate", "edit"
+   * @param imageCount Number of images generated
+   * @param size Image size descriptor (e.g., "1024x1024")
+   * @param quality Quality level (e.g., "standard", "hd")
+   * @param durationMs Wall-clock duration in milliseconds
+   * @param costUsd Estimated cost in USD, if available
+   * @param success Whether the operation succeeded
+   * @param errorMessage Error message if the operation failed
+   */
+  case class ImageGenerationCompleted(
+    model: String,
+    provider: String,
+    operation: String,
+    imageCount: Int,
+    size: String,
+    quality: String,
+    durationMs: Long,
+    costUsd: Option[Double] = None,
+    success: Boolean = true,
+    errorMessage: Option[String] = None,
+    timestamp: Instant = Instant.now()
+  ) extends TraceEvent {
+    def eventType: String = "image_generation_completed"
+    def toJson: ujson.Value = {
+      val base = ujson.Obj(
+        "event_type"  -> eventType,
+        "timestamp"   -> timestamp.toString,
+        "model"       -> model,
+        "provider"    -> provider,
+        "operation"   -> operation,
+        "image_count" -> imageCount,
+        "size"        -> size,
+        "quality"     -> quality,
+        "duration_ms" -> durationMs.toDouble,
+        "success"     -> success
+      )
+      costUsd.foreach(c => base("cost_usd") = c)
+      errorMessage.foreach(m => base("error_message") = m)
+      base
+    }
+  }
+
+  /**
    * Cache hit event for semantic caching
    */
   case class CacheHit(

--- a/modules/core/src/test/scala/org/llm4s/imagegeneration/ImageGenerationCostTrackingSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/imagegeneration/ImageGenerationCostTrackingSpec.scala
@@ -218,9 +218,30 @@ class ImageGenerationCostTrackingSpec extends AnyFlatSpec with Matchers {
     val errorCount = getMetricValue(
       prometheusMetrics.registry,
       "llm4s_image_generations_total",
-      Map("provider" -> "openai", "model" -> "dall-e-3", "operation" -> "generate", "status" -> "error_unknown")
+      Map("provider" -> "openai", "model" -> "dall-e-3", "operation" -> "generate", "status" -> "error_service_error")
     )
     errorCount shouldBe 1.0
+  }
+
+  it should "record image generation error counter on failure" in {
+    val prometheusMetrics = PrometheusMetrics.create()
+    val tracing           = new TracingCollector()
+    val config            = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
+    val instrumented = new InstrumentedImageGenerationClient(
+      new FailingImageClient(),
+      config,
+      prometheusMetrics,
+      tracing
+    )
+
+    instrumented.generateImage("A cat")
+
+    val imageGenErrorCount = getMetricValue(
+      prometheusMetrics.registry,
+      "llm4s_image_generation_errors_total",
+      Map("provider" -> "openai", "model" -> "dall-e-3", "operation" -> "generate", "error_type" -> "service_error")
+    )
+    imageGenErrorCount shouldBe 1.0
   }
 
   it should "record duration histogram" in {
@@ -304,28 +325,6 @@ class ImageGenerationCostTrackingSpec extends AnyFlatSpec with Matchers {
     event.costUsd shouldBe Some(0.040)
   }
 
-  it should "emit CostRecorded trace event when cost is available" in {
-    val tracing = new TracingCollector()
-    val config  = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
-    val instrumented = new InstrumentedImageGenerationClient(
-      new MockImageClient(),
-      config,
-      MetricsCollector.noop,
-      tracing
-    )
-
-    instrumented.generateImage("A cat", ImageGenerationOptions(size = ImageSize.Square1024, quality = Some("standard")))
-
-    val costEvents = tracing.events.collect { case e: TraceEvent.CostRecorded => e }
-    costEvents should have size 1
-
-    val costEvent = costEvents.head
-    costEvent.model shouldBe "dall-e-3"
-    costEvent.operation shouldBe "image_generation"
-    costEvent.costType shouldBe "image_generation"
-    costEvent.costUsd shouldBe 0.040 +- 0.001
-  }
-
   it should "emit error trace event on failure" in {
     val tracing = new TracingCollector()
     val config  = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
@@ -345,22 +344,6 @@ class ImageGenerationCostTrackingSpec extends AnyFlatSpec with Matchers {
     event.success shouldBe false
     event.errorMessage shouldBe Some("Service unavailable")
     event.costUsd shouldBe None
-  }
-
-  it should "not emit CostRecorded on failure" in {
-    val tracing = new TracingCollector()
-    val config  = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
-    val instrumented = new InstrumentedImageGenerationClient(
-      new FailingImageClient(),
-      config,
-      MetricsCollector.noop,
-      tracing
-    )
-
-    instrumented.generateImage("A cat")
-
-    val costEvents = tracing.events.collect { case e: TraceEvent.CostRecorded => e }
-    costEvents shouldBe empty
   }
 
   // ─────────────────────────────────────────────────────────────

--- a/modules/core/src/test/scala/org/llm4s/imagegeneration/ImageGenerationCostTrackingSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/imagegeneration/ImageGenerationCostTrackingSpec.scala
@@ -1,0 +1,457 @@
+package org.llm4s.imagegeneration
+
+import org.llm4s.metrics._
+import org.llm4s.trace.{ TraceEvent, Tracing }
+import org.llm4s.agent.AgentState
+import org.llm4s.llmconnect.model.{ Completion, TokenUsage }
+import org.llm4s.types.Result
+import io.prometheus.metrics.model.registry.PrometheusRegistry
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+
+class ImageGenerationCostTrackingSpec extends AnyFlatSpec with Matchers {
+
+  private val mockImageData =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+  class MockImageClient extends ImageGenerationClient {
+    override def generateImage(
+      prompt: String,
+      options: ImageGenerationOptions
+    ): Either[ImageGenerationError, GeneratedImage] =
+      Right(
+        GeneratedImage(
+          data = mockImageData,
+          format = options.format,
+          size = options.size,
+          prompt = prompt,
+          seed = options.seed
+        )
+      )
+
+    override def generateImages(
+      prompt: String,
+      count: Int,
+      options: ImageGenerationOptions
+    ): Either[ImageGenerationError, Seq[GeneratedImage]] =
+      Right(
+        (1 to count).map(i =>
+          GeneratedImage(
+            data = mockImageData,
+            format = options.format,
+            size = options.size,
+            prompt = prompt,
+            seed = options.seed.map(_ + i)
+          )
+        )
+      )
+  }
+
+  class FailingImageClient extends ImageGenerationClient {
+    override def generateImage(
+      prompt: String,
+      options: ImageGenerationOptions
+    ): Either[ImageGenerationError, GeneratedImage] =
+      Left(ServiceError("Service unavailable", 503))
+
+    override def generateImages(
+      prompt: String,
+      count: Int,
+      options: ImageGenerationOptions
+    ): Either[ImageGenerationError, Seq[GeneratedImage]] =
+      Left(ServiceError("Service unavailable", 503))
+  }
+
+  class TracingCollector extends Tracing {
+    var events: List[TraceEvent] = Nil
+
+    override def traceEvent(event: TraceEvent): Result[Unit] = {
+      events = events :+ event
+      Right(())
+    }
+    override def traceAgentState(state: AgentState): Result[Unit]                                   = Right(())
+    override def traceToolCall(toolName: String, input: String, output: String): Result[Unit]       = Right(())
+    override def traceError(error: Throwable, context: String): Result[Unit]                        = Right(())
+    override def traceCompletion(completion: Completion, model: String): Result[Unit]               = Right(())
+    override def traceTokenUsage(usage: TokenUsage, model: String, operation: String): Result[Unit] = Right(())
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // TraceEvent.ImageGenerationCompleted
+  // ─────────────────────────────────────────────────────────────
+
+  "TraceEvent.ImageGenerationCompleted" should "serialize to JSON correctly" in {
+    val event = TraceEvent.ImageGenerationCompleted(
+      model = "dall-e-3",
+      provider = "openai",
+      operation = "generate",
+      imageCount = 2,
+      size = "1024x1024",
+      quality = "hd",
+      durationMs = 3500,
+      costUsd = Some(0.160),
+      success = true
+    )
+
+    event.eventType shouldBe "image_generation_completed"
+    val json = event.toJson
+    json("event_type").str shouldBe "image_generation_completed"
+    json("model").str shouldBe "dall-e-3"
+    json("provider").str shouldBe "openai"
+    json("operation").str shouldBe "generate"
+    json("image_count").num shouldBe 2.0
+    json("size").str shouldBe "1024x1024"
+    json("quality").str shouldBe "hd"
+    json("duration_ms").num shouldBe 3500.0
+    json("cost_usd").num shouldBe 0.160 +- 0.001
+    json("success").bool shouldBe true
+  }
+
+  it should "omit optional fields when None" in {
+    val event = TraceEvent.ImageGenerationCompleted(
+      model = "dall-e-3",
+      provider = "openai",
+      operation = "generate",
+      imageCount = 1,
+      size = "1024x1024",
+      quality = "standard",
+      durationMs = 2000
+    )
+
+    val json = event.toJson
+    json.obj.contains("cost_usd") shouldBe false
+    json.obj.contains("error_message") shouldBe false
+  }
+
+  it should "include error message on failure" in {
+    val event = TraceEvent.ImageGenerationCompleted(
+      model = "dall-e-3",
+      provider = "openai",
+      operation = "generate",
+      imageCount = 0,
+      size = "1024x1024",
+      quality = "standard",
+      durationMs = 500,
+      success = false,
+      errorMessage = Some("Service unavailable")
+    )
+
+    val json = event.toJson
+    json("success").bool shouldBe false
+    json("error_message").str shouldBe "Service unavailable"
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // InstrumentedImageGenerationClient - metrics recording
+  // ─────────────────────────────────────────────────────────────
+
+  "InstrumentedImageGenerationClient" should "record metrics on successful generation" in {
+    val prometheusMetrics = PrometheusMetrics.create()
+    val tracing           = new TracingCollector()
+    val config            = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
+    val instrumented = new InstrumentedImageGenerationClient(
+      new MockImageClient(),
+      config,
+      prometheusMetrics,
+      tracing
+    )
+
+    val result = instrumented.generateImage(
+      "A cat",
+      ImageGenerationOptions(size = ImageSize.Square1024, quality = Some("standard"))
+    )
+    result.isRight shouldBe true
+
+    val imageGenCount = getMetricValue(
+      prometheusMetrics.registry,
+      "llm4s_image_generations_total",
+      Map("provider" -> "openai", "model" -> "dall-e-3", "operation" -> "generate", "status" -> "success")
+    )
+    imageGenCount shouldBe 1.0
+
+    val imagesCount = getMetricValue(
+      prometheusMetrics.registry,
+      "llm4s_images_generated_total",
+      Map("provider" -> "openai", "model" -> "dall-e-3")
+    )
+    imagesCount shouldBe 1.0
+  }
+
+  it should "record cost metrics when pricing is available" in {
+    val prometheusMetrics = PrometheusMetrics.create()
+    val tracing           = new TracingCollector()
+    val config            = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
+    val instrumented = new InstrumentedImageGenerationClient(
+      new MockImageClient(),
+      config,
+      prometheusMetrics,
+      tracing
+    )
+
+    instrumented.generateImage("A cat", ImageGenerationOptions(size = ImageSize.Square1024, quality = Some("standard")))
+
+    val imageCost = getMetricValue(
+      prometheusMetrics.registry,
+      "llm4s_image_generation_cost_usd_total",
+      Map("provider" -> "openai", "model" -> "dall-e-3")
+    )
+    imageCost shouldBe 0.040 +- 0.001
+  }
+
+  it should "record metrics on failed generation" in {
+    val prometheusMetrics = PrometheusMetrics.create()
+    val tracing           = new TracingCollector()
+    val config            = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
+    val instrumented = new InstrumentedImageGenerationClient(
+      new FailingImageClient(),
+      config,
+      prometheusMetrics,
+      tracing
+    )
+
+    val result = instrumented.generateImage("A cat")
+    result.isLeft shouldBe true
+
+    val errorCount = getMetricValue(
+      prometheusMetrics.registry,
+      "llm4s_image_generations_total",
+      Map("provider" -> "openai", "model" -> "dall-e-3", "operation" -> "generate", "status" -> "error_unknown")
+    )
+    errorCount shouldBe 1.0
+  }
+
+  it should "record duration histogram" in {
+    val prometheusMetrics = PrometheusMetrics.create()
+    val tracing           = new TracingCollector()
+    val config            = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
+    val instrumented = new InstrumentedImageGenerationClient(
+      new MockImageClient(),
+      config,
+      prometheusMetrics,
+      tracing
+    )
+
+    instrumented.generateImage("A cat")
+
+    val histogramCount = getHistogramCount(
+      prometheusMetrics.registry,
+      "llm4s_image_generation_duration_seconds",
+      Map("provider" -> "openai", "model" -> "dall-e-3", "operation" -> "generate")
+    )
+    histogramCount shouldBe 1.0
+  }
+
+  it should "record multiple images count correctly" in {
+    val prometheusMetrics = PrometheusMetrics.create()
+    val tracing           = new TracingCollector()
+    val config            = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
+    val instrumented = new InstrumentedImageGenerationClient(
+      new MockImageClient(),
+      config,
+      prometheusMetrics,
+      tracing
+    )
+
+    instrumented.generateImages(
+      "Dogs",
+      3,
+      ImageGenerationOptions(size = ImageSize.Square1024, quality = Some("standard"))
+    )
+
+    val imagesCount = getMetricValue(
+      prometheusMetrics.registry,
+      "llm4s_images_generated_total",
+      Map("provider" -> "openai", "model" -> "dall-e-3")
+    )
+    imagesCount shouldBe 3.0
+
+    val imageCost = getMetricValue(
+      prometheusMetrics.registry,
+      "llm4s_image_generation_cost_usd_total",
+      Map("provider" -> "openai", "model" -> "dall-e-3")
+    )
+    imageCost shouldBe 0.120 +- 0.001
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // InstrumentedImageGenerationClient - trace events
+  // ─────────────────────────────────────────────────────────────
+
+  it should "emit ImageGenerationCompleted trace event on success" in {
+    val tracing = new TracingCollector()
+    val config  = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
+    val instrumented = new InstrumentedImageGenerationClient(
+      new MockImageClient(),
+      config,
+      MetricsCollector.noop,
+      tracing
+    )
+
+    instrumented.generateImage("A cat", ImageGenerationOptions(size = ImageSize.Square1024, quality = Some("standard")))
+
+    val imageEvents = tracing.events.collect { case e: TraceEvent.ImageGenerationCompleted => e }
+    imageEvents should have size 1
+
+    val event = imageEvents.head
+    event.model shouldBe "dall-e-3"
+    event.provider shouldBe "openai"
+    event.operation shouldBe "generate"
+    event.imageCount shouldBe 1
+    event.success shouldBe true
+    event.costUsd shouldBe Some(0.040)
+  }
+
+  it should "emit CostRecorded trace event when cost is available" in {
+    val tracing = new TracingCollector()
+    val config  = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
+    val instrumented = new InstrumentedImageGenerationClient(
+      new MockImageClient(),
+      config,
+      MetricsCollector.noop,
+      tracing
+    )
+
+    instrumented.generateImage("A cat", ImageGenerationOptions(size = ImageSize.Square1024, quality = Some("standard")))
+
+    val costEvents = tracing.events.collect { case e: TraceEvent.CostRecorded => e }
+    costEvents should have size 1
+
+    val costEvent = costEvents.head
+    costEvent.model shouldBe "dall-e-3"
+    costEvent.operation shouldBe "image_generation"
+    costEvent.costType shouldBe "image_generation"
+    costEvent.costUsd shouldBe 0.040 +- 0.001
+  }
+
+  it should "emit error trace event on failure" in {
+    val tracing = new TracingCollector()
+    val config  = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
+    val instrumented = new InstrumentedImageGenerationClient(
+      new FailingImageClient(),
+      config,
+      MetricsCollector.noop,
+      tracing
+    )
+
+    instrumented.generateImage("A cat")
+
+    val imageEvents = tracing.events.collect { case e: TraceEvent.ImageGenerationCompleted => e }
+    imageEvents should have size 1
+
+    val event = imageEvents.head
+    event.success shouldBe false
+    event.errorMessage shouldBe Some("Service unavailable")
+    event.costUsd shouldBe None
+  }
+
+  it should "not emit CostRecorded on failure" in {
+    val tracing = new TracingCollector()
+    val config  = OpenAIConfig(apiKey = "test-key", model = "dall-e-3")
+    val instrumented = new InstrumentedImageGenerationClient(
+      new FailingImageClient(),
+      config,
+      MetricsCollector.noop,
+      tracing
+    )
+
+    instrumented.generateImage("A cat")
+
+    val costEvents = tracing.events.collect { case e: TraceEvent.CostRecorded => e }
+    costEvents shouldBe empty
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // MetricsCollector.noop compatibility
+  // ─────────────────────────────────────────────────────────────
+
+  "MetricsCollector.noop" should "not throw on image generation methods" in {
+    val metrics = MetricsCollector.noop
+
+    noException should be thrownBy {
+      metrics.observeImageGeneration("openai", "dall-e-3", "generate", Outcome.Success, 1.second, 1)
+      metrics.recordImageGenerationCost("openai", "dall-e-3", 0.04, 1)
+      metrics.observeImageGeneration(
+        "openai",
+        "dall-e-3",
+        "generate",
+        Outcome.Error(ErrorKind.ServiceError),
+        500.millis,
+        0
+      )
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // ImageGeneration factory with instrumentation
+  // ─────────────────────────────────────────────────────────────
+
+  "ImageGeneration.client with metrics and tracing" should "return an instrumented client" in {
+    val tracing = new TracingCollector()
+    val metrics = PrometheusMetrics.create()
+    val config  = StableDiffusionConfig()
+
+    val result = ImageGeneration.client(config, metrics, tracing)
+    result.isRight shouldBe true
+  }
+
+  "ImageGeneration.client without args" should "still work (backward compatible)" in {
+    val result = ImageGeneration.client(StableDiffusionConfig())
+    result.isRight shouldBe true
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Helpers
+  // ─────────────────────────────────────────────────────────────
+
+  private def getMetricValue(registry: PrometheusRegistry, name: String, labels: Map[String, String]): Double = {
+    val lookupName = name.stripSuffix("_total")
+    val snapshots  = registry.scrape()
+
+    snapshots
+      .stream()
+      .iterator()
+      .asScala
+      .find(_.getMetadata.getName == lookupName)
+      .flatMap { metricSnapshot =>
+        metricSnapshot.getDataPoints
+          .iterator()
+          .asScala
+          .find { dataPoint =>
+            val dpLabels = dataPoint.getLabels.iterator().asScala.map(l => l.getName -> l.getValue).toMap
+            labels.forall { case (k, v) => dpLabels.get(k).contains(v) }
+          }
+          .map {
+            case c: io.prometheus.metrics.model.snapshots.CounterSnapshot.CounterDataPointSnapshot => c.getValue
+            case _                                                                                 => 0.0
+          }
+      }
+      .getOrElse(0.0)
+  }
+
+  private def getHistogramCount(registry: PrometheusRegistry, name: String, labels: Map[String, String]): Double = {
+    val lookupName = name.stripSuffix("_total")
+    val snapshots  = registry.scrape()
+
+    snapshots
+      .stream()
+      .iterator()
+      .asScala
+      .find(_.getMetadata.getName == lookupName)
+      .flatMap { metricSnapshot =>
+        metricSnapshot.getDataPoints
+          .iterator()
+          .asScala
+          .find { dataPoint =>
+            val dpLabels = dataPoint.getLabels.iterator().asScala.map(l => l.getName -> l.getValue).toMap
+            labels.forall { case (k, v) => dpLabels.get(k).contains(v) }
+          }
+          .collect { case h: io.prometheus.metrics.model.snapshots.HistogramSnapshot.HistogramDataPointSnapshot =>
+            h.getCount.toDouble
+          }
+      }
+      .getOrElse(0.0)
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/imagegeneration/ImagePricingRegistrySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/imagegeneration/ImagePricingRegistrySpec.scala
@@ -1,0 +1,82 @@
+package org.llm4s.imagegeneration
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ImagePricingRegistrySpec extends AnyFlatSpec with Matchers {
+
+  "ImagePricingRegistry.costPerImage" should "return correct price for gpt-image-1 standard config" in {
+    ImagePricingRegistry.costPerImage("gpt-image-1", "medium", "1024x1024") shouldBe Some(0.042)
+  }
+
+  it should "return correct price for gpt-image-1 high quality large" in {
+    ImagePricingRegistry.costPerImage("gpt-image-1", "high", "1536x1024") shouldBe Some(0.250)
+  }
+
+  it should "return correct price for dall-e-3 standard" in {
+    ImagePricingRegistry.costPerImage("dall-e-3", "standard", "1024x1024") shouldBe Some(0.040)
+  }
+
+  it should "return correct price for dall-e-3 hd" in {
+    ImagePricingRegistry.costPerImage("dall-e-3", "hd", "1024x1024") shouldBe Some(0.080)
+  }
+
+  it should "return correct price for dall-e-2" in {
+    ImagePricingRegistry.costPerImage("dall-e-2", "standard", "512x512") shouldBe Some(0.018)
+  }
+
+  it should "return None for unknown model" in {
+    ImagePricingRegistry.costPerImage("unknown-model", "standard", "1024x1024") shouldBe None
+  }
+
+  it should "return None for unknown quality" in {
+    ImagePricingRegistry.costPerImage("dall-e-3", "ultra", "1024x1024") shouldBe None
+  }
+
+  it should "return None for unknown size" in {
+    ImagePricingRegistry.costPerImage("dall-e-3", "standard", "2048x2048") shouldBe None
+  }
+
+  "ImagePricingRegistry.costPerImageWithDefaults" should "default quality to standard" in {
+    ImagePricingRegistry.costPerImageWithDefaults("dall-e-3", None, ImageSize.Square1024) shouldBe Some(0.040)
+  }
+
+  it should "default quality to standard when empty string" in {
+    ImagePricingRegistry.costPerImageWithDefaults("dall-e-3", Some(""), ImageSize.Square1024) shouldBe Some(0.040)
+  }
+
+  it should "use provided quality when present" in {
+    ImagePricingRegistry.costPerImageWithDefaults("dall-e-3", Some("hd"), ImageSize.Square1024) shouldBe Some(0.080)
+  }
+
+  it should "handle ImageSize.Auto" in {
+    ImagePricingRegistry.costPerImageWithDefaults("gpt-image-1", Some("low"), ImageSize.Auto) shouldBe Some(0.011)
+  }
+
+  it should "handle custom sizes by formatting as WxH" in {
+    ImagePricingRegistry.costPerImageWithDefaults("dall-e-2", None, ImageSize.Custom(512, 512)) shouldBe Some(0.018)
+  }
+
+  "ImagePricingRegistry.estimateCost" should "multiply per-image cost by count" in {
+    val singleCost = ImagePricingRegistry.costPerImageWithDefaults("dall-e-3", Some("standard"), ImageSize.Square1024)
+    singleCost shouldBe Some(0.040)
+
+    ImagePricingRegistry.estimateCost("dall-e-3", Some("standard"), ImageSize.Square1024, 3) shouldBe Some(0.120)
+  }
+
+  it should "return None when pricing is unknown" in {
+    ImagePricingRegistry.estimateCost("unknown-model", None, ImageSize.Square1024, 1) shouldBe None
+  }
+
+  it should "return Some(0.0) when count is 0" in {
+    ImagePricingRegistry.estimateCost("dall-e-3", Some("standard"), ImageSize.Square1024, 0) shouldBe Some(0.0)
+  }
+
+  "ImagePricingRegistry.knownModels" should "include expected models" in {
+    val models = ImagePricingRegistry.knownModels
+    models should contain("gpt-image-1")
+    models should contain("dall-e-3")
+    models should contain("dall-e-2")
+    models should contain("stable-diffusion-xl-1024-v1-0")
+  }
+}

--- a/modules/trace-opentelemetry/src/main/scala/org/llm4s/trace/OpenTelemetryTracing.scala
+++ b/modules/trace-opentelemetry/src/main/scala/org/llm4s/trace/OpenTelemetryTracing.scala
@@ -265,6 +265,25 @@ class OpenTelemetryTracing(
             .put("timestamp", e.timestamp.toString)
             .build()
         )
+
+      case e: TraceEvent.ImageGenerationCompleted =>
+        val builder = Attributes
+          .builder()
+          .put(TraceAttributes.EventType, "image-generation")
+          .put("gen_ai.request.model", e.model)
+          .put("provider", e.provider)
+          .put("operation", e.operation)
+          .put("image_count", e.imageCount.toLong)
+          .put("size", e.size)
+          .put("quality", e.quality)
+          .put("duration_ms", e.durationMs)
+          .put("success", e.success)
+        e.costUsd.foreach(c => builder.put("cost.usd", c))
+        e.errorMessage.foreach(m => builder.put("error.message", m))
+        (
+          "Image Generation - " + e.operation,
+          builder.build()
+        )
     }
   }
 


### PR DESCRIPTION
- Add ImagePricingRegistry with per-image pricing for DALL-E 2/3, GPT-Image-1, Stable Diffusion XL, and Stability AI models across quality/size variants
- Add InstrumentedImageGenerationClient decorator that wraps any ImageGenerationClient with metrics collection and trace event emission
- Add observeImageGeneration and recordImageGenerationCost to MetricsCollector
- Add Prometheus counters (llm4s_image_generations_total, llm4s_images_generated_total, llm4s_image_generation_cost_usd_total) and histogram (llm4s_image_generation_duration_seconds) to PrometheusMetrics
- Add ImageGenerationCompleted TraceEvent with JSON serialization
- Update ConsoleTracing, LangfuseTracing, OpenTelemetryTracing, and TraceCollector to handle the new trace event
- Add ImageGeneration.client(config, metrics, tracing) factory overload while preserving backward compatibility of client(config)
- Add comprehensive tests: ImagePricingRegistrySpec (13 tests) and ImageGenerationCostTrackingSpec (15 tests)

Closes #501
 