### PR TITLE
fix: handle input_json_delta in Anthropic streaming tool calls

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
@@ -8,6 +8,8 @@ import com.anthropic.models.messages.{
   ThinkingConfigEnabled,
   Tool
 }
+
+import scala.collection.mutable
 import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.config.{ AnthropicConfig, ProviderConfig }
 import org.llm4s.llmconnect.model._
@@ -201,6 +203,7 @@ curl https://api.anthropic.com/v1/messages \
         // Create accumulator for building the final completion
         val accumulator                      = StreamingAccumulator.create()
         var currentMessageId: Option[String] = None
+        val blockIndexToToolId               = mutable.Map.empty[Long, String]
 
         // Process the stream
         val attempt = Try {
@@ -261,6 +264,24 @@ curl https://api.anthropic.com/v1/messages \
                     }
                   }
                 }
+
+                // Handle input_json_delta for tool call arguments
+                Try(delta.inputJson()).foreach { inputJsonOpt =>
+                  if (inputJsonOpt != null && inputJsonOpt.isPresent) {
+                    val fragment   = inputJsonOpt.get().partialJson()
+                    val toolCallId = blockIndexToToolId.getOrElse(contentDelta.index(), "")
+                    if (fragment != null && fragment.nonEmpty && toolCallId.nonEmpty) {
+                      val chunk = StreamedChunk(
+                        id = currentMessageId.getOrElse(""),
+                        content = None,
+                        toolCall = Some(ToolCall(id = toolCallId, name = "", arguments = ujson.Str(fragment))),
+                        finishReason = None
+                      )
+                      accumulator.addChunk(chunk)
+                      onChunk(chunk)
+                    }
+                  }
+                }
               }
 
               val contentStartOpt = event.contentBlockStart()
@@ -269,6 +290,7 @@ curl https://api.anthropic.com/v1/messages \
                 val block        = contentStart.contentBlock()
                 if (block.isToolUse) {
                   val toolUse = block.asToolUse()
+                  blockIndexToToolId(contentStart.index()) = toolUse.id()
                   val chunk = StreamedChunk(
                     id = currentMessageId.getOrElse(""),
                     content = None,

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/streaming/StreamingResponseHandler.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/streaming/StreamingResponseHandler.scala
@@ -182,6 +182,8 @@ class AnthropicStreamingHandler extends BaseStreamingResponseHandler {
 
   private val sseParser                        = SSEParser.createStreamingParser()
   private var currentMessageId: Option[String] = None
+  private val blockIndexToToolId: scala.collection.mutable.Map[Long, String] =
+    scala.collection.mutable.Map.empty
 
   override def processChunk(chunk: String): Result[Option[StreamedChunk]] =
     scala.util
@@ -196,6 +198,29 @@ class AnthropicStreamingHandler extends BaseStreamingResponseHandler {
                 event.data.foreach { data =>
                   Try(ujson.read(data)).toOption.foreach { json =>
                     currentMessageId = json.obj.get("message").flatMap(_("id").strOpt)
+                  }
+                }
+              case Some("content_block_start") =>
+                event.data.foreach { data =>
+                  Try(ujson.read(data)).toOption.foreach { json =>
+                    val blockIndex =
+                      json.obj.get("index").flatMap(_.numOpt).map(_.toLong).getOrElse(0L)
+                    for {
+                      cb       <- json.obj.get("content_block")
+                      cbType   <- cb.obj.get("type").flatMap(_.strOpt) if cbType == "tool_use"
+                      toolId   <- cb.obj.get("id").flatMap(_.strOpt)
+                      toolName <- cb.obj.get("name").flatMap(_.strOpt)
+                    } {
+                      blockIndexToToolId(blockIndex) = toolId
+                      val c = StreamedChunk(
+                        id = currentMessageId.getOrElse(""),
+                        content = None,
+                        toolCall = Some(ToolCall(id = toolId, name = toolName, arguments = ujson.Obj())),
+                        finishReason = None
+                      )
+                      accumulator.addChunk(c)
+                      latestChunk = Some(c)
+                    }
                   }
                 }
               case Some("content_block_delta") =>
@@ -239,9 +264,21 @@ class AnthropicStreamingHandler extends BaseStreamingResponseHandler {
           )
 
         case "input_json_delta" =>
-          // Handle tool use deltas
-          // This would accumulate JSON for tool calls
-          None // Simplified for now
+          val fragment =
+            delta.obj.get("partial_json").flatMap(_.strOpt).getOrElse("")
+          val blockIndex =
+            json.obj.get("index").flatMap(_.numOpt).map(_.toLong).getOrElse(0L)
+          val toolCallId = blockIndexToToolId.getOrElse(blockIndex, "")
+          if (fragment.nonEmpty && toolCallId.nonEmpty)
+            Some(
+              StreamedChunk(
+                id = currentMessageId.getOrElse(""),
+                content = None,
+                toolCall = Some(ToolCall(id = toolCallId, name = "", arguments = ujson.Str(fragment))),
+                finishReason = None
+              )
+            )
+          else None
 
         case _ =>
           None

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/AnthropicStreamingToolArgsBugSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/AnthropicStreamingToolArgsBugSpec.scala
@@ -1,0 +1,109 @@
+package org.llm4s.llmconnect.provider
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import org.llm4s.llmconnect.model.{ StreamedChunk, ToolCall }
+import org.llm4s.llmconnect.streaming.StreamingAccumulator
+
+/**
+ * Regression tests for issue #820: AnthropicClient.streamComplete() was
+ * silently dropping all tool-call arguments because input_json_delta events
+ * were never forwarded to the StreamingAccumulator.
+ *
+ * These tests exercise the accumulator layer directly to verify that
+ * tool-call argument fragments are correctly assembled.
+ */
+class AnthropicStreamingToolArgsBugSpec extends AnyFlatSpec with Matchers {
+
+  private def toolStartChunk(msgId: String, toolId: String, toolName: String): StreamedChunk =
+    StreamedChunk(
+      id = msgId,
+      content = None,
+      toolCall = Some(ToolCall(id = toolId, name = toolName, arguments = ujson.Obj())),
+      finishReason = None
+    )
+
+  private def argFragmentChunk(msgId: String, toolId: String, fragment: String): StreamedChunk =
+    StreamedChunk(
+      id = msgId,
+      content = None,
+      toolCall = Some(ToolCall(id = toolId, name = "", arguments = ujson.Str(fragment))),
+      finishReason = None
+    )
+
+  private def stopChunk(msgId: String): StreamedChunk =
+    StreamedChunk(
+      id = msgId,
+      content = None,
+      toolCall = None,
+      finishReason = Some("end_turn")
+    )
+
+  "StreamingAccumulator" should "assemble tool-call arguments from fragments" in {
+    val acc = StreamingAccumulator.create()
+    acc.addChunk(toolStartChunk("msg_1", "toolu_01A", "get_weather"))
+    acc.addChunk(argFragmentChunk("msg_1", "toolu_01A", "{\"location\""))
+    acc.addChunk(argFragmentChunk("msg_1", "toolu_01A", ": \"Paris\"}"))
+    acc.addChunk(stopChunk("msg_1"))
+
+    val calls = acc.getCurrentToolCalls
+    calls should have size 1
+    calls.head.name shouldBe "get_weather"
+    calls.head.arguments shouldBe ujson.Obj("location" -> "Paris")
+  }
+
+  it should "handle multiple tool calls with separate argument streams" in {
+    val acc = StreamingAccumulator.create()
+    acc.addChunk(toolStartChunk("msg_1", "toolu_01A", "get_weather"))
+    acc.addChunk(argFragmentChunk("msg_1", "toolu_01A", "{\"city\":\"London\"}"))
+    acc.addChunk(toolStartChunk("msg_1", "toolu_01B", "get_time"))
+    acc.addChunk(argFragmentChunk("msg_1", "toolu_01B", "{\"tz\":\"UTC\"}"))
+    acc.addChunk(stopChunk("msg_1"))
+
+    val calls = acc.getCurrentToolCalls
+    calls should have size 2
+    val byName = calls.map(c => c.name -> c).toMap
+    byName("get_weather").arguments shouldBe ujson.Obj("city" -> "London")
+    byName("get_time").arguments shouldBe ujson.Obj("tz" -> "UTC")
+  }
+
+  it should "handle many small argument fragments" in {
+    val acc = StreamingAccumulator.create()
+    acc.addChunk(toolStartChunk("msg_1", "toolu_01A", "search"))
+    // Simulate character-level streaming
+    val fullJson = "{\"query\":\"hello world\"}"
+    fullJson.foreach(ch => acc.addChunk(argFragmentChunk("msg_1", "toolu_01A", ch.toString)))
+    acc.addChunk(stopChunk("msg_1"))
+
+    val calls = acc.getCurrentToolCalls
+    calls should have size 1
+    calls.head.arguments shouldBe ujson.Obj("query" -> "hello world")
+  }
+
+  it should "return empty arguments when no fragments are provided" in {
+    val acc = StreamingAccumulator.create()
+    acc.addChunk(toolStartChunk("msg_1", "toolu_01A", "no_args_tool"))
+    acc.addChunk(stopChunk("msg_1"))
+
+    val calls = acc.getCurrentToolCalls
+    calls should have size 1
+    calls.head.arguments shouldBe ujson.Obj()
+  }
+
+  it should "preserve tool call alongside text content" in {
+    val acc = StreamingAccumulator.create()
+    // Text content first
+    acc.addChunk(StreamedChunk("msg_1", content = Some("Let me check "), toolCall = None, finishReason = None))
+    acc.addChunk(StreamedChunk("msg_1", content = Some("the weather."), toolCall = None, finishReason = None))
+    // Then tool call
+    acc.addChunk(toolStartChunk("msg_1", "toolu_01A", "get_weather"))
+    acc.addChunk(argFragmentChunk("msg_1", "toolu_01A", "{\"city\":\"NYC\"}"))
+    acc.addChunk(stopChunk("msg_1"))
+
+    acc.getCurrentContent shouldBe "Let me check the weather."
+    val calls = acc.getCurrentToolCalls
+    calls should have size 1
+    calls.head.arguments shouldBe ujson.Obj("city" -> "NYC")
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/streaming/AnthropicStreamingHandlerToolArgsSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/streaming/AnthropicStreamingHandlerToolArgsSpec.scala
@@ -1,0 +1,145 @@
+package org.llm4s.llmconnect.streaming
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Regression test for the SSE-based AnthropicStreamingHandler path (issue #820).
+ * Verifies that content_block_start events register tool calls and
+ * input_json_delta events accumulate their arguments.
+ */
+class AnthropicStreamingHandlerToolArgsSpec extends AnyFlatSpec with Matchers {
+
+  private def sseEvent(eventType: String, data: String): String =
+    s"event: $eventType\ndata: $data\n\n"
+
+  "AnthropicStreamingHandler" should "accumulate tool-call arguments from SSE events" in {
+    val handler = new AnthropicStreamingHandler
+
+    handler.processChunk(
+      sseEvent(
+        "message_start",
+        """{"message":{"id":"msg_01","type":"message","role":"assistant"}}"""
+      )
+    )
+
+    handler.processChunk(
+      sseEvent(
+        "content_block_start",
+        """{"index":0,"content_block":{"type":"tool_use","id":"toolu_01A","name":"get_weather","input":{}}}"""
+      )
+    )
+
+    handler.processChunk(
+      sseEvent(
+        "content_block_delta",
+        """{"index":0,"delta":{"type":"input_json_delta","partial_json":"{\"location\""}}"""
+      )
+    )
+    handler.processChunk(
+      sseEvent(
+        "content_block_delta",
+        """{"index":0,"delta":{"type":"input_json_delta","partial_json":": \"Paris\"}"}}"""
+      )
+    )
+
+    handler.processChunk(sseEvent("message_stop", "{}"))
+
+    val completion = handler.getCompletion
+    completion.isRight shouldBe true
+    val calls = completion.toOption.get.message.toolCalls
+    calls should have size 1
+    calls.head.id shouldBe "toolu_01A"
+    calls.head.name shouldBe "get_weather"
+    calls.head.arguments shouldBe ujson.Obj("location" -> "Paris")
+  }
+
+  it should "handle multiple tool calls at different block indices" in {
+    val handler = new AnthropicStreamingHandler
+
+    handler.processChunk(
+      sseEvent("message_start", """{"message":{"id":"msg_02"}}""")
+    )
+
+    handler.processChunk(
+      sseEvent(
+        "content_block_start",
+        """{"index":0,"content_block":{"type":"tool_use","id":"toolu_A","name":"tool_a","input":{}}}"""
+      )
+    )
+    handler.processChunk(
+      sseEvent(
+        "content_block_delta",
+        """{"index":0,"delta":{"type":"input_json_delta","partial_json":"{\"x\":1}"}}"""
+      )
+    )
+
+    handler.processChunk(
+      sseEvent(
+        "content_block_start",
+        """{"index":1,"content_block":{"type":"tool_use","id":"toolu_B","name":"tool_b","input":{}}}"""
+      )
+    )
+    handler.processChunk(
+      sseEvent(
+        "content_block_delta",
+        """{"index":1,"delta":{"type":"input_json_delta","partial_json":"{\"y\":2}"}}"""
+      )
+    )
+
+    handler.processChunk(sseEvent("message_stop", "{}"))
+
+    val completion = handler.getCompletion
+    completion.isRight shouldBe true
+    val calls = completion.toOption.get.message.toolCalls
+    calls should have size 2
+    val byName = calls.map(c => c.name -> c).toMap
+    byName("tool_a").arguments shouldBe ujson.Obj("x" -> 1)
+    byName("tool_b").arguments shouldBe ujson.Obj("y" -> 2)
+  }
+
+  it should "interleave text and tool-call content" in {
+    val handler = new AnthropicStreamingHandler
+
+    handler.processChunk(
+      sseEvent("message_start", """{"message":{"id":"msg_03"}}""")
+    )
+
+    // Text block
+    handler.processChunk(
+      sseEvent(
+        "content_block_start",
+        """{"index":0,"content_block":{"type":"text","text":""}}"""
+      )
+    )
+    handler.processChunk(
+      sseEvent(
+        "content_block_delta",
+        """{"index":0,"delta":{"type":"text_delta","text":"Checking weather..."}}"""
+      )
+    )
+
+    // Tool block
+    handler.processChunk(
+      sseEvent(
+        "content_block_start",
+        """{"index":1,"content_block":{"type":"tool_use","id":"toolu_C","name":"weather","input":{}}}"""
+      )
+    )
+    handler.processChunk(
+      sseEvent(
+        "content_block_delta",
+        """{"index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"NYC\"}"}}"""
+      )
+    )
+
+    handler.processChunk(sseEvent("message_stop", "{}"))
+
+    val completion = handler.getCompletion
+    completion.isRight shouldBe true
+    val result = completion.toOption.get
+    result.content shouldBe "Checking weather..."
+    result.message.toolCalls should have size 1
+    result.message.toolCalls.head.arguments shouldBe ujson.Obj("city" -> "NYC")
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #820

`AnthropicClient.streamComplete()` and `AnthropicStreamingHandler` were silently dropping all tool-call arguments because `input_json_delta` events were never processed. Tool calls returned with `arguments = {}` while the non-streaming `complete()` path worked correctly.

### Root cause
Two independent streaming implementations had the same gap:
1. **`AnthropicClient.streamComplete()`** (SDK-based) — the `contentBlockDelta` handler processed `text` and `thinking` deltas but had no branch for `inputJson`
2. **`AnthropicStreamingHandler`** (SSE-based) — had an explicit `input_json_delta` stub returning `None`

Neither implementation tracked the `blockIndex → toolId` mapping needed to route argument fragments to the correct tool call.

### Changes

**`AnthropicClient.scala`:**
- Add `blockIndexToToolId` map to track which block index belongs to which tool call
- Record the mapping in `contentBlockStart` when a `tool_use` block is encountered
- Handle `delta.inputJson()` in `contentBlockDelta` to emit argument fragments as `StreamedChunk` with `ujson.Str(fragment)`

**`StreamingResponseHandler.scala`:**
- Add `blockIndexToToolId` map to `AnthropicStreamingHandler`
- Handle `content_block_start` SSE events to register tool calls and populate the index mapping
- Replace the `input_json_delta` stub with fragment forwarding using the block index mapping

The `StreamingAccumulator` already correctly assembles `ujson.Str` fragments into complete JSON — the bug was entirely in the event handlers not emitting them.

## Test plan
- [x] `AnthropicStreamingToolArgsBugSpec` — 5 tests: single tool, multiple tools, character-level fragments, no-arg tool, text+tool interleave
- [x] `AnthropicStreamingHandlerToolArgsSpec` — 3 tests: SSE single tool, multiple block indices, text+tool interleave
- [x] Full suite passes (5617 tests, 0 failures)