### PR TITLE
feat: add CostTracker for in-process cost aggregation

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/metrics/CostTracker.scala
+++ b/modules/core/src/main/scala/org/llm4s/metrics/CostTracker.scala
@@ -111,27 +111,41 @@ final class CostTracker private () extends MetricsCollector {
 
   /** Returns a [[UsageSummary]] for interop with agent-level tracking. */
   def snapshot: UsageSummary = {
-    val models = byModel
+    val current = state.get()
+    val models = current.map { case (model, acc) =>
+      model -> ModelUsage(
+        requestCount = acc.requestCount,
+        inputTokens = acc.inputTokens,
+        outputTokens = acc.outputTokens,
+        thinkingTokens = 0L,
+        totalCost = acc.totalCost
+      )
+    }
     UsageSummary(
-      requestCount = totalRequests,
-      inputTokens = totalInputTokens,
-      outputTokens = totalOutputTokens,
+      requestCount = current.values.foldLeft(0L)(_ + _.requestCount),
+      inputTokens = current.values.foldLeft(0L)(_ + _.inputTokens),
+      outputTokens = current.values.foldLeft(0L)(_ + _.outputTokens),
       thinkingTokens = 0L,
-      totalCost = totalCost,
+      totalCost = current.values.foldLeft(BigDecimal(0))(_ + _.totalCost),
       byModel = models
     )
   }
 
   /** Human-readable summary string. */
   def summary: String = {
-    val cost   = totalCost.setScale(6, BigDecimal.RoundingMode.HALF_UP)
-    val models = state.get()
-    val modelLines = models.toSeq.sortBy(_._1).map { case (model, acc) =>
+    val current  = state.get()
+    val reqCount = current.values.foldLeft(0L)(_ + _.requestCount)
+    val tokenCount = current.values.foldLeft(0L)(_ + _.inputTokens) +
+      current.values.foldLeft(0L)(_ + _.outputTokens)
+    val cost = current.values
+      .foldLeft(BigDecimal(0))(_ + _.totalCost)
+      .setScale(6, BigDecimal.RoundingMode.HALF_UP)
+    val modelLines = current.toSeq.sortBy(_._1).map { case (model, acc) =>
       val mc = acc.totalCost.setScale(6, BigDecimal.RoundingMode.HALF_UP)
       s"  $model: ${acc.requestCount} requests, ${acc.inputTokens + acc.outputTokens} tokens, $$$mc"
     }
     val header =
-      s"CostTracker: $totalRequests requests, $totalTokens tokens, $$$cost"
+      s"CostTracker: $reqCount requests, $tokenCount tokens, $$$cost"
     if (modelLines.isEmpty) header
     else (header +: modelLines).mkString("\n")
   }

--- a/modules/core/src/main/scala/org/llm4s/metrics/MetricsCollector.scala
+++ b/modules/core/src/main/scala/org/llm4s/metrics/MetricsCollector.scala
@@ -120,40 +120,43 @@ object MetricsCollector {
    * }}}
    */
   def compose(collectors: MetricsCollector*): MetricsCollector = new MetricsCollector {
+    private def safeForEach(f: MetricsCollector => Unit): Unit =
+      collectors.foreach(c => scala.util.Try(f(c)))
+
     override def observeRequest(
       provider: String,
       model: String,
       outcome: Outcome,
       duration: FiniteDuration
-    ): Unit = collectors.foreach(_.observeRequest(provider, model, outcome, duration))
+    ): Unit = safeForEach(_.observeRequest(provider, model, outcome, duration))
 
     override def addTokens(
       provider: String,
       model: String,
       inputTokens: Long,
       outputTokens: Long
-    ): Unit = collectors.foreach(_.addTokens(provider, model, inputTokens, outputTokens))
+    ): Unit = safeForEach(_.addTokens(provider, model, inputTokens, outputTokens))
 
     override def recordCost(
       provider: String,
       model: String,
       costUsd: Double
-    ): Unit = collectors.foreach(_.recordCost(provider, model, costUsd))
+    ): Unit = safeForEach(_.recordCost(provider, model, costUsd))
 
     override def recordRetryAttempt(
       provider: String,
       attemptNumber: Int
-    ): Unit = collectors.foreach(_.recordRetryAttempt(provider, attemptNumber))
+    ): Unit = safeForEach(_.recordRetryAttempt(provider, attemptNumber))
 
     override def recordCircuitBreakerTransition(
       provider: String,
       newState: String
-    ): Unit = collectors.foreach(_.recordCircuitBreakerTransition(provider, newState))
+    ): Unit = safeForEach(_.recordCircuitBreakerTransition(provider, newState))
 
     override def recordError(
       errorKind: ErrorKind,
       provider: String
-    ): Unit = collectors.foreach(_.recordError(errorKind, provider))
+    ): Unit = safeForEach(_.recordError(errorKind, provider))
   }
 
   val noop: MetricsCollector = new MetricsCollector {

--- a/modules/core/src/test/scala/org/llm4s/metrics/CostTrackerSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/metrics/CostTrackerSpec.scala
@@ -127,6 +127,25 @@ class CostTrackerSpec extends AnyFlatSpec with Matchers {
     (snap.byModel should contain).key("gpt-4o")
   }
 
+  it should "produce a snapshot where totals match byModel breakdown" in {
+    val tracker = mkTracker()
+
+    tracker.observeRequest("openai", "gpt-4o", Outcome.Success, 1.second)
+    tracker.addTokens("openai", "gpt-4o", 100L, 50L)
+    tracker.recordCost("openai", "gpt-4o", 0.01)
+
+    tracker.observeRequest("anthropic", "claude-sonnet", Outcome.Success, 2.seconds)
+    tracker.addTokens("anthropic", "claude-sonnet", 200L, 80L)
+    tracker.recordCost("anthropic", "claude-sonnet", 0.02)
+
+    val snap = tracker.snapshot
+
+    snap.requestCount shouldBe snap.byModel.values.map(_.requestCount).sum
+    snap.inputTokens shouldBe snap.byModel.values.map(_.inputTokens).sum
+    snap.outputTokens shouldBe snap.byModel.values.map(_.outputTokens).sum
+    snap.totalCost shouldBe snap.byModel.values.map(_.totalCost).sum
+  }
+
   "MetricsCollector.compose" should "fan out to all collectors" in {
     val tracker1 = mkTracker()
     val tracker2 = mkTracker()
@@ -140,5 +159,28 @@ class CostTrackerSpec extends AnyFlatSpec with Matchers {
     tracker2.totalRequests shouldBe 1L
     tracker1.totalTokens shouldBe 150L
     tracker2.totalCost shouldBe BigDecimal.decimal(0.01)
+  }
+
+  it should "continue to remaining collectors when one throws" in {
+    val failing = new MetricsCollector {
+      override def observeRequest(p: String, m: String, o: Outcome, d: FiniteDuration): Unit =
+        throw new RuntimeException("boom")
+      override def addTokens(p: String, m: String, i: Long, o: Long): Unit =
+        throw new RuntimeException("boom")
+      override def recordCost(p: String, m: String, c: Double): Unit =
+        throw new RuntimeException("boom")
+    }
+    val tracker  = mkTracker()
+    val composed = MetricsCollector.compose(failing, tracker)
+
+    noException should be thrownBy {
+      composed.observeRequest("openai", "gpt-4o", Outcome.Success, 1.second)
+      composed.addTokens("openai", "gpt-4o", 100L, 50L)
+      composed.recordCost("openai", "gpt-4o", 0.01)
+    }
+
+    tracker.totalRequests shouldBe 1L
+    tracker.totalTokens shouldBe 150L
+    tracker.totalCost shouldBe BigDecimal.decimal(0.01)
   }
 }


### PR DESCRIPTION
## Summary

Closes #515

- Add `CostTracker`, a `MetricsCollector` implementation that accumulates cost/token/request data in-memory with lock-free thread safety (`AtomicReference` + CAS) and BigDecimal precision for cost accumulation
- Add `MetricsCollector.compose()` combinator to fan out metrics calls to multiple collectors (e.g. `CostTracker` alongside `PrometheusMetrics`)
- Query API: `totalCost`, `totalTokens`, `totalRequests`, `byModel` (returns `ModelUsage`), `snapshot` (returns `UsageSummary`), `summary` (human-readable string), `reset()`

### Usage
```scala
// Standalone
val tracker = CostTracker.create()
val client = LLMConnect.getClient(config, tracker)
// ... make calls ...
println(tracker.summary)

// Composed with Prometheus
val combined = MetricsCollector.compose(prometheusMetrics, tracker)
val client = LLMConnect.getClient(config, combined)
```

## Test plan
- [x] Empty tracker returns zeros/empty maps
- [x] Single request accumulation (tokens, cost, request count)
- [x] Multiple models tracked separately with correct aggregates
- [x] BigDecimal precision: 1000 × $0.001 == $1.00 exactly
- [x] Thread safety: 10 concurrent threads × 100 ops, final totals match expected sums
- [x] Reset clears all state
- [x] `summary` string contains key fields
- [x] `snapshot` returns valid `UsageSummary`
- [x] `MetricsCollector.compose` fans out to all collectors
- [x] All 5618 existing tests pass