### PR TITLE
fix: recreate heartbeat executor on start to allow container restart (#715)

### DIFF
--- a/modules/workspace/workspaceClient/src/main/scala/org/llm4s/workspace/ContainerisedWorkspace.scala
+++ b/modules/workspace/workspaceClient/src/main/scala/org/llm4s/workspace/ContainerisedWorkspace.scala
@@ -46,9 +46,9 @@ class ContainerisedWorkspace(
   private val ResponseTimeoutBufferSec = 5
 
   // State tracking
-  private val containerRunning                            = new AtomicBoolean(false)
-  private val wsConnected                                 = new AtomicBoolean(false)
-  private val heartbeatExecutor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
+  private val containerRunning  = new AtomicBoolean(false)
+  private val wsConnected       = new AtomicBoolean(false)
+  private val heartbeatExecutor = new AtomicReference[ScheduledExecutorService]()
 
   // WebSocket client and response handling
   private val wsClient          = new AtomicReference[WebSocketClient]()
@@ -264,7 +264,9 @@ class ContainerisedWorkspace(
   private def startHeartbeatTask(): Unit = {
     logger.info("Starting heartbeat task")
 
-    heartbeatExecutor.scheduleAtFixedRate(
+    val executor = Executors.newSingleThreadScheduledExecutor()
+    heartbeatExecutor.set(executor)
+    executor.scheduleAtFixedRate(
       () =>
         if (containerRunning.get() && wsConnected.get()) {
           val hb = Try(sendHeartbeat())
@@ -310,9 +312,11 @@ class ContainerisedWorkspace(
     }
 
     // Shutdown heartbeat task
-    heartbeatExecutor.shutdown()
-    val term = Try(heartbeatExecutor.awaitTermination(3, TimeUnit.SECONDS)).getOrElse(false)
-    if (!term) heartbeatExecutor.shutdownNow()
+    Option(heartbeatExecutor.getAndSet(null)).foreach { executor =>
+      executor.shutdown()
+      val term = Try(executor.awaitTermination(3, TimeUnit.SECONDS)).getOrElse(false)
+      if (!term) executor.shutdownNow()
+    }
 
     // Execute stop and remove as separate commands
     val stopResult = Try {


### PR DESCRIPTION
## Summary
- Changed `heartbeatExecutor` from a fixed `ScheduledExecutorService` (created once at construction) to an `AtomicReference` that is recreated fresh on each `startHeartbeatTask()` call
- `stopContainer()` atomically retrieves and nulls the reference before shutting down the executor, making cleanup idempotent
- This allows the same `ContainerisedWorkspace` instance to be stopped and restarted without `RejectedExecutionException`

Closes #715

## Test plan
- [x] All existing workspace client tests pass (13 succeeded, 5 Docker tests skipped as expected)
- [x] Downstream `workspaceSamples` compiles cleanly
- [x] Pre-commit hooks pass
- [ ] Manual: start → stop → start cycle with Docker should succeed without executor rejection errors