### PR TITLE
[BUG FIX] Add StreamingWithToolsExample for OpenAI streaming with tools (#843)

### DIFF
--- a/modules/samples/src/main/scala/org/llm4s/samples/streaming/StreamingWithToolsExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/streaming/StreamingWithToolsExample.scala
@@ -59,12 +59,11 @@ object StreamingWithToolsExample extends App {
       .`object`[TimeInput]("Time query")
       .withOptionalField("timezone", Schema.string("Timezone name, e.g. Europe/London"))
   ).withHandler { extractor =>
-    extractor.getOptString("timezone").map { tzOpt =>
-      val zoneId   = tzOpt.getOrElse(java.time.ZoneId.systemDefault().getId)
-      val now      = java.time.ZonedDateTime.now(java.time.ZoneId.of(zoneId))
-      val formatted = now.toString
-      TimeOutput(formatted, zoneId)
-    }
+    val tzOpt     = extractor.getString("timezone").toOption
+    val zoneId    = tzOpt.getOrElse(java.time.ZoneId.systemDefault().getId)
+    val now       = java.time.ZonedDateTime.now(java.time.ZoneId.of(zoneId))
+    val formatted = now.toString
+    Right(TimeOutput(formatted, zoneId))
   }.buildSafe()
 
   // Stream all important agent events so users can see progress
@@ -113,9 +112,9 @@ object StreamingWithToolsExample extends App {
   }
 
   val result = for {
-    timeTool   <- timeToolResult
-    provider   <- Llm4sConfig.provider()
-    client     <- LLMConnect.getClient(provider)
+    timeTool <- timeToolResult
+    provider <- Llm4sConfig.provider()
+    client   <- LLMConnect.getClient(provider)
     agent = new Agent(client)
     tools = new ToolRegistry(Seq(timeTool))
 
@@ -135,7 +134,5 @@ object StreamingWithToolsExample extends App {
 
     case Left(error) =>
       logger.error("Error: {}", error.message)
-      System.exit(1)
   }
 }
-


### PR DESCRIPTION
**Summary**

This PR adds a concrete streaming + tools example that resolves the behavior described in **#843**  
("[BUG] OpenAI streaming example hangs when tool calling is enabled").

Instead of calling `streamComplete` directly with tools (which only surfaces `tool_call` deltas and leaves orchestration to the caller), the new example uses the `Agent` API with streaming events. This provides:

- Proper OpenAI-style streamed tokens,
- Tool execution via the `ToolRegistry`,
- A final, completed answer without the stream hanging.

**Changes**

- Added `StreamingWithToolsExample` under:
  `modules/samples/src/main/scala/org/llm4s/samples/streaming/StreamingWithToolsExample.scala`

Key properties of the example:

- Uses `Agent.runWithEvents` and `ToolRegistry` with a simple `get_time` tool.
- Streams text via `TextDelta` events and prints them as they arrive.
- Logs tool call start/completion events and the final agent status.
- Runs with:

  ```bash
  export LLM_MODEL=openai/gpt-4o
  export OPENAI_API_KEY=sk-...
  sbt "samples/runMain org.llm4s.samples.streaming.StreamingWithToolsExample"