### PR TITLE
feat: enhance Python interpreter detection

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/speech/util/PlatformCommands.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/util/PlatformCommands.scala
@@ -49,11 +49,17 @@ object PlatformCommands {
     if (isWindows) Seq("cmd", "/c", "type") else Seq("cat")
 
   /**
+   * Returns the name of the first available Python interpreter on this machine
+   * (tries python3, python, then py), or None if none can be found.
+   */
+  def pythonInterpreter: Option[String] =
+    Seq("python3", "python", "py").find(isCommandAvailable)
+
+  /**
    * Get a command that writes a minimal valid WAV file to the path given by the --out argument.
-   * Requires Python3 to be available.
-   *
-   * NOTE: Python3 is not guaranteed on Windows; this mock is intended for macOS/Linux CI only.
-   * If running on Windows with Python3 available, this will work; otherwise skip tests using it.
+   * Uses the first available Python interpreter (python3, python, or py).
+   * Returns a command using that interpreter, or falls back to python3 if none detected
+   * (in which case tests guarded by pythonInterpreter.isDefined will be skipped first).
    */
   def mockWavWriter: Seq[String] = {
     val script =
@@ -66,7 +72,7 @@ object PlatformCommands {
         |                struct.pack('<IHHIIHH', 16, 1, 1, 22050, 44100, 2, 16) +
         |                b'data' + struct.pack('<I', 0))
         """.stripMargin.trim
-    Seq("python3", "-c", script)
+    Seq(pythonInterpreter.getOrElse("python3"), "-c", script)
   }
 
   /**

--- a/modules/core/src/test/scala/org/llm4s/speech/SpeechIntegrationTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/speech/SpeechIntegrationTest.scala
@@ -72,7 +72,10 @@ class SpeechIntegrationTest extends AnyFunSuite with Matchers {
   }
 
   test("Tacotron2TextToSpeech should handle voice options") {
-    assume(PlatformCommands.isCommandAvailable("python3"), "python3 required for TTS mock")
+    assume(
+      PlatformCommands.pythonInterpreter.isDefined,
+      "No Python interpreter (python3/python/py) found — skipping TTS mock test"
+    )
     // mockWavWriter writes a minimal valid WAV to --out so the full pipeline succeeds
     val tts = new Tacotron2TextToSpeech(PlatformCommands.mockWavWriter)
     val options = TTSOptions(

--- a/modules/core/src/test/scala/org/llm4s/speech/Tacotron2AdapterTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/speech/Tacotron2AdapterTest.scala
@@ -6,7 +6,10 @@ import org.llm4s.speech.util.PlatformCommands
 
 class Tacotron2AdapterTest extends AnyFunSuite {
   test("options assemble CLI flags") {
-    assume(PlatformCommands.isCommandAvailable("python3"), "python3 required for TTS mock")
+    assume(
+      PlatformCommands.pythonInterpreter.isDefined,
+      "No Python interpreter (python3/python/py) found — skipping TTS mock test"
+    )
     // Smoke test: uses a mock that writes a minimal valid WAV to --out, verifying the
     // full pipeline (argument assembly -> CLI -> WAV parse) compiles and returns Right.
     val adapter = new Tacotron2TextToSpeech(PlatformCommands.mockWavWriter)


### PR DESCRIPTION
Fixes #839 
## What does this PR do?
Detect the first available Python interpreter (python3, python, py) and use it for the WAV-writing test mock. Update TTS tests to guard on the new detection helper instead of assuming python3 exists. This prevents Windows test failures where python3 is not installed.
 
## Why 
On Windows many setups have `python.exe` or use the `py` launcher rather than a `python3` executable; hardcoding `python3` caused deterministic test failures on such environments. This change keeps the security-focused PRs separate from test infra fixes and makes tests robust across developer machines and CI.

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt test` — tests pass on Scala 3
- [x] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"
