### PR TITLE
docs: add Code of Conduct reference in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 Thank you for your interest in contributing to LLM4S!
 
+## Code of Conduct
+
+This project follows our [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold these standards.
+
 ## Quick Start
 
 1. **Read the docs:**


### PR DESCRIPTION
## Summary
- Adds a "Code of Conduct" section near the top of CONTRIBUTING.md linking to CODE_OF_CONDUCT.md
- Ensures new contributors are aware of community standards before contributing

Fixes #753

## Test plan
- [x] Verify the link to CODE_OF_CONDUCT.md resolves correctly
- [x] Confirm section placement is near the top, before Quick Start