### PR TITLE
docs: fix Codecov badge token and close #581

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/static/v1?label=Chat%20on&message=Discord&color=blue&logo=Discord&style=flat-square" alt="Discord">
     </a>
     <a href="https://codecov.io/gh/llm4s/llm4s">
-        <img src="https://codecov.io/gh/llm4s/llm4s/branch/main/graph/badge.svg" alt="codecov">
+        <img src="https://codecov.io/gh/llm4s/llm4s/branch/main/graph/badge.svg?token=WQSNRKV121" alt="codecov">
     </a>
 </h4>
 <h4 align="center">


### PR DESCRIPTION
## Summary
- Adds the `?token=WQSNRKV121` parameter to the Codecov badge URL in README.md for reliable rendering
- Closes #581 — the Codecov-driven coverage identification requested in the issue is already fully implemented:
  - **CI uploads coverage to Codecov** on every push/PR (`ci.yml` coverage job using `codecov/codecov-action@v4`)
  - **Codecov dashboard** at https://app.codecov.io/gh/llm4s/llm4s provides file-level and line-level coverage, uncovered areas, and PR coverage diffs
  - **Coverage badge** in README links to the dashboard
  - **Coverage Gaps Analysis workflow** exists for deeper analysis
  - **`sbt cov`** available locally for contributors

Closes #581

## Test plan
- [x] Verify badge renders correctly with token parameter