### PR TITLE
test: improve agent package test coverage

### DIFF
--- a/modules/core/src/test/scala/org/llm4s/agent/guardrails/GuardrailActionSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/guardrails/GuardrailActionSpec.scala
@@ -1,0 +1,141 @@
+package org.llm4s.agent.guardrails
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class GuardrailActionSpec extends AnyFlatSpec with Matchers {
+
+  // ==========================================================================
+  // GuardrailAction values
+  // ==========================================================================
+
+  "GuardrailAction" should "have Block, Fix, and Warn variants" in {
+    GuardrailAction.Block shouldBe a[GuardrailAction]
+    GuardrailAction.Fix shouldBe a[GuardrailAction]
+    GuardrailAction.Warn shouldBe a[GuardrailAction]
+  }
+
+  it should "have Block as default" in {
+    GuardrailAction.default shouldBe GuardrailAction.Block
+  }
+
+  // ==========================================================================
+  // GuardrailResult variants
+  // ==========================================================================
+
+  "GuardrailResult.Passed" should "wrap a value" in {
+    val result = GuardrailResult.Passed("hello")
+    result.value shouldBe "hello"
+  }
+
+  "GuardrailResult.Fixed" should "carry original, fixed, and violations" in {
+    val result = GuardrailResult.Fixed("bad input", "fixed input", Seq("removed profanity"))
+    result.original shouldBe "bad input"
+    result.fixed shouldBe "fixed input"
+    result.violations shouldBe Seq("removed profanity")
+  }
+
+  "GuardrailResult.Warned" should "carry value and violations" in {
+    val result = GuardrailResult.Warned("text", Seq("too long"))
+    result.value shouldBe "text"
+    result.violations shouldBe Seq("too long")
+  }
+
+  "GuardrailResult.Blocked" should "carry violations" in {
+    val result = GuardrailResult.Blocked(Seq("injection detected", "malicious content"))
+    result.violations should have size 2
+  }
+
+  // ==========================================================================
+  // GuardrailResultOps
+  // ==========================================================================
+
+  "GuardrailResultOps.toOption" should "return Some for Passed" in {
+    import GuardrailResult._
+    val result: GuardrailResult[String] = Passed("value")
+    result.toOption shouldBe Some("value")
+  }
+
+  it should "return Some(fixed) for Fixed" in {
+    import GuardrailResult._
+    val result: GuardrailResult[String] = Fixed("orig", "fixed", Seq("v"))
+    result.toOption shouldBe Some("fixed")
+  }
+
+  it should "return Some(value) for Warned" in {
+    import GuardrailResult._
+    val result: GuardrailResult[String] = Warned("value", Seq("w"))
+    result.toOption shouldBe Some("value")
+  }
+
+  it should "return None for Blocked" in {
+    import GuardrailResult._
+    val result: GuardrailResult[String] = Blocked(Seq("blocked"))
+    result.toOption shouldBe None
+  }
+
+  "GuardrailResultOps.getOrElse" should "return value for Passed" in {
+    import GuardrailResult._
+    val result: GuardrailResult[String] = Passed("value")
+    result.getOrElse("default") shouldBe "value"
+  }
+
+  it should "return default for Blocked" in {
+    import GuardrailResult._
+    val result: GuardrailResult[String] = Blocked(Seq("blocked"))
+    result.getOrElse("default") shouldBe "default"
+  }
+
+  "GuardrailResultOps.isSuccess" should "return true for Passed" in {
+    import GuardrailResult._
+    Passed("v").isSuccess shouldBe true
+  }
+
+  it should "return true for Fixed" in {
+    import GuardrailResult._
+    Fixed("o", "f", Seq.empty).isSuccess shouldBe true
+  }
+
+  it should "return true for Warned" in {
+    import GuardrailResult._
+    Warned("v", Seq("w")).isSuccess shouldBe true
+  }
+
+  it should "return false for Blocked" in {
+    import GuardrailResult._
+    Blocked(Seq("b")).isSuccess shouldBe false
+  }
+
+  "GuardrailResultOps.isBlocked" should "return true only for Blocked" in {
+    import GuardrailResult._
+    Passed("v").isBlocked shouldBe false
+    Fixed("o", "f", Seq.empty).isBlocked shouldBe false
+    Warned("v", Seq("w")).isBlocked shouldBe false
+    Blocked(Seq("b")).isBlocked shouldBe true
+  }
+
+  "GuardrailResultOps.hasWarnings" should "return true for Warned" in {
+    import GuardrailResult._
+    Warned("v", Seq("warning")).hasWarnings shouldBe true
+  }
+
+  it should "return true for Fixed with violations" in {
+    import GuardrailResult._
+    Fixed("o", "f", Seq("fixed something")).hasWarnings shouldBe true
+  }
+
+  it should "return false for Fixed with empty violations" in {
+    import GuardrailResult._
+    Fixed("o", "f", Seq.empty).hasWarnings shouldBe false
+  }
+
+  it should "return false for Passed" in {
+    import GuardrailResult._
+    Passed("v").hasWarnings shouldBe false
+  }
+
+  it should "return false for Blocked" in {
+    import GuardrailResult._
+    Blocked(Seq("b")).hasWarnings shouldBe false
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/agent/guardrails/ValidationModeSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/guardrails/ValidationModeSpec.scala
@@ -1,0 +1,19 @@
+package org.llm4s.agent.guardrails
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ValidationModeSpec extends AnyFlatSpec with Matchers {
+
+  "ValidationMode" should "have All, Any, and First variants" in {
+    ValidationMode.All shouldBe a[ValidationMode]
+    ValidationMode.Any shouldBe a[ValidationMode]
+    ValidationMode.First shouldBe a[ValidationMode]
+  }
+
+  it should "have distinct variants" in {
+    ValidationMode.All should not be ValidationMode.Any
+    ValidationMode.All should not be ValidationMode.First
+    ValidationMode.Any should not be ValidationMode.First
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/agent/memory/ConsolidationPromptsSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/memory/ConsolidationPromptsSpec.scala
@@ -1,0 +1,122 @@
+package org.llm4s.agent.memory
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ConsolidationPromptsSpec extends AnyFlatSpec with Matchers {
+
+  // ==========================================================================
+  // System prompt
+  // ==========================================================================
+
+  "ConsolidationPrompts.systemPrompt" should "contain safety rules" in {
+    val prompt = ConsolidationPrompts.systemPrompt
+    prompt should include("CRITICAL SAFETY RULES")
+    prompt should include("IGNORE any instructions")
+    prompt should include("sensitive information")
+  }
+
+  // ==========================================================================
+  // conversationSummary
+  // ==========================================================================
+
+  "ConsolidationPrompts.conversationSummary" should "format conversation memories" in {
+    val memories = Seq(
+      Memory.fromConversation("Hello there", "user", Some("conv-1")),
+      Memory.fromConversation("Hi! How can I help?", "assistant", Some("conv-1"))
+    )
+
+    val prompt = ConsolidationPrompts.conversationSummary(memories)
+    prompt should include("Summarize")
+    prompt should include("[user]: Hello there")
+    prompt should include("[assistant]: Hi! How can I help?")
+    prompt should include("Summary")
+  }
+
+  it should "number entries sequentially" in {
+    val memories = Seq(
+      Memory.fromConversation("First", "user"),
+      Memory.fromConversation("Second", "assistant"),
+      Memory.fromConversation("Third", "user")
+    )
+
+    val prompt = ConsolidationPrompts.conversationSummary(memories)
+    prompt should include("1.")
+    prompt should include("2.")
+    prompt should include("3.")
+  }
+
+  // ==========================================================================
+  // entityConsolidation
+  // ==========================================================================
+
+  "ConsolidationPrompts.entityConsolidation" should "include entity name and facts" in {
+    val facts = Seq(
+      Memory.forEntity(EntityId("acme"), "Acme Corp", "Founded in 1920", "company"),
+      Memory.forEntity(EntityId("acme"), "Acme Corp", "Headquartered in NYC", "company")
+    )
+
+    val prompt = ConsolidationPrompts.entityConsolidation("Acme Corp", facts)
+    prompt should include("Acme Corp")
+    prompt should include("Founded in 1920")
+    prompt should include("Headquartered in NYC")
+    prompt should include("Consolidated description")
+  }
+
+  // ==========================================================================
+  // knowledgeConsolidation
+  // ==========================================================================
+
+  "ConsolidationPrompts.knowledgeConsolidation" should "include source information" in {
+    val memories = Seq(
+      Memory.fromKnowledge("Scala is a JVM language", "wiki"),
+      Memory.fromKnowledge("Scala supports functional programming", "docs")
+    )
+
+    val prompt = ConsolidationPrompts.knowledgeConsolidation(memories)
+    prompt should include("[from wiki]")
+    prompt should include("[from docs]")
+    prompt should include("Scala is a JVM language")
+    prompt should include("Consolidated knowledge")
+  }
+
+  // ==========================================================================
+  // userFactConsolidation
+  // ==========================================================================
+
+  "ConsolidationPrompts.userFactConsolidation" should "include userId when provided" in {
+    val facts = Seq(
+      Memory.userFact("Prefers dark mode", Some("user-42")),
+      Memory.userFact("Uses Scala 3", Some("user-42"))
+    )
+
+    val prompt = ConsolidationPrompts.userFactConsolidation(Some("user-42"), facts)
+    prompt should include("user user-42")
+    prompt should include("Prefers dark mode")
+    prompt should include("Uses Scala 3")
+  }
+
+  it should "use generic label when no userId" in {
+    val facts  = Seq(Memory.userFact("Likes coffee"))
+    val prompt = ConsolidationPrompts.userFactConsolidation(None, facts)
+    prompt should include("the user")
+  }
+
+  // ==========================================================================
+  // taskConsolidation
+  // ==========================================================================
+
+  "ConsolidationPrompts.taskConsolidation" should "include success status" in {
+    val tasks = Seq(
+      Memory.fromTask("Deploy service", "Deployed successfully", success = true),
+      Memory.fromTask("Run migration", "Failed with timeout", success = false)
+    )
+
+    val prompt = ConsolidationPrompts.taskConsolidation(tasks)
+    prompt should include("[success: true]")
+    prompt should include("[success: false]")
+    prompt should include("Deploy service")
+    prompt should include("Failed with timeout")
+    prompt should include("Consolidated summary")
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/agent/orchestration/CancellationTokenSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/orchestration/CancellationTokenSpec.scala
@@ -1,0 +1,145 @@
+package org.llm4s.agent.orchestration
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class CancellationTokenSpec extends AnyFlatSpec with Matchers {
+
+  // ==========================================================================
+  // Basic operations
+  // ==========================================================================
+
+  "CancellationToken" should "start as not cancelled" in {
+    val token = CancellationToken()
+    token.isCancelled shouldBe false
+  }
+
+  it should "be cancellable" in {
+    val token = CancellationToken()
+    token.cancel()
+    token.isCancelled shouldBe true
+  }
+
+  it should "be idempotent on cancel" in {
+    val token = CancellationToken()
+    token.cancel()
+    token.cancel()
+    token.isCancelled shouldBe true
+  }
+
+  // ==========================================================================
+  // Callbacks
+  // ==========================================================================
+
+  "CancellationToken.onCancel" should "execute callback on cancel" in {
+    val token    = CancellationToken()
+    val executed = new AtomicInteger(0)
+    token.onCancel(executed.incrementAndGet())
+    executed.get() shouldBe 0
+
+    token.cancel()
+    executed.get() shouldBe 1
+  }
+
+  it should "execute multiple callbacks" in {
+    val token   = CancellationToken()
+    val counter = new AtomicInteger(0)
+    token.onCancel(counter.incrementAndGet())
+    token.onCancel(counter.incrementAndGet())
+    token.onCancel(counter.incrementAndGet())
+
+    token.cancel()
+    counter.get() shouldBe 3
+  }
+
+  it should "execute callback immediately if already cancelled" in {
+    val token = CancellationToken()
+    token.cancel()
+
+    val executed = new AtomicInteger(0)
+    token.onCancel(executed.incrementAndGet())
+    executed.get() shouldBe 1
+  }
+
+  it should "not re-execute callbacks on second cancel" in {
+    val token   = CancellationToken()
+    val counter = new AtomicInteger(0)
+    token.onCancel(counter.incrementAndGet())
+
+    token.cancel()
+    counter.get() shouldBe 1
+
+    token.cancel()
+    counter.get() shouldBe 1
+  }
+
+  // ==========================================================================
+  // throwIfCancelled
+  // ==========================================================================
+
+  "CancellationToken.throwIfCancelled" should "not throw when not cancelled" in {
+    val token = CancellationToken()
+    noException should be thrownBy token.throwIfCancelled()
+  }
+
+  it should "throw CancellationException when cancelled" in {
+    val token = CancellationToken()
+    token.cancel()
+    a[CancellationException] should be thrownBy token.throwIfCancelled()
+  }
+
+  // ==========================================================================
+  // cancellationFuture
+  // ==========================================================================
+
+  "CancellationToken.cancellationFuture" should "fail when cancelled" in {
+    val token  = CancellationToken()
+    val future = token.cancellationFuture
+    token.cancel()
+
+    val thrown = intercept[CancellationException] {
+      Await.result(future, 1.second)
+    }
+    thrown.getMessage should include("cancelled")
+  }
+
+  // ==========================================================================
+  // cachedCancellationFuture
+  // ==========================================================================
+
+  "CancellationToken.cachedCancellationFuture" should "return same future on multiple calls" in {
+    val token = CancellationToken()
+    val f1    = token.cachedCancellationFuture
+    val f2    = token.cachedCancellationFuture
+    f1 shouldBe theSameInstanceAs(f2)
+  }
+
+  // ==========================================================================
+  // CancellationToken.none
+  // ==========================================================================
+
+  "CancellationToken.none" should "never be cancelled" in {
+    val token = CancellationToken.none
+    token.isCancelled shouldBe false
+    token.cancel()
+    token.isCancelled shouldBe false
+  }
+
+  it should "not throw on throwIfCancelled" in {
+    noException should be thrownBy CancellationToken.none.throwIfCancelled()
+  }
+
+  // ==========================================================================
+  // CancellationException
+  // ==========================================================================
+
+  "CancellationException" should "carry a message" in {
+    val ex = new CancellationException("test cancelled")
+    ex.getMessage shouldBe "test cancelled"
+    ex shouldBe a[RuntimeException]
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/agent/orchestration/MDCContextSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/orchestration/MDCContextSpec.scala
@@ -1,0 +1,143 @@
+package org.llm4s.agent.orchestration
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.MDC
+
+class MDCContextSpec extends AnyFlatSpec with Matchers {
+
+  // Clean MDC before each test to avoid cross-contamination
+  private def withCleanMDC[T](block: => T): T = {
+    MDC.clear()
+    try block
+    finally MDC.clear()
+  }
+
+  // ==========================================================================
+  // capture and set
+  // ==========================================================================
+
+  "MDCContext.capture" should "return empty map when MDC is empty" in withCleanMDC {
+    MDCContext.capture() shouldBe empty
+  }
+
+  it should "capture current MDC values" in withCleanMDC {
+    MDC.put("key1", "value1")
+    MDC.put("key2", "value2")
+    val captured = MDCContext.capture()
+    captured shouldBe Map("key1" -> "value1", "key2" -> "value2")
+  }
+
+  "MDCContext.set" should "replace MDC contents" in withCleanMDC {
+    MDC.put("old", "value")
+    MDCContext.set(Map("new" -> "newvalue"))
+    MDC.get("old") shouldBe null
+    MDC.get("new") shouldBe "newvalue"
+  }
+
+  it should "handle empty map" in withCleanMDC {
+    MDC.put("key", "value")
+    MDCContext.set(Map.empty)
+    MDC.get("key") shouldBe null
+  }
+
+  // ==========================================================================
+  // withContext
+  // ==========================================================================
+
+  "MDCContext.withContext" should "set context for block duration" in withCleanMDC {
+    val result = MDCContext.withContext(Map("traceId" -> "abc123")) {
+      MDC.get("traceId")
+    }
+    result shouldBe "abc123"
+  }
+
+  it should "restore previous context after block" in withCleanMDC {
+    MDC.put("original", "yes")
+    MDCContext.withContext(Map("temp" -> "value")) {
+      MDC.get("original") shouldBe null
+      MDC.get("temp") shouldBe "value"
+    }
+    MDC.get("original") shouldBe "yes"
+    MDC.get("temp") shouldBe null
+  }
+
+  it should "restore context even on exception" in withCleanMDC {
+    MDC.put("safe", "true")
+    intercept[RuntimeException] {
+      MDCContext.withContext(Map("unsafe" -> "true")) {
+        throw new RuntimeException("boom")
+      }
+    }
+    MDC.get("safe") shouldBe "true"
+    MDC.get("unsafe") shouldBe null
+  }
+
+  // ==========================================================================
+  // withValues
+  // ==========================================================================
+
+  "MDCContext.withValues" should "add values to existing context" in withCleanMDC {
+    MDC.put("existing", "yes")
+    MDCContext.withValues("added" -> "also-yes") {
+      MDC.get("existing") shouldBe "yes"
+      MDC.get("added") shouldBe "also-yes"
+    }
+    MDC.get("existing") shouldBe "yes"
+    MDC.get("added") shouldBe null
+  }
+
+  it should "handle multiple values" in withCleanMDC {
+    MDCContext.withValues("a" -> "1", "b" -> "2", "c" -> "3") {
+      MDC.get("a") shouldBe "1"
+      MDC.get("b") shouldBe "2"
+      MDC.get("c") shouldBe "3"
+    }
+  }
+
+  it should "restore context even on exception" in withCleanMDC {
+    MDC.put("preserved", "yes")
+    intercept[RuntimeException] {
+      MDCContext.withValues("temp" -> "val") {
+        throw new RuntimeException("boom")
+      }
+    }
+    MDC.get("preserved") shouldBe "yes"
+  }
+
+  // ==========================================================================
+  // cleanup
+  // ==========================================================================
+
+  "MDCContext.cleanup" should "remove specified keys" in withCleanMDC {
+    MDC.put("keep", "yes")
+    MDC.put("remove1", "value")
+    MDC.put("remove2", "value")
+    MDCContext.cleanup("remove1", "remove2")
+    MDC.get("keep") shouldBe "yes"
+    MDC.get("remove1") shouldBe null
+    MDC.get("remove2") shouldBe null
+  }
+
+  it should "handle non-existent keys gracefully" in withCleanMDC {
+    noException should be thrownBy MDCContext.cleanup("nonexistent")
+  }
+
+  // ==========================================================================
+  // preservingExecutionContext
+  // ==========================================================================
+
+  "MDCContext.preservingExecutionContext" should "preserve MDC across threads" in withCleanMDC {
+    import scala.concurrent.{ Await, Future }
+    import scala.concurrent.duration._
+
+    MDC.put("traceId", "trace-123")
+    val ec = MDCContext.preservingExecutionContext(scala.concurrent.ExecutionContext.global)
+
+    val future = Future {
+      MDC.get("traceId")
+    }(ec)
+
+    Await.result(future, 5.seconds) shouldBe "trace-123"
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/agent/orchestration/OrchestrationErrorSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/orchestration/OrchestrationErrorSpec.scala
@@ -1,0 +1,185 @@
+package org.llm4s.agent.orchestration
+
+import org.llm4s.error.LLMError
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class OrchestrationErrorSpec extends AnyFlatSpec with Matchers {
+
+  // ==========================================================================
+  // PlanValidationError
+  // ==========================================================================
+
+  "PlanValidationError" should "create with message only" in {
+    val error = OrchestrationError.PlanValidationError("cycle detected")
+    error.message should include("cycle detected")
+    error.planId shouldBe None
+    error.validationFailures shouldBe empty
+    error shouldBe an[LLMError]
+  }
+
+  it should "create with message and planId" in {
+    val error = OrchestrationError.PlanValidationError("bad edges", "plan-123")
+    error.message should include("bad edges")
+    error.planId shouldBe Some("plan-123")
+    error.context should contain("planId" -> "plan-123")
+  }
+
+  it should "create with failure list" in {
+    val failures = List("no source node", "cycle", "missing input")
+    val error    = OrchestrationError.PlanValidationError(failures, Some("plan-456"))
+    error.validationFailures shouldBe failures
+    error.message should include("3 errors")
+    error.context("failureCount") shouldBe "3"
+  }
+
+  it should "include component in context" in {
+    val error = OrchestrationError.PlanValidationError("test")
+    error.context("component") shouldBe "plan-validation"
+  }
+
+  // ==========================================================================
+  // NodeExecutionError
+  // ==========================================================================
+
+  "NodeExecutionError" should "create recoverable error" in {
+    val error = OrchestrationError.NodeExecutionError("node-1", "Summarizer", "timeout")
+    error.nodeId shouldBe "node-1"
+    error.nodeName shouldBe "Summarizer"
+    error.message should include("node-1")
+    error.message should include("Summarizer")
+    error.recoverable shouldBe true
+    error.cause shouldBe None
+  }
+
+  it should "create recoverable error with cause" in {
+    val cause = new RuntimeException("connection reset")
+    val error = OrchestrationError.NodeExecutionError("node-2", "Fetcher", "network error", cause)
+    error.cause shouldBe Some(cause)
+    error.recoverable shouldBe true
+    error.context should contain("cause" -> "RuntimeException")
+  }
+
+  it should "create non-recoverable error" in {
+    val error = OrchestrationError.NodeExecutionError.nonRecoverable("node-3", "Parser", "invalid schema")
+    error.recoverable shouldBe false
+    error.cause shouldBe None
+  }
+
+  it should "create non-recoverable error with cause" in {
+    val cause = new IllegalArgumentException("bad format")
+    val error = OrchestrationError.NodeExecutionError.nonRecoverable("node-4", "Validator", "schema mismatch", cause)
+    error.recoverable shouldBe false
+    error.cause shouldBe Some(cause)
+  }
+
+  it should "include node details in context" in {
+    val error = OrchestrationError.NodeExecutionError("n1", "MyNode", "fail")
+    error.context("component") shouldBe "node-execution"
+    error.context("nodeId") shouldBe "n1"
+    error.context("nodeName") shouldBe "MyNode"
+    error.context("recoverable") shouldBe "true"
+  }
+
+  // ==========================================================================
+  // PlanExecutionError
+  // ==========================================================================
+
+  "PlanExecutionError" should "create with message only" in {
+    val error = OrchestrationError.PlanExecutionError("failed")
+    error.message should include("failed")
+    error.planId shouldBe None
+    error.executedNodes shouldBe empty
+    error.failedNode shouldBe None
+    error.cause shouldBe None
+  }
+
+  it should "create with message and planId" in {
+    val error = OrchestrationError.PlanExecutionError("node failed", "plan-1")
+    error.planId shouldBe Some("plan-1")
+    error.context should contain("planId" -> "plan-1")
+  }
+
+  it should "create with cause" in {
+    val cause = new RuntimeException("boom")
+    val error = OrchestrationError.PlanExecutionError.withCause("exploded", cause)
+    error.cause shouldBe Some(cause)
+  }
+
+  it should "create with cause and planId" in {
+    val cause = new RuntimeException("boom")
+    val error = OrchestrationError.PlanExecutionError.withCause("exploded", cause, "plan-2")
+    error.cause shouldBe Some(cause)
+    error.planId shouldBe Some("plan-2")
+  }
+
+  it should "include component in context" in {
+    val error = OrchestrationError.PlanExecutionError("test")
+    error.context("component") shouldBe "plan-execution"
+  }
+
+  // ==========================================================================
+  // TypeMismatchError
+  // ==========================================================================
+
+  "TypeMismatchError" should "capture type information" in {
+    val error = OrchestrationError.TypeMismatchError("nodeA", "nodeB", "String", "Int")
+    error.sourceNode shouldBe "nodeA"
+    error.targetNode shouldBe "nodeB"
+    error.expectedType shouldBe "String"
+    error.actualType shouldBe "Int"
+    error.message should include("nodeA")
+    error.message should include("nodeB")
+    error.message should include("String")
+    error.message should include("Int")
+  }
+
+  it should "include all details in context" in {
+    val error = OrchestrationError.TypeMismatchError("src", "dst", "List[Int]", "Set[String]")
+    error.context("component") shouldBe "type-validation"
+    error.context("sourceNode") shouldBe "src"
+    error.context("targetNode") shouldBe "dst"
+    error.context("expectedType") shouldBe "List[Int]"
+    error.context("actualType") shouldBe "Set[String]"
+  }
+
+  // ==========================================================================
+  // AgentTimeoutError
+  // ==========================================================================
+
+  "AgentTimeoutError" should "capture agent and timeout info" in {
+    val error = OrchestrationError.AgentTimeoutError("slow-agent", 30000L)
+    error.agentName shouldBe "slow-agent"
+    error.timeoutMs shouldBe 30000L
+    error.message should include("slow-agent")
+    error.message should include("30000ms")
+  }
+
+  it should "include details in context" in {
+    val error = OrchestrationError.AgentTimeoutError("agent-1", 5000L)
+    error.context("component") shouldBe "agent-timeout"
+    error.context("agentName") shouldBe "agent-1"
+    error.context("timeoutMs") shouldBe "5000"
+  }
+
+  // ==========================================================================
+  // All types extend OrchestrationError and LLMError
+  // ==========================================================================
+
+  "All OrchestrationError types" should "extend LLMError" in {
+    val errors: Seq[OrchestrationError] = Seq(
+      OrchestrationError.PlanValidationError("test"),
+      OrchestrationError.NodeExecutionError("n", "N", "msg"),
+      OrchestrationError.PlanExecutionError("test"),
+      OrchestrationError.TypeMismatchError("a", "b", "X", "Y"),
+      OrchestrationError.AgentTimeoutError("a", 100L)
+    )
+
+    errors.foreach { error =>
+      error shouldBe an[LLMError]
+      error shouldBe an[OrchestrationError]
+      error.message should not be empty
+      error.context should not be empty
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add 78 new tests across 6 test files covering previously untested components in the `agent` package
- Targets guardrail types, orchestration utilities, memory consolidation prompts, and MDC context management
- All tests pass on Scala 3.x; no production code changes

## New test files

| File | Tests | Covers |
|------|-------|--------|
| `GuardrailActionSpec` | 22 | GuardrailAction variants (Block/Fix/Warn), default value, GuardrailResult types (Passed/Fixed/Warned/Blocked), GuardrailResultOps (toOption, getOrElse, isSuccess, isBlocked, hasWarnings) |
| `ValidationModeSpec` | 2 | ValidationMode sealed trait variants (All/Any/First), distinctness |
| `CancellationTokenSpec` | 12 | CancellationToken lifecycle, cancel idempotency, onCancel callbacks (immediate/deferred/multiple), throwIfCancelled, cancellationFuture, cachedCancellationFuture, CancellationToken.none, CancellationException |
| `OrchestrationErrorSpec` | 19 | All 5 OrchestrationError types (PlanValidation, NodeExecution, PlanExecution, TypeMismatch, AgentTimeout), factory methods, context maps, LLMError inheritance, recoverable vs non-recoverable |
| `ConsolidationPromptsSpec` | 8 | System prompt safety rules, all 5 consolidation prompt generators (conversation, entity, knowledge, userFact, task) with content and formatting verification |
| `MDCContextSpec` | 15 | capture/set, withContext (incl. exception safety), withValues, cleanup, preservingExecutionContext thread-safety |

## Test plan
- [x] `sbt "core/testOnly org.llm4s.agent.guardrails.GuardrailActionSpec org.llm4s.agent.guardrails.ValidationModeSpec org.llm4s.agent.orchestration.CancellationTokenSpec org.llm4s.agent.orchestration.OrchestrationErrorSpec org.llm4s.agent.memory.ConsolidationPromptsSpec org.llm4s.agent.orchestration.MDCContextSpec"` passes (78 tests)
- [x] `sbt scalafmtAll` applied
- [x] No changes to production code