### PR TITLE
fix: propagate pgKeywordTableName in RAGConfig.withSearchIndex

### DIFF
--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -254,6 +254,9 @@ llm4s {
         vectorTableName = "vectors"
         vectorTableName = ${?PGVECTOR_TABLE}
 
+        keywordTableName = "documents"
+        keywordTableName = ${?PGVECTOR_KEYWORD_TABLE}
+
         maxPoolSize = 10
         maxPoolSize = ${?PGVECTOR_MAX_POOL_SIZE}
       }

--- a/modules/core/src/main/scala/org/llm4s/config/PgSearchIndexConfigLoader.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/PgSearchIndexConfigLoader.scala
@@ -8,13 +8,14 @@ import pureconfig.{ ConfigReader => PureConfigReader, ConfigSource }
 object PgSearchIndexConfigLoader {
 
   implicit private val pgConfigReader: PureConfigReader[SearchIndex.PgConfig] =
-    PureConfigReader.forProduct7(
+    PureConfigReader.forProduct8(
       "host",
       "port",
       "database",
       "user",
       "password",
       "vectorTableName",
+      "keywordTableName",
       "maxPoolSize"
     )(SearchIndex.PgConfig.apply)
 

--- a/modules/core/src/main/scala/org/llm4s/rag/RAGConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/rag/RAGConfig.scala
@@ -336,7 +336,8 @@ final case class RAGConfig(
           pgVectorConnectionString = Some(pgCfg.jdbcUrl),
           pgVectorUser = Some(pgCfg.user),
           pgVectorPassword = Some(pgCfg.password),
-          pgVectorTableName = Some(pgCfg.vectorTableName)
+          pgVectorTableName = Some(pgCfg.vectorTableName),
+          pgKeywordTableName = Some(pgCfg.keywordTableName)
         )
       case None =>
         baseConfig

--- a/modules/core/src/main/scala/org/llm4s/rag/permissions/SearchIndex.scala
+++ b/modules/core/src/main/scala/org/llm4s/rag/permissions/SearchIndex.scala
@@ -174,6 +174,7 @@ object SearchIndex {
    * @param user Database user
    * @param password Database password
    * @param vectorTableName Name of the vectors table
+   * @param keywordTableName Name of the keyword index table
    * @param maxPoolSize Maximum connection pool size
    */
   final case class PgConfig(
@@ -183,6 +184,7 @@ object SearchIndex {
     user: String = "postgres",
     password: String = "",
     vectorTableName: String = "vectors",
+    keywordTableName: String = "documents",
     maxPoolSize: Int = 10
   ) {
     def jdbcUrl: String = s"jdbc:postgresql://$host:$port/$database"

--- a/modules/core/src/test/scala/org/llm4s/config/Llm4sConfigFacadeSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/config/Llm4sConfigFacadeSpec.scala
@@ -72,6 +72,7 @@ class Llm4sConfigFacadeSpec extends AnyWordSpec with Matchers {
         "llm4s.rag.permissions.pg.user",
         "llm4s.rag.permissions.pg.password",
         "llm4s.rag.permissions.pg.vectorTableName",
+        "llm4s.rag.permissions.pg.keywordTableName",
         "llm4s.rag.permissions.pg.maxPoolSize"
       )
       withProps(Map.empty, pgKeys) {
@@ -88,13 +89,14 @@ class Llm4sConfigFacadeSpec extends AnyWordSpec with Matchers {
 
     "load valid pg config with overrides" in {
       val props = Map(
-        "llm4s.rag.permissions.pg.host"            -> "localhost",
-        "llm4s.rag.permissions.pg.port"            -> "5432",
-        "llm4s.rag.permissions.pg.database"        -> "testdb",
-        "llm4s.rag.permissions.pg.user"            -> "testuser",
-        "llm4s.rag.permissions.pg.password"        -> "testpass",
-        "llm4s.rag.permissions.pg.vectorTableName" -> "test_vectors",
-        "llm4s.rag.permissions.pg.maxPoolSize"     -> "5"
+        "llm4s.rag.permissions.pg.host"             -> "localhost",
+        "llm4s.rag.permissions.pg.port"             -> "5432",
+        "llm4s.rag.permissions.pg.database"         -> "testdb",
+        "llm4s.rag.permissions.pg.user"             -> "testuser",
+        "llm4s.rag.permissions.pg.password"         -> "testpass",
+        "llm4s.rag.permissions.pg.vectorTableName"  -> "test_vectors",
+        "llm4s.rag.permissions.pg.keywordTableName" -> "test_keywords",
+        "llm4s.rag.permissions.pg.maxPoolSize"      -> "5"
       )
 
       withProps(props) {
@@ -107,6 +109,7 @@ class Llm4sConfigFacadeSpec extends AnyWordSpec with Matchers {
         pg.user shouldBe "testuser"
         pg.password shouldBe "testpass"
         pg.vectorTableName shouldBe "test_vectors"
+        pg.keywordTableName shouldBe "test_keywords"
         pg.maxPoolSize shouldBe 5
       }
     }

--- a/modules/core/src/test/scala/org/llm4s/config/PgSearchIndexConfigLoaderSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/config/PgSearchIndexConfigLoaderSpec.scala
@@ -28,6 +28,7 @@ class PgSearchIndexConfigLoaderSpec extends AnyWordSpec with Matchers with Eithe
           |        user = "pguser"
           |        password = "pgpass123"
           |        vectorTableName = "my_vectors"
+          |        keywordTableName = "my_keywords"
           |        maxPoolSize = 20
           |      }
           |    }
@@ -45,6 +46,7 @@ class PgSearchIndexConfigLoaderSpec extends AnyWordSpec with Matchers with Eithe
       pg.user shouldBe "pguser"
       pg.password shouldBe "pgpass123"
       pg.vectorTableName shouldBe "my_vectors"
+      pg.keywordTableName shouldBe "my_keywords"
       pg.maxPoolSize shouldBe 20
     }
 
@@ -95,6 +97,7 @@ class PgSearchIndexConfigLoaderSpec extends AnyWordSpec with Matchers with Eithe
           |        user = "postgres"
           |        password = ""
           |        vectorTableName = "vectors"
+          |        keywordTableName = "documents"
           |        maxPoolSize = 10
           |      }
           |    }
@@ -110,6 +113,7 @@ class PgSearchIndexConfigLoaderSpec extends AnyWordSpec with Matchers with Eithe
       pg.port shouldBe 5432
       pg.database shouldBe "postgres"
       pg.vectorTableName shouldBe "vectors"
+      pg.keywordTableName shouldBe "documents"
       pg.maxPoolSize shouldBe 10
       pg.jdbcUrl shouldBe "jdbc:postgresql://localhost:5432/postgres"
     }


### PR DESCRIPTION
## Summary
- Fixes #812 — `RAGConfig.withSearchIndex(pgSearchIndex)` now correctly propagates the keyword table name, ensuring both vector and keyword storage use PostgreSQL consistently

## Changes
- Add `keywordTableName: String = "documents"` to `SearchIndex.PgConfig`
- Set `pgKeywordTableName = Some(pgCfg.keywordTableName)` in `RAGConfig.withSearchIndex`
- Update `PgSearchIndexConfigLoader` (`forProduct7` → `forProduct8`)
- Add `keywordTableName` to `reference.conf` with `PGVECTOR_KEYWORD_TABLE` env override
- Update `PgSearchIndexConfigLoaderSpec` and `Llm4sConfigFacadeSpec` tests

## Context
PR #815 addressed this same issue but included 2600+ unrelated lines. This is a clean 6-file, 23-line fix.

## Test plan
- [ ] `PgSearchIndexConfigLoaderSpec` passes (config loading with new field)
- [ ] `Llm4sConfigFacadeSpec` passes (facade with new field)
- [ ] Pre-commit hook passes (all 5521 tests green)