### PR TITLE
fix: replace unsafe .getOrElse(Seq.empty) with typed error in AnswerRelevancy (#733)

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/rag/evaluation/metrics/AnswerRelevancy.scala
+++ b/modules/core/src/main/scala/org/llm4s/rag/evaluation/metrics/AnswerRelevancy.scala
@@ -139,7 +139,12 @@ Respond with ONLY a JSON array of strings:"""
    */
   private def embedText(text: String): Result[Seq[Double]] = {
     val request = EmbeddingRequest(input = Seq(text), model = modelConfig)
-    embeddingClient.embed(request).map(response => response.embeddings.headOption.getOrElse(Seq.empty))
+    embeddingClient
+      .embed(request)
+      .flatMap(response =>
+        response.embeddings.headOption
+          .toRight(org.llm4s.error.ProcessingError("embedText", "Embedding provider returned empty embeddings list"))
+      )
   }
 
   /**


### PR DESCRIPTION
## Summary
- `AnswerRelevancy.embedText()` silently returned an empty embedding vector (`Seq.empty`) when the provider returned no embeddings, producing meaningless similarity scores downstream
- Replaced with `.headOption.toRight(ProcessingError(...))` to return a typed error instead
- The other locations mentioned in the issue (`RAG.scala`, `RAGPipeline.scala`) already use `headOption.toRight(...)`
- `CachingLLMClient.scala` guards with `.nonEmpty` before `.head`, so is already safe

## Test plan
- [x] All 82 RAG evaluation tests pass
- [x] Pre-commit checks pass

Closes #733