### PR TITLE
[ENHANCEMENT] Add TruffleHog secret scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,33 @@
+name: Secret Scan
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  schedule:
+    - cron: "0 3 * * 1" # optional weekly scan
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trufflehog-scan:
+    name: TruffleHog Secret Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history so TruffleHog can optionally scan history
+          fetch-depth: 0
+
+      - name: Run TruffleHog on repo
+        uses: trufflesecurity/trufflehog@v3
+        with:
+          path: .
+          # Scan the current commit (HEAD). Maintainers can adjust to history mode if desired.
+          scanArguments: "--only-verified"
+

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -2,9 +2,9 @@ name: Secret Scan
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
   schedule:
     - cron: "0 3 * * 1" # optional weekly scan
   workflow_dispatch:
@@ -25,9 +25,9 @@ jobs:
           fetch-depth: 0
 
       - name: Run TruffleHog on repo
-        uses: trufflesecurity/trufflehog@v3
+        # Pinned to the v3.95.3 release commit (no floating `v3` tag exists upstream)
+        uses: trufflesecurity/trufflehog@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab # v3.95.3
         with:
           path: .
           # Scan the current commit (HEAD). Maintainers can adjust to history mode if desired.
-          scanArguments: "--only-verified"
-
+          extra_args: "--only-verified"


### PR DESCRIPTION
Summary

This PR adds a dedicated secret scanning workflow to the CI pipeline to reduce the risk of leaking LLM provider API keys and other sensitive tokens in the repository. It aligns with the project’s focus on safe model deployments and provides a concrete CI template that downstream Scala/LLM projects can reuse.

Details

Adds a new GitHub Actions workflow: .github/workflows/secret-scan.yml.
Triggers on:
push to main and master,
pull_request targeting main and master,
a weekly scheduled run (cron: "0 3 * * 1"),
manual workflow_dispatch.
Uses trufflesecurity/trufflehog@v3 to scan the repository for secrets:
Checks the current commit (HEAD) by default.
Uses --only-verified to focus on high-confidence findings and reduce false positives.
Fetches full git history (fetch-depth: 0) so maintainers can easily switch to history scanning if desired later.
Motivation

Prevent accidental commits of LLM provider keys such as OPENAI_API_KEY, ANTHROPIC_API_KEY, AZURE_OPENAI_KEY, HUGGING_FACE_HUB_TOKEN, etc.
Provide a reference CI template for secure LLM deployments in Scala, consistent with GSoC “CI/CD Templates for Safe Model Deployments”.
Give contributors immediate CI feedback if a secret is introduced in a PR.
Future Extensions (Optional)

Add a dedicated TruffleHog config / allowlist file for known dummy keys and fixtures.
Extend to Trivy repo/image/IaC scanning if you want a unified security toolchain.
Document the workflow briefly in CONTRIBUTING.md or SECURITY.md (how to handle findings and rotate keys).
Issue

Fixes #841
