### PR TITLE
fix: Guard against division by zero in TokenWindow.getUsageInfo

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/context/TokenWindow.scala
+++ b/modules/core/src/main/scala/org/llm4s/context/TokenWindow.scala
@@ -60,7 +60,7 @@ object TokenWindow {
   ): TokenUsageInfo = {
     val currentTokens  = tokenCounter.countConversation(conversation)
     val withinBudget   = currentTokens <= budget
-    val utilizationPct = (currentTokens.toDouble / budget * 100).round.toInt
+    val utilizationPct = if (budget > 0) (currentTokens.toDouble / budget * 100).round.toInt else 0
 
     TokenUsageInfo(currentTokens, budget, withinBudget, utilizationPct)
   }

--- a/modules/core/src/test/scala/org/llm4s/context/TokenWindowSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/context/TokenWindowSpec.scala
@@ -162,6 +162,15 @@ class TokenWindowSpec extends AnyFlatSpec with Matchers {
     infoOver.withinBudget shouldBe false
   }
 
+  it should "return zero utilization when budget is zero" in {
+    val conversation = ContextTestFixtures.smallConversation
+    val info         = TokenWindow.getUsageInfo(conversation, counter, 0)
+
+    info.utilizationPercentage shouldBe 0
+    info.withinBudget shouldBe false
+    info.budgetLimit shouldBe 0
+  }
+
   // ============ Edge Cases ============
 
   "TokenWindow" should "handle single message conversation" in {


### PR DESCRIPTION

## What does this PR do?

`TokenWindow.getUsageInfo` is a public method that computes utilization percentage by dividing `currentTokens` by `budget`. When `budget` is 0, this division produces `Infinity`, which overflows on `.round.toInt` and returns a nonsensical utilization value.

This PR adds a `budget > 0` guard that returns 0% utilization for non-positive budgets, and adds a corresponding edge case test.

**Note:** The sibling method `trimToBudget` already validates `budget > 0` via `validateInputs`, but `getUsageInfo` is independently callable and had no such guard.

### Changes
- **TokenWindow.scala** — Guard division with `if (budget > 0)`, fallback to `0`
- **TokenWindowSpec.scala** — Add test: `"return zero utilization when budget is zero"`

## Related issue

<!-- If no issue exists yet, consider opening one first per CONTRIBUTING.md -->

## How was this tested?

Added unit test `TokenWindow.getUsageInfo` `"should return zero utilization when budget is zero"` which verifies:
- `utilizationPercentage` is `0`
- `withinBudget` is `false`
- `budgetLimit` is `0`

```bash
sbt "core/testOnly org.llm4s.context.TokenWindowSpec"
```

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt test` — tests pass on Scala 3
- [x] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"