### PR TITLE
fix(anthropic): preserve streamed tool args from input_json_delta 

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
@@ -4,6 +4,7 @@ import com.anthropic.core.{ JsonObject, ObjectMappers }
 import com.anthropic.models.messages.{
   Message,
   MessageCreateParams,
+  RawContentBlockDeltaEvent,
   RawMessageStreamEvent,
   ThinkingConfigEnabled,
   Tool
@@ -20,6 +21,7 @@ import org.llm4s.error.ThrowableOps._
 
 import scala.jdk.CollectionConverters._
 import scala.util.Try
+import scala.collection.mutable
 
 /**
  * [[LLMClient]] implementation for Anthropic Claude models.
@@ -201,6 +203,7 @@ curl https://api.anthropic.com/v1/messages \
         // Create accumulator for building the final completion
         val accumulator                      = StreamingAccumulator.create()
         var currentMessageId: Option[String] = None
+        val blockIndexToToolId              = mutable.Map[Long, String]()
 
         // Process the stream
         val attempt = Try {
@@ -220,7 +223,7 @@ curl https://api.anthropic.com/v1/messages \
               }
 
               // Check for content block delta event
-              val contentDeltaOpt = event.contentBlockDelta()
+              val contentDeltaOpt: java.util.Optional[RawContentBlockDeltaEvent] = event.contentBlockDelta()
               if (contentDeltaOpt != null && contentDeltaOpt.isPresent) {
                 val contentDelta = contentDeltaOpt.get()
                 val delta        = contentDelta.delta()
@@ -261,6 +264,25 @@ curl https://api.anthropic.com/v1/messages \
                     }
                   }
                 }
+
+                // Handle incremental tool arguments emitted as input_json_delta.
+                // Anthropic streams tool JSON as fragments keyed by content block index.
+                Try(delta.isInputJson()).toOption.filter(identity).foreach { _ =>
+                  Try(delta.asInputJson()).toOption.foreach { inputJsonDelta =>
+                    val fragment   = Option(inputJsonDelta.partialJson()).getOrElse("")
+                    val toolCallId = blockIndexToToolId.getOrElse(contentDelta.index(), "")
+                    if (fragment.nonEmpty && toolCallId.nonEmpty) {
+                      val chunk = StreamedChunk(
+                        id = currentMessageId.getOrElse(""),
+                        content = None,
+                        toolCall = Some(ToolCall(id = toolCallId, name = "", arguments = ujson.Str(fragment))),
+                        finishReason = None
+                      )
+                      accumulator.addChunk(chunk)
+                      onChunk(chunk)
+                    }
+                  }
+                }
               }
 
               val contentStartOpt = event.contentBlockStart()
@@ -269,6 +291,7 @@ curl https://api.anthropic.com/v1/messages \
                 val block        = contentStart.contentBlock()
                 if (block.isToolUse) {
                   val toolUse = block.asToolUse()
+                  blockIndexToToolId(contentStart.index()) = toolUse.id()
                   val chunk = StreamedChunk(
                     id = currentMessageId.getOrElse(""),
                     content = None,

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/streaming/StreamingResponseHandler.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/streaming/StreamingResponseHandler.scala
@@ -182,6 +182,7 @@ class AnthropicStreamingHandler extends BaseStreamingResponseHandler {
 
   private val sseParser                        = SSEParser.createStreamingParser()
   private var currentMessageId: Option[String] = None
+  private val blockIndexToToolId               = scala.collection.mutable.Map[Long, String]()
 
   override def processChunk(chunk: String): Result[Option[StreamedChunk]] =
     scala.util
@@ -196,6 +197,15 @@ class AnthropicStreamingHandler extends BaseStreamingResponseHandler {
                 event.data.foreach { data =>
                   Try(ujson.read(data)).toOption.foreach { json =>
                     currentMessageId = json.obj.get("message").flatMap(_("id").strOpt)
+                  }
+                }
+              case Some("content_block_start") =>
+                event.data.foreach { data =>
+                  Try(ujson.read(data)).toOption.foreach { json =>
+                    parseAnthropicContentBlockStart(json).foreach { c =>
+                      accumulator.addChunk(c)
+                      latestChunk = Some(c)
+                    }
                   }
                 }
               case Some("content_block_delta") =>
@@ -222,6 +232,29 @@ class AnthropicStreamingHandler extends BaseStreamingResponseHandler {
         error
       }
 
+  private def parseAnthropicContentBlockStart(json: Value): Option[StreamedChunk] =
+    Try {
+      val indexOpt    = json.obj.get("index").flatMap(_.numOpt).map(_.toLong)
+      val contentOpt  = json.obj.get("content_block")
+      val blockType   = contentOpt.flatMap(_.obj.get("type")).flatMap(_.strOpt).getOrElse("")
+      val toolId      = contentOpt.flatMap(_.obj.get("id")).flatMap(_.strOpt).getOrElse("")
+      val toolName    = contentOpt.flatMap(_.obj.get("name")).flatMap(_.strOpt).getOrElse("")
+
+      if (blockType == "tool_use" && toolId.nonEmpty) {
+        indexOpt.foreach(i => blockIndexToToolId(i) = toolId)
+        Some(
+          StreamedChunk(
+            id = currentMessageId.getOrElse(""),
+            content = None,
+            toolCall = Some(ToolCall(id = toolId, name = toolName, arguments = ujson.Obj())),
+            finishReason = None
+          )
+        )
+      } else {
+        None
+      }
+    }.toOption.flatten
+
   private def parseAnthropicDelta(json: Value): Option[StreamedChunk] =
     Try {
       val delta     = json("delta")
@@ -239,9 +272,21 @@ class AnthropicStreamingHandler extends BaseStreamingResponseHandler {
           )
 
         case "input_json_delta" =>
-          // Handle tool use deltas
-          // This would accumulate JSON for tool calls
-          None // Simplified for now
+          val fragment   = delta.obj.get("partial_json").flatMap(_.strOpt).getOrElse("")
+          val blockIndex = json.obj.get("index").flatMap(_.numOpt).map(_.toLong).getOrElse(0L)
+          val toolCallId = blockIndexToToolId.getOrElse(blockIndex, "")
+          if (fragment.nonEmpty && toolCallId.nonEmpty) {
+            Some(
+              StreamedChunk(
+                id = currentMessageId.getOrElse(""),
+                content = None,
+                toolCall = Some(ToolCall(id = toolCallId, name = "", arguments = ujson.Str(fragment))),
+                finishReason = None
+              )
+            )
+          } else {
+            None
+          }
 
         case _ =>
           None

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/AnthropicStreamingToolArgsBugSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/AnthropicStreamingToolArgsBugSpec.scala
@@ -1,0 +1,105 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.llmconnect.streaming.{ AnthropicStreamingHandler, StreamingAccumulator }
+import org.llm4s.llmconnect.model.{ StreamedChunk, ToolCall }
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class AnthropicStreamingToolArgsBugSpec extends AnyFunSuite with Matchers {
+
+  test("streaming accumulator assembles tool arguments from JSON fragments") {
+    val acc = StreamingAccumulator.create()
+
+    acc.addChunk(toolStartChunk("msg_1", "toolu_01A", "get_weather"))
+    acc.addChunk(argFragmentChunk("msg_1", "toolu_01A", "{\"location\""))
+    acc.addChunk(argFragmentChunk("msg_1", "toolu_01A", ": \"Paris\"}"))
+
+    val toolCalls = acc.getCurrentToolCalls
+    toolCalls should have size 1
+    toolCalls.head.id shouldBe "toolu_01A"
+    toolCalls.head.name shouldBe "get_weather"
+    toolCalls.head.arguments shouldBe ujson.Obj("location" -> "Paris")
+  }
+
+  test("anthropic streaming handler routes input_json_delta by content block index") {
+    val handler = new AnthropicStreamingHandler()
+
+    handler.processChunk(
+      sse(
+        "message_start",
+        ujson.Obj("type" -> "message_start", "message" -> ujson.Obj("id" -> "msg_1")).render()
+      )
+    )
+
+    handler.processChunk(
+      sse(
+        "content_block_start",
+        ujson
+          .Obj(
+            "type" -> "content_block_start",
+            "index" -> 0,
+            "content_block" -> ujson.Obj(
+              "type" -> "tool_use",
+              "id" -> "toolu_01A",
+              "name" -> "get_weather",
+              "input" -> ujson.Obj()
+            )
+          )
+          .render()
+      )
+    )
+
+    handler.processChunk(
+      sse(
+        "content_block_delta",
+        ujson
+          .Obj(
+            "type" -> "content_block_delta",
+            "index" -> 0,
+            "delta" -> ujson.Obj("type" -> "input_json_delta", "partial_json" -> "{\"location\"")
+          )
+          .render()
+      )
+    )
+
+    handler.processChunk(
+      sse(
+        "content_block_delta",
+        ujson
+          .Obj(
+            "type" -> "content_block_delta",
+            "index" -> 0,
+            "delta" -> ujson.Obj("type" -> "input_json_delta", "partial_json" -> ":\"Paris\"}")
+          )
+          .render()
+      )
+    )
+
+    handler.processChunk(sse("message_stop", ujson.Obj("type" -> "message_stop").render()))
+
+    val completion = handler.getCompletion.toOption.get
+    completion.message.toolCalls should have size 1
+    completion.message.toolCalls.head.id shouldBe "toolu_01A"
+    completion.message.toolCalls.head.name shouldBe "get_weather"
+    completion.message.toolCalls.head.arguments shouldBe ujson.Obj("location" -> "Paris")
+  }
+
+  private def sse(eventType: String, data: String): String =
+    s"event: $eventType\ndata: $data\n\n"
+
+  private def toolStartChunk(messageId: String, toolCallId: String, name: String): StreamedChunk =
+    StreamedChunk(
+      id = messageId,
+      content = None,
+      toolCall = Some(ToolCall(id = toolCallId, name = name, arguments = ujson.Obj())),
+      finishReason = None
+    )
+
+  private def argFragmentChunk(messageId: String, toolCallId: String, partialJson: String): StreamedChunk =
+    StreamedChunk(
+      id = messageId,
+      content = None,
+      toolCall = Some(ToolCall(id = toolCallId, name = "", arguments = ujson.Str(partialJson))),
+      finishReason = None
+    )
+}


### PR DESCRIPTION
## Fix: Preserve Streaming Tool Arguments in Anthropic Client (Issue #820)
### Root Cause
Two independent streaming paths both lacked proper `input_json_delta` handling:
1. **SDK Stream Path** (`AnthropicClient.streamComplete`): No content block index mapping to tool IDs.
2. **SSE Handler Path** (`StreamingResponseHandler`): Stub implementation ignored delta fragments.

### Solution Implemented
Added bidirectional content block index → tool ID mapping in both paths:

**File 1: AnthropicClient.scala** (+25 insertions)
- Added `blockIndexToToolId: Map[Long, String]` to track tool call IDs by content block index
- On `contentBlockStart` for tool_use: store mapping `blockIndexToToolId(index) = toolId`
- On `input_json_delta`: extract `partialJson` fragment, resolve toolId via index, emit `ToolCall` with fragment
- `StreamingAccumulator` automatically reconstructs full JSON object from fragments.

**File 2: StreamingResponseHandler.scala** (+51 insertions)
- Added `content_block_start` event parser in `AnthropicStreamingHandler`
- Implemented same index→toolId registration and block type detection
- Replaced `input_json_delta` stub with fragment forwarding logic tied to index mapping
- Routes SSE fragments to correct tool via stored index mapping.

**File 3: AnthropicStreamingToolArgsBugSpec.scala** (+105 insertions - new regression spec)
- Test A: Validates that `StreamingAccumulator` correctly assembles `{"location": "Paris"}` from 3 JSON fragments
- Test B: Validates that SSE handler correctly routes `input_json_delta` fragments by content block index
  and produces complete tool arguments matching non-streaming behavior.
 