### PR TITLE
fix: add releaseResources to MistralClient to close httpClient (#685)

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
@@ -36,6 +36,12 @@ class MistralClient(
   protected def providerName: String      = "mistral"
   protected def modelName: String         = config.model
 
+  override protected def releaseResources(): Unit =
+    (httpClient: Any) match {
+      case c: AutoCloseable => c.close()
+      case _                => ()
+    }
+
   override def complete(
     conversation: Conversation,
     options: CompletionOptions


### PR DESCRIPTION
## Summary
- `LLMClient` already extends `AutoCloseable` and 8 of 9 providers already close their HTTP clients in `releaseResources()`
- `MistralClient` was the only provider missing this override, leaking its JDK `HttpClient` thread pool on `close()`
- Added `releaseResources()` using the same safe pattern as other providers: `(httpClient: Any) match { case c: AutoCloseable => c.close(); case _ => () }`

## Test plan
- [x] Existing `MistralClientClosedStateTest` verifies close idempotency and error-after-close behavior
- [x] `LLMClientContractBehaviors` verifies `AutoCloseable` compliance and `Using` support
- [x] All pre-commit checks pass

Closes #685