### PR TITLE
refactor: replace throw with Result and fix coding standard violations

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/assistant/SessionManager.scala
+++ b/modules/core/src/main/scala/org/llm4s/assistant/SessionManager.scala
@@ -59,7 +59,7 @@ class SessionManager(sessionDir: DirectoryPath, agent: Agent) {
    * Converts SessionState to JSON format for persistence (using upickle automatic derivation)
    * Note: We handle ToolRegistry separately since it contains function references
    */
-  private def sessionStateToJson(state: SessionState): String = {
+  private def sessionStateToJson(state: SessionState): Either[AssistantError, String] = {
     logger.debug("Starting SessionState serialization")
 
     // Test each component separately
@@ -72,30 +72,31 @@ class SessionManager(sessionDir: DirectoryPath, agent: Agent) {
     val createdJson = ujson.Str(state.created.toString)
     logger.debug("Created timestamp serialized successfully")
 
-    val agentStateJson = state.agentState match {
+    val agentStateJsonResult: Either[AssistantError, ujson.Value] = state.agentState match {
       case None =>
         logger.debug("No agent state to serialize")
-        ujson.Null
+        Right(ujson.Null)
       case Some(agentState) =>
         logger.debug("Serializing agent state components")
 
         // Test conversation serialization
-        val conversationJson = Try(write(agentState.conversation)).getOrElse {
-          val ex = new RuntimeException("Conversation serialization failed")
+        val conversationResult = Try(write(agentState.conversation)).toEither.left.map { ex =>
           logger.error("Failed to serialize conversation", ex)
-          throw ex
+          AssistantError.jsonSerializationFailed("Conversation", ex)
         }
-        logger.debug("Conversation serialized successfully")
 
         // Test status serialization
-        val statusJson = Try(write(agentState.status)).getOrElse {
-          val ex = new RuntimeException("AgentStatus serialization failed")
+        val statusResult = Try(write(agentState.status)).toEither.left.map { ex =>
           logger.error("Failed to serialize agent status", ex)
-          throw ex
+          AssistantError.jsonSerializationFailed("AgentStatus", ex)
         }
-        logger.debug("AgentStatus serialized successfully")
 
-        ujson.Obj(
+        for {
+          conversationJson <- conversationResult
+          _ = logger.debug("Conversation serialized successfully")
+          statusJson <- statusResult
+          _ = logger.debug("AgentStatus serialized successfully")
+        } yield ujson.Obj(
           "conversation" -> ujson.read(conversationJson),
           "initialQuery" -> agentState.initialQuery.map(ujson.Str.apply).getOrElse(ujson.Null),
           "status"       -> ujson.read(statusJson),
@@ -104,16 +105,18 @@ class SessionManager(sessionDir: DirectoryPath, agent: Agent) {
         )
     }
 
-    val jsonObj = ujson.Obj(
-      "sessionId"  -> sessionIdJson,
-      "sessionDir" -> sessionDirJson,
-      "created"    -> createdJson,
-      "agentState" -> agentStateJson
-    )
+    agentStateJsonResult.map { agentStateJson =>
+      val jsonObj = ujson.Obj(
+        "sessionId"  -> sessionIdJson,
+        "sessionDir" -> sessionDirJson,
+        "created"    -> createdJson,
+        "agentState" -> agentStateJson
+      )
 
-    val result = ujson.write(jsonObj)
-    logger.debug("SessionState serialization completed successfully")
-    result
+      val result = ujson.write(jsonObj)
+      logger.debug("SessionState serialization completed successfully")
+      result
+    }
   }
 
   /**
@@ -156,8 +159,7 @@ class SessionManager(sessionDir: DirectoryPath, agent: Agent) {
    * Creates JSON content for session storage
    */
   private def createJsonContent(state: SessionState): Either[AssistantError, String] =
-    Try(sessionStateToJson(state)).toEither
-      .leftMap(ex => AssistantError.jsonSerializationFailed("SessionState", ex))
+    sessionStateToJson(state)
 
   /**
    * Converts JSON back to SessionState for loading

--- a/modules/core/src/main/scala/org/llm4s/config/Llm4sConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/Llm4sConfig.scala
@@ -235,10 +235,11 @@ object Llm4sConfig {
    *         when `EMBEDDING_MODEL` is absent or unrecognised.
    */
   def loadTextEmbeddingModel(): Result[TextEmbeddingModelSettings] =
-    org.llm4s.config.EmbeddingsConfigLoader.loadProvider(ConfigSource.default).map { case (provider, cfg) =>
-      val p    = provider.toLowerCase
-      val dims = ModelDimensionRegistry.getDimension(p, cfg.model)
-      TextEmbeddingModelSettings(provider = p, modelName = cfg.model, dimensions = dims)
+    org.llm4s.config.EmbeddingsConfigLoader.loadProvider(ConfigSource.default).flatMap { case (provider, cfg) =>
+      val p = provider.toLowerCase
+      ModelDimensionRegistry.getDimension(p, cfg.model).map { dims =>
+        TextEmbeddingModelSettings(provider = p, modelName = cfg.model, dimensions = dims)
+      }
     }
 
   /** Alias for [[loadTextEmbeddingModel]]. */

--- a/modules/core/src/main/scala/org/llm4s/error/NonRecoverableError.scala
+++ b/modules/core/src/main/scala/org/llm4s/error/NonRecoverableError.scala
@@ -17,6 +17,6 @@ package org.llm4s.error
  *
  * @see [[RecoverableError]] for errors that may succeed on retry
  */
-protected trait NonRecoverableError extends LLMError {
+trait NonRecoverableError extends LLMError {
   final override def isRecoverable: Boolean = false
 }

--- a/modules/core/src/main/scala/org/llm4s/error/RecoverableError.scala
+++ b/modules/core/src/main/scala/org/llm4s/error/RecoverableError.scala
@@ -18,7 +18,7 @@ package org.llm4s.error
  * @see [[NonRecoverableError]] for errors that cannot be recovered
  * @see [[ErrorRecovery]] for retry utilities
  */
-protected trait RecoverableError extends LLMError {
+trait RecoverableError extends LLMError {
 
   /** Suggested delay in milliseconds before retrying. */
   def retryDelay: Option[Long] = None

--- a/modules/core/src/main/scala/org/llm4s/error/ServiceError.scala
+++ b/modules/core/src/main/scala/org/llm4s/error/ServiceError.scala
@@ -12,7 +12,7 @@ final case class ServiceError private (
     with RecoverableError {
 
   override val code: Option[String]     = Some(httpStatus.toString)
-  override val retryDelay: Option[Long] = if (isRecoverable) Some(2000) else None
+  override val retryDelay: Option[Long] = Some(2000)
 
   override val context: Map[String, String] = Map(
     "httpStatus" -> httpStatus.toString,

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMClientRetry.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMClientRetry.scala
@@ -1,6 +1,6 @@
 package org.llm4s.llmconnect
 
-import org.llm4s.error.{ LLMError, RateLimitError, ServiceError, SimpleError, ValidationError }
+import org.llm4s.error.{ LLMError, RateLimitError, RecoverableError, ServiceError, SimpleError, ValidationError }
 import org.llm4s.llmconnect.model._
 import org.llm4s.types.Result
 
@@ -144,8 +144,9 @@ object LLMClientRetry {
     e.httpStatus >= 500 || e.httpStatus == 429 || e.httpStatus == 408
 
   private def isRetryable(e: LLMError): Boolean = e match {
-    case s: ServiceError => isRetryableServiceError(s)
-    case other           => LLMError.isRecoverable(other)
+    case s: ServiceError     => isRetryableServiceError(s)
+    case _: RecoverableError => true
+    case _                   => false
   }
 
   /** Validate maxAttempts and baseDelay; return ValidationError if invalid so Result contract is preserved. */

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/config/ModelDimensionRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/config/ModelDimensionRegistry.scala
@@ -1,5 +1,8 @@
 package org.llm4s.llmconnect.config
 
+import org.llm4s.error.ConfigurationError
+import org.llm4s.types.Result
+
 object ModelDimensionRegistry {
 
   /**
@@ -32,12 +35,12 @@ object ModelDimensionRegistry {
     )
   )
 
-  def getDimension(provider: String, model: String): Int =
+  def getDimension(provider: String, model: String): Result[Int] =
     dimensions
       .getOrElse(provider.toLowerCase, Map.empty)
-      .getOrElse(
-        model,
-        throw new IllegalArgumentException(
+      .get(model)
+      .toRight(
+        ConfigurationError(
           s"[ModelDimensionRegistry] Unknown model '$model' for provider '$provider'"
         )
       )

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/streaming/StreamingResponseHandler.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/streaming/StreamingResponseHandler.scala
@@ -254,11 +254,12 @@ class AnthropicStreamingHandler extends BaseStreamingResponseHandler {
  */
 object StreamingResponseHandler {
 
-  def forProvider(provider: String): StreamingResponseHandler =
+  def forProvider(provider: String): Result[StreamingResponseHandler] =
     provider.toLowerCase match {
-      case "openai" | "azure" => new OpenAIStreamingHandler()
-      case "anthropic"        => new AnthropicStreamingHandler()
-      case "openrouter"       => new OpenAIStreamingHandler() // OpenRouter uses OpenAI format
-      case _                  => throw new IllegalArgumentException(s"Unsupported streaming provider: $provider")
+      case "openai" | "azure" => Right(new OpenAIStreamingHandler())
+      case "anthropic"        => Right(new AnthropicStreamingHandler())
+      case "openrouter"       => Right(new OpenAIStreamingHandler()) // OpenRouter uses OpenAI format
+      case _ =>
+        Left(ServiceError(500, "streaming", s"Unsupported streaming provider: $provider"))
     }
 }

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/utils/ModelSelector.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/utils/ModelSelector.scala
@@ -27,18 +27,21 @@ object ModelSelector {
         )
       case Image =>
         val name = localModels.imageModel
-        val dim  = ModelDimensionRegistry.getDimension("local", name)
-        logger.info(s"[ModelSelector] Image model: $name ($dim dims)")
-        Right(EmbeddingModelConfig(name, dim))
+        ModelDimensionRegistry.getDimension("local", name).map { dim =>
+          logger.info(s"[ModelSelector] Image model: $name ($dim dims)")
+          EmbeddingModelConfig(name, dim)
+        }
       case Audio =>
         val name = localModels.audioModel
-        val dim  = ModelDimensionRegistry.getDimension("local", name)
-        logger.info(s"[ModelSelector] Audio model: $name ($dim dims)")
-        Right(EmbeddingModelConfig(name, dim))
+        ModelDimensionRegistry.getDimension("local", name).map { dim =>
+          logger.info(s"[ModelSelector] Audio model: $name ($dim dims)")
+          EmbeddingModelConfig(name, dim)
+        }
       case Video =>
         val name = localModels.videoModel
-        val dim  = ModelDimensionRegistry.getDimension("local", name)
-        logger.info(s"[ModelSelector] Video model: $name ($dim dims)")
-        Right(EmbeddingModelConfig(name, dim))
+        ModelDimensionRegistry.getDimension("local", name).map { dim =>
+          logger.info(s"[ModelSelector] Video model: $name ($dim dims)")
+          EmbeddingModelConfig(name, dim)
+        }
     }
 }

--- a/modules/core/src/main/scala/org/llm4s/mcp/MCPTransport.scala
+++ b/modules/core/src/main/scala/org/llm4s/mcp/MCPTransport.scala
@@ -116,76 +116,76 @@ class StreamableHTTPTransportImpl(
       )
 
       logger.debug(s"StreamableHTTPTransport($name) received HTTP response: status=${response.statusCode}")
-
-      // Handle session management during initialization according to MCP spec : the server may or may not include a session id
-      if (request.method == "initialize" && response.statusCode >= 200 && response.statusCode < 300) {
-        // Look for mcp-session-id header in response (lowercase per spec)
-        val sessionIdOpt = response.headers.get("mcp-session-id").flatMap(_.headOption)
-
-        sessionIdOpt.foreach { sessionId =>
-          val trimmed = sessionId.trim
-          if (trimmed.nonEmpty) {
-            mcpSessionId = Some(trimmed)
-            logger.info(s"StreamableHTTPTransport($name) established MCP session: $trimmed")
-          }
-        }
-
-        if (sessionIdOpt.isEmpty) {
-          logger.debug(s"StreamableHTTPTransport($name) no session management (server chose not to use sessions)")
-        }
-      }
-
-      // Handle session expiration (404 with existing session)
-      if (response.statusCode == 404 && mcpSessionId.isDefined) {
-        logger.warn(s"StreamableHTTPTransport($name) session expired (404), clearing session")
-        mcpSessionId = None
-        throw new RuntimeException("MCP session expired, client should reinitialize")
-      }
-
-      // Handle 405 Method Not Allowed (server doesn't support Streamable HTTP)
-      if (response.statusCode == 405) {
-        throw new RuntimeException("Server does not support Streamable HTTP transport (405 Method Not Allowed)")
-      }
-
-      // Handle other HTTP errors
-      if (response.statusCode >= 400) {
-        throw new RuntimeException(
-          s"HTTP error ${response.statusCode}: ${org.llm4s.util.Redaction.truncateForLog(response.body)}"
-        )
-      }
-
-      // Determine response type based on content-type header
-      val responseBody = response.body
-      val contentType  = response.headers.get("content-type").flatMap(_.headOption).map(_.toLowerCase)
-      val isSSE        = contentType.exists(_.contains("text/event-stream"))
-
-      val jsonResponse = if (isSSE) {
-        // Server chose to respond with SSE stream
-        logger.debug(s"StreamableHTTPTransport($name) received SSE stream response")
-        parseSSEResponse(responseBody)
-      } else {
-        // Standard JSON response
-        logger.debug(s"StreamableHTTPTransport($name) received JSON response")
-        read[JsonRpcResponse](responseBody)
-      }
-
-      logger.debug(s"StreamableHTTPTransport($name) parsed JSON response: id=${jsonResponse.id}")
-      jsonResponse
+      response
     } match {
-      case Success(response) =>
-        response.error match {
-          case Some(error) =>
-            logger.error(
-              s"StreamableHTTPTransport($name) JSON-RPC error from $url: code=${error.code}, message=${error.message}"
-            )
-            Left(s"JSON-RPC Error ${error.code}: ${error.message}")
-          case None =>
-            logger.debug(s"StreamableHTTPTransport($name) request successful: id=${response.id}")
-            Right(response)
-        }
       case Failure(exception) =>
         logger.error(s"StreamableHTTPTransport($name) transport error for $url: ${exception.getMessage}", exception)
         Left(s"Transport error: ${exception.getMessage}")
+      case Success(response) =>
+        // Handle session management during initialization according to MCP spec : the server may or may not include a session id
+        if (request.method == "initialize" && response.statusCode >= 200 && response.statusCode < 300) {
+          // Look for mcp-session-id header in response (lowercase per spec)
+          val sessionIdOpt = response.headers.get("mcp-session-id").flatMap(_.headOption)
+
+          sessionIdOpt.foreach { sessionId =>
+            val trimmed = sessionId.trim
+            if (trimmed.nonEmpty) {
+              mcpSessionId = Some(trimmed)
+              logger.info(s"StreamableHTTPTransport($name) established MCP session: $trimmed")
+            }
+          }
+
+          if (sessionIdOpt.isEmpty) {
+            logger.debug(s"StreamableHTTPTransport($name) no session management (server chose not to use sessions)")
+          }
+        }
+
+        // Handle session expiration (404 with existing session)
+        if (response.statusCode == 404 && mcpSessionId.isDefined) {
+          logger.warn(s"StreamableHTTPTransport($name) session expired (404), clearing session")
+          mcpSessionId = None
+          Left("Transport error: MCP session expired, client should reinitialize")
+        } else if (response.statusCode == 405) {
+          // Handle 405 Method Not Allowed (server doesn't support Streamable HTTP)
+          Left("Transport error: Server does not support Streamable HTTP transport (405 Method Not Allowed)")
+        } else if (response.statusCode >= 400) {
+          // Handle other HTTP errors
+          Left(
+            s"Transport error: HTTP error ${response.statusCode}: ${org.llm4s.util.Redaction.truncateForLog(response.body)}"
+          )
+        } else {
+          // Determine response type based on content-type header
+          val responseBody = response.body
+          val contentType  = response.headers.get("content-type").flatMap(_.headOption).map(_.toLowerCase)
+          val isSSE        = contentType.exists(_.contains("text/event-stream"))
+
+          val jsonResponseResult = if (isSSE) {
+            // Server chose to respond with SSE stream
+            logger.debug(s"StreamableHTTPTransport($name) received SSE stream response")
+            parseSSEResponse(responseBody)
+          } else {
+            // Standard JSON response
+            logger.debug(s"StreamableHTTPTransport($name) received JSON response")
+            Try(read[JsonRpcResponse](responseBody)) match {
+              case Success(r) => Right(r)
+              case Failure(e) => Left(s"Transport error: ${e.getMessage}")
+            }
+          }
+
+          jsonResponseResult.flatMap { jsonResponse =>
+            logger.debug(s"StreamableHTTPTransport($name) parsed JSON response: id=${jsonResponse.id}")
+            jsonResponse.error match {
+              case Some(error) =>
+                logger.error(
+                  s"StreamableHTTPTransport($name) JSON-RPC error from $url: code=${error.code}, message=${error.message}"
+                )
+                Left(s"JSON-RPC Error ${error.code}: ${error.message}")
+              case None =>
+                logger.debug(s"StreamableHTTPTransport($name) request successful: id=${jsonResponse.id}")
+                Right(jsonResponse)
+            }
+          }
+        }
     }
   }
 
@@ -210,7 +210,7 @@ class StreamableHTTPTransportImpl(
     mcpSessionId.fold(headersWithProtocol)(sessionId => headersWithProtocol + ("mcp-session-id" -> sessionId))
   }
 
-  private def parseSSEResponse(sseBody: String): JsonRpcResponse = {
+  private def parseSSEResponse(sseBody: String): Either[String, JsonRpcResponse] = {
     // Parse Server-Sent Events format according to W3C SSE specification
     // SSE format: event: <type>\ndata: <content>\nid: <id>\n\n
     val lines = sseBody.split("\n")
@@ -286,10 +286,12 @@ class StreamableHTTPTransportImpl(
     }
 
     // Return the first valid JSON-RPC response
-    jsonResponses.headOption.getOrElse {
-      throw new RuntimeException(
-        s"No valid JSON-RPC response found in SSE stream. Found ${events.size} events, none contained valid JSON-RPC responses."
-      )
+    jsonResponses.headOption match {
+      case Some(response) => Right(response)
+      case None =>
+        Left(
+          s"Transport error: No valid JSON-RPC response found in SSE stream. Found ${events.size} events, none contained valid JSON-RPC responses."
+        )
     }
   }
 
@@ -315,23 +317,24 @@ class StreamableHTTPTransportImpl(
         s"StreamableHTTPTransport($name) received HTTP response for notification: status=${response.statusCode}"
       )
 
-      // Handle HTTP errors (notifications still use HTTP)
-      if (response.statusCode >= 400) {
-        throw new RuntimeException(
-          s"HTTP error ${response.statusCode}: ${org.llm4s.util.Redaction.truncateForLog(response.body)}"
-        )
-      }
-
-      // For notifications, we don't parse the response body since no response is expected
-      logger.debug(s"StreamableHTTPTransport($name) notification sent successfully")
-      ()
+      response
     } match {
-      case Success(_) =>
-        logger.debug(s"StreamableHTTPTransport($name) notification successful")
-        Right(())
       case Failure(exception) =>
         logger.error(s"StreamableHTTPTransport($name) notification error for $url: ${exception.getMessage}", exception)
         Left(s"Notification error: ${exception.getMessage}")
+      case Success(response) =>
+        // Handle HTTP errors (notifications still use HTTP)
+        if (response.statusCode >= 400) {
+          val errorMsg =
+            s"HTTP error ${response.statusCode}: ${org.llm4s.util.Redaction.truncateForLog(response.body)}"
+          logger.error(s"StreamableHTTPTransport($name) notification error for $url: $errorMsg")
+          Left(s"Notification error: $errorMsg")
+        } else {
+          // For notifications, we don't parse the response body since no response is expected
+          logger.debug(s"StreamableHTTPTransport($name) notification sent successfully")
+          logger.debug(s"StreamableHTTPTransport($name) notification successful")
+          Right(())
+        }
     }
   }
 
@@ -411,69 +414,73 @@ class SSETransportImpl(
       )
 
       logger.debug(s"SSETransport($name) received HTTP response: status=${response.statusCode}")
-
-      // Handle session management during initialization
-      if (request.method == "initialize" && response.statusCode >= 200 && response.statusCode < 300) {
-        // Look for mcp-session-id header in response (lowercase per spec)
-        val sessionIdOpt = response.headers.get("mcp-session-id").flatMap(_.headOption)
-
-        sessionIdOpt.foreach { sessionId =>
-          val trimmed = sessionId.trim
-          if (trimmed.nonEmpty) {
-            mcpSessionId = Some(trimmed)
-            logger.info(s"SSETransport($name) established MCP session: $trimmed")
-          }
-        }
-
-        if (sessionIdOpt.isEmpty) {
-          logger.debug(s"SSETransport($name) no session management (server chose not to use sessions)")
-        }
-      }
-
-      // Handle session expiration (404 with existing session)
-      if (response.statusCode == 404 && mcpSessionId.isDefined) {
-        logger.warn(s"SSETransport($name) session expired (404), clearing session")
-        mcpSessionId = None
-        throw new RuntimeException("MCP session expired, client should reinitialize")
-      }
-
-      // Handle other HTTP errors
-      if (response.statusCode >= 400) {
-        throw new RuntimeException(
-          s"HTTP error ${response.statusCode}: ${org.llm4s.util.Redaction.truncateForLog(response.body)}"
-        )
-      }
-
-      // Determine response type based on content-type header
-      val responseBody = response.body
-      val contentType  = response.headers.get("content-type").flatMap(_.headOption).map(_.toLowerCase)
-      val isSSE        = contentType.exists(_.contains("text/event-stream"))
-
-      val jsonResponse = if (isSSE) {
-        // Server responded with SSE stream
-        logger.debug(s"SSETransport($name) received SSE stream response")
-        parseSSEResponse(responseBody)
-      } else {
-        // Standard JSON response
-        logger.debug(s"SSETransport($name) received JSON response")
-        read[JsonRpcResponse](responseBody)
-      }
-
-      logger.debug(s"SSETransport($name) parsed JSON response: id=${jsonResponse.id}")
-      jsonResponse
+      response
     } match {
-      case Success(response) =>
-        response.error match {
-          case Some(error) =>
-            logger.error(s"SSETransport($name) JSON-RPC error from $url: code=${error.code}, message=${error.message}")
-            Left(s"JSON-RPC Error ${error.code}: ${error.message}")
-          case None =>
-            logger.debug(s"SSETransport($name) request successful: id=${response.id}")
-            Right(response)
-        }
       case Failure(exception) =>
         logger.error(s"SSETransport($name) transport error for $url: ${exception.getMessage}", exception)
         Left(s"Transport error: ${exception.getMessage}")
+      case Success(response) =>
+        // Handle session management during initialization
+        if (request.method == "initialize" && response.statusCode >= 200 && response.statusCode < 300) {
+          // Look for mcp-session-id header in response (lowercase per spec)
+          val sessionIdOpt = response.headers.get("mcp-session-id").flatMap(_.headOption)
+
+          sessionIdOpt.foreach { sessionId =>
+            val trimmed = sessionId.trim
+            if (trimmed.nonEmpty) {
+              mcpSessionId = Some(trimmed)
+              logger.info(s"SSETransport($name) established MCP session: $trimmed")
+            }
+          }
+
+          if (sessionIdOpt.isEmpty) {
+            logger.debug(s"SSETransport($name) no session management (server chose not to use sessions)")
+          }
+        }
+
+        // Handle session expiration (404 with existing session)
+        if (response.statusCode == 404 && mcpSessionId.isDefined) {
+          logger.warn(s"SSETransport($name) session expired (404), clearing session")
+          mcpSessionId = None
+          Left("Transport error: MCP session expired, client should reinitialize")
+        } else if (response.statusCode >= 400) {
+          // Handle other HTTP errors
+          Left(
+            s"Transport error: HTTP error ${response.statusCode}: ${org.llm4s.util.Redaction.truncateForLog(response.body)}"
+          )
+        } else {
+          // Determine response type based on content-type header
+          val responseBody = response.body
+          val contentType  = response.headers.get("content-type").flatMap(_.headOption).map(_.toLowerCase)
+          val isSSE        = contentType.exists(_.contains("text/event-stream"))
+
+          val jsonResponseResult = if (isSSE) {
+            // Server responded with SSE stream
+            logger.debug(s"SSETransport($name) received SSE stream response")
+            parseSSEResponse(responseBody)
+          } else {
+            // Standard JSON response
+            logger.debug(s"SSETransport($name) received JSON response")
+            Try(read[JsonRpcResponse](responseBody)) match {
+              case Success(r) => Right(r)
+              case Failure(e) => Left(s"Transport error: ${e.getMessage}")
+            }
+          }
+
+          jsonResponseResult.flatMap { jsonResponse =>
+            logger.debug(s"SSETransport($name) parsed JSON response: id=${jsonResponse.id}")
+            jsonResponse.error match {
+              case Some(error) =>
+                logger.error(
+                  s"SSETransport($name) JSON-RPC error from $url: code=${error.code}, message=${error.message}"
+                )
+                Left(s"JSON-RPC Error ${error.code}: ${error.message}")
+              case None =>
+                logger.debug(s"SSETransport($name) request successful: id=${jsonResponse.id}")
+                Right(jsonResponse)
+            }
+          }
+        }
     }
   }
 
@@ -498,7 +505,7 @@ class SSETransportImpl(
     mcpSessionId.fold(headersWithProtocol)(sessionId => headersWithProtocol + ("mcp-session-id" -> sessionId))
   }
 
-  private def parseSSEResponse(sseBody: String): JsonRpcResponse = {
+  private def parseSSEResponse(sseBody: String): Either[String, JsonRpcResponse] = {
     // Parse Server-Sent Events format according to MCP spec
     val lines = sseBody.split("\n")
 
@@ -519,8 +526,9 @@ class SSETransportImpl(
       }
 
     // Return the first valid JSON-RPC response
-    jsonResponses.headOption.getOrElse {
-      throw new RuntimeException("No valid JSON-RPC response found in SSE stream")
+    jsonResponses.headOption match {
+      case Some(response) => Right(response)
+      case None           => Left("Transport error: No valid JSON-RPC response found in SSE stream")
     }
   }
 
@@ -542,24 +550,24 @@ class SSETransportImpl(
       )
 
       logger.debug(s"SSETransport($name) received HTTP response for notification: status=${response.statusCode}")
-
-      // Handle HTTP errors
-      if (response.statusCode >= 400) {
-        throw new RuntimeException(
-          s"HTTP error ${response.statusCode}: ${org.llm4s.util.Redaction.truncateForLog(response.body)}"
-        )
-      }
-
-      // For notifications, we don't parse the response body since no response is expected
-      logger.debug(s"SSETransport($name) notification sent successfully")
-      ()
+      response
     } match {
-      case Success(_) =>
-        logger.debug(s"SSETransport($name) notification successful")
-        Right(())
       case Failure(exception) =>
         logger.error(s"SSETransport($name) notification error for $url: ${exception.getMessage}", exception)
         Left(s"Notification error: ${exception.getMessage}")
+      case Success(response) =>
+        // Handle HTTP errors
+        if (response.statusCode >= 400) {
+          val errorMsg =
+            s"HTTP error ${response.statusCode}: ${org.llm4s.util.Redaction.truncateForLog(response.body)}"
+          logger.error(s"SSETransport($name) notification error for $url: $errorMsg")
+          Left(s"Notification error: $errorMsg")
+        } else {
+          // For notifications, we don't parse the response body since no response is expected
+          logger.debug(s"SSETransport($name) notification sent successfully")
+          logger.debug(s"SSETransport($name) notification successful")
+          Right(())
+        }
     }
   }
 
@@ -685,25 +693,26 @@ class StdioTransportImpl(
       )
 
       process = Some(newProcess)
-
-      // Wait for server to be ready (check if it's responsive)
-      waitForServerReady(newProcess) match {
-        case Right(_) =>
-          logger.info(s"StdioTransport($name) process started and ready")
-          // Start the background reader thread
-          startReaderThread()
-          newProcess
-        case Left(error) =>
-          // Clean up failed process
-          cleanupProcess()
-          throw new RuntimeException(s"Server startup failed: $error")
-      }
+      newProcess
     } match {
-      case Success(p) => Right(p)
       case Failure(e) =>
         cleanupProcess()
         logger.error(s"StdioTransport($name) failed to start process: ${e.getMessage}", e)
         Left(s"Failed to start MCP server process: ${e.getMessage}")
+      case Success(newProcess) =>
+        // Wait for server to be ready (check if it's responsive)
+        waitForServerReady(newProcess) match {
+          case Right(_) =>
+            logger.info(s"StdioTransport($name) process started and ready")
+            // Start the background reader thread
+            startReaderThread()
+            Right(newProcess)
+          case Left(error) =>
+            // Clean up failed process
+            cleanupProcess()
+            logger.error(s"StdioTransport($name) failed to start process: Server startup failed: $error")
+            Left(s"Failed to start MCP server process: Server startup failed: $error")
+        }
     }
   }
 
@@ -861,69 +870,74 @@ class StdioTransportImpl(
 
           try {
             // Acquire write lock to ensure atomic request transmission
-            writeLock.lock()
-            try {
-              // Read any pending stderr for diagnostics
-              readAvailableStderr()
+            val writeError: Option[String] = {
+              writeLock.lock()
+              try {
+                // Read any pending stderr for diagnostics
+                readAvailableStderr()
 
-              val requestJson = write(request)
-              logger.info(s"StdioTransport($name) writing to stdin: $requestJson")
+                val requestJson = write(request)
+                logger.info(s"StdioTransport($name) writing to stdin: $requestJson")
 
-              // Write request as line-delimited JSON (one complete JSON object per line)
-              writer.println(requestJson)
-              writer.flush() // Ensure the request is immediately sent to the server
+                // Write request as line-delimited JSON (one complete JSON object per line)
+                writer.println(requestJson)
+                writer.flush() // Ensure the request is immediately sent to the server
 
-              if (writer.checkError()) {
-                pendingRequests.remove(request.id)
-                throw new RuntimeException("Failed to write to process stdin (broken pipe)")
-              }
-            } finally writeLock.unlock()
-
-            // Wait for response with timeout (blocking on the future)
-            Try {
-              responseFuture.get(RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-            } match {
-              case Success(responseLine) =>
-                if (responseLine.isEmpty) {
-                  Left(s"No response from MCP server for request ${request.id}")
-                } else {
-                  logger.info(s"StdioTransport($name) received from stdout: $responseLine")
-
-                  // Parse JSON response
-                  Try(read[JsonRpcResponse](responseLine)) match {
-                    case Success(response) =>
-                      response.error match {
-                        case Some(error) =>
-                          logger.error(
-                            s"StdioTransport($name) JSON-RPC error: code=${error.code}, message=${error.message}"
-                          )
-                          Left(s"JSON-RPC Error ${error.code}: ${error.message}")
-                        case None =>
-                          logger.debug(s"StdioTransport($name) request successful: id=${response.id}")
-                          Right(response)
-                      }
-                    case Failure(parseError) =>
-                      Left(s"Failed to parse response: ${parseError.getMessage}")
-                  }
-                }
-              case Failure(_: java.util.concurrent.TimeoutException) =>
-                pendingRequests.remove(request.id)
-                val stderrOutput = readAvailableStderr()
-                val errorMsg =
-                  s"Timeout waiting for response to request ${request.id} after ${RESPONSE_TIMEOUT_MS}ms. Server stderr: $stderrOutput"
-                logger.error(s"StdioTransport($name) $errorMsg")
-                Left(s"Stdio transport error: $errorMsg")
-              case Failure(e) =>
-                pendingRequests.remove(request.id)
-                val stderrOutput = readAvailableStderr()
-                val errorMsg = if (stderrOutput.nonEmpty) {
-                  s"${e.getMessage}. Server stderr: $stderrOutput"
-                } else {
-                  e.getMessage
-                }
-                logger.error(s"StdioTransport($name) transport error: $errorMsg", e)
-                Left(s"Stdio transport error: $errorMsg")
+                if (writer.checkError()) {
+                  pendingRequests.remove(request.id)
+                  Some("Stdio transport error: Failed to write to process stdin (broken pipe)")
+                } else None
+              } finally writeLock.unlock()
             }
+
+            if (writeError.isDefined) Left(writeError.get)
+            else {
+              // Wait for response with timeout (blocking on the future)
+              Try {
+                responseFuture.get(RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+              } match {
+                case Success(responseLine) =>
+                  if (responseLine.isEmpty) {
+                    Left(s"No response from MCP server for request ${request.id}")
+                  } else {
+                    logger.info(s"StdioTransport($name) received from stdout: $responseLine")
+
+                    // Parse JSON response
+                    Try(read[JsonRpcResponse](responseLine)) match {
+                      case Success(response) =>
+                        response.error match {
+                          case Some(error) =>
+                            logger.error(
+                              s"StdioTransport($name) JSON-RPC error: code=${error.code}, message=${error.message}"
+                            )
+                            Left(s"JSON-RPC Error ${error.code}: ${error.message}")
+                          case None =>
+                            logger.debug(s"StdioTransport($name) request successful: id=${response.id}")
+                            Right(response)
+                        }
+                      case Failure(parseError) =>
+                        Left(s"Failed to parse response: ${parseError.getMessage}")
+                    }
+                  }
+                case Failure(_: java.util.concurrent.TimeoutException) =>
+                  pendingRequests.remove(request.id)
+                  val stderrOutput = readAvailableStderr()
+                  val errorMsg =
+                    s"Timeout waiting for response to request ${request.id} after ${RESPONSE_TIMEOUT_MS}ms. Server stderr: $stderrOutput"
+                  logger.error(s"StdioTransport($name) $errorMsg")
+                  Left(s"Stdio transport error: $errorMsg")
+                case Failure(e) =>
+                  pendingRequests.remove(request.id)
+                  val stderrOutput = readAvailableStderr()
+                  val errorMsg = if (stderrOutput.nonEmpty) {
+                    s"${e.getMessage}. Server stderr: $stderrOutput"
+                  } else {
+                    e.getMessage
+                  }
+                  logger.error(s"StdioTransport($name) transport error: $errorMsg", e)
+                  Left(s"Stdio transport error: $errorMsg")
+              }
+            } // end else
           } catch {
             case e: Exception =>
               pendingRequests.remove(request.id)
@@ -1026,17 +1040,23 @@ class StdioTransportImpl(
               writer.flush() // Ensure the notification is immediately sent to the server
 
               if (writer.checkError()) {
-                throw new RuntimeException("Failed to write notification to process stdin (broken pipe)")
+                // For notifications, we don't wait for a response - just return success
+                logger.debug(s"StdioTransport($name) notification sent successfully")
+                false // indicates write error
+              } else {
+                logger.debug(s"StdioTransport($name) notification sent successfully")
+                true // indicates success
               }
-
-              // For notifications, we don't wait for a response - just return success
-              logger.debug(s"StdioTransport($name) notification sent successfully")
-              ()
             } finally writeLock.unlock()
           } match {
-            case Success(_) =>
+            case Success(true) =>
               logger.debug(s"StdioTransport($name) notification successful")
               Right(())
+            case Success(false) =>
+              val msg =
+                "Stdio notification error: Failed to write notification to process stdin (broken pipe)"
+              logger.error(s"StdioTransport($name) $msg")
+              Left(msg)
             case Failure(exception) =>
               // Read stderr for additional context
               val stderrOutput = readAvailableStderr()

--- a/modules/core/src/main/scala/org/llm4s/model/ModelRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/model/ModelRegistry.scala
@@ -339,16 +339,18 @@ object ModelRegistry {
     }
   }
 
-  private def loadEmbeddedMetadata(): Result[Map[String, ModelMetadata]] =
-    Try {
-      val stream = getClass.getResourceAsStream(EmbeddedMetadataPath)
-      if (stream == null) {
-        throw new IllegalStateException(s"Embedded metadata not found: $EmbeddedMetadataPath")
-      }
-      Using.resource(Source.fromInputStream(stream))(source => source.mkString)
-    }.toEither.left
-      .map(e => ConfigurationError(s"Failed to load embedded metadata: ${e.getMessage}"))
-      .flatMap(parseMetadataJson)
+  private def loadEmbeddedMetadata(): Result[Map[String, ModelMetadata]] = {
+    val stream = getClass.getResourceAsStream(EmbeddedMetadataPath)
+    if (stream == null) {
+      Left(ConfigurationError(s"Embedded metadata not found: $EmbeddedMetadataPath"))
+    } else {
+      Try {
+        Using.resource(Source.fromInputStream(stream))(source => source.mkString)
+      }.toEither.left
+        .map(e => ConfigurationError(s"Failed to load embedded metadata: ${e.getMessage}"))
+        .flatMap(parseMetadataJson)
+    }
+  }
 
   private def parseMetadataJson(content: String): Result[Map[String, ModelMetadata]] =
     Try {

--- a/modules/core/src/main/scala/org/llm4s/rag/benchmark/DatasetManager.scala
+++ b/modules/core/src/main/scala/org/llm4s/rag/benchmark/DatasetManager.scala
@@ -202,27 +202,28 @@ class DatasetManager {
   def loadDocumentsFromDirectory(
     path: String,
     extensions: Set[String] = Set(".txt", ".md")
-  ): Result[Seq[(String, String)]] =
-    Try {
-      val dir = Paths.get(path)
-      if (!Files.isDirectory(dir)) {
-        throw new IllegalArgumentException(s"Not a directory: $path")
-      }
-
-      import scala.jdk.CollectionConverters._
-      Files
-        .walk(dir)
-        .iterator()
-        .asScala
-        .filter(p => Files.isRegularFile(p))
-        .filter(p => extensions.exists(ext => p.toString.toLowerCase.endsWith(ext)))
-        .map { p =>
-          val filename = dir.relativize(p).toString
-          val content  = new String(Files.readAllBytes(p))
-          (filename, content)
-        }
-        .toSeq
-    }.toResult.left.map(e => EvaluationError(s"Failed to load documents: ${e.message}"))
+  ): Result[Seq[(String, String)]] = {
+    val dir = Paths.get(path)
+    if (!Files.isDirectory(dir)) {
+      Left(EvaluationError(s"Not a directory: $path"))
+    } else {
+      Try {
+        import scala.jdk.CollectionConverters._
+        Files
+          .walk(dir)
+          .iterator()
+          .asScala
+          .filter(p => Files.isRegularFile(p))
+          .filter(p => extensions.exists(ext => p.toString.toLowerCase.endsWith(ext)))
+          .map { p =>
+            val filename = dir.relativize(p).toString
+            val content  = new String(Files.readAllBytes(p))
+            (filename, content)
+          }
+          .toSeq
+      }.toResult.left.map(e => EvaluationError(s"Failed to load documents: ${e.message}"))
+    }
+  }
 
   /**
    * Detect dataset format from file.

--- a/modules/core/src/main/scala/org/llm4s/rag/benchmark/DatasetManager.scala
+++ b/modules/core/src/main/scala/org/llm4s/rag/benchmark/DatasetManager.scala
@@ -202,28 +202,31 @@ class DatasetManager {
   def loadDocumentsFromDirectory(
     path: String,
     extensions: Set[String] = Set(".txt", ".md")
-  ): Result[Seq[(String, String)]] = {
-    val dir = Paths.get(path)
-    if (!Files.isDirectory(dir)) {
-      Left(EvaluationError(s"Not a directory: $path"))
-    } else {
-      Try {
+  ): Result[Seq[(String, String)]] =
+    Try {
+      val dir = Paths.get(path)
+      if (!Files.isDirectory(dir)) {
+        Left(EvaluationError(s"Not a directory: $path"))
+      } else {
         import scala.jdk.CollectionConverters._
-        Files
-          .walk(dir)
-          .iterator()
-          .asScala
-          .filter(p => Files.isRegularFile(p))
-          .filter(p => extensions.exists(ext => p.toString.toLowerCase.endsWith(ext)))
-          .map { p =>
-            val filename = dir.relativize(p).toString
-            val content  = new String(Files.readAllBytes(p))
-            (filename, content)
-          }
-          .toSeq
-      }.toResult.left.map(e => EvaluationError(s"Failed to load documents: ${e.message}"))
-    }
-  }
+        Right(
+          Files
+            .walk(dir)
+            .iterator()
+            .asScala
+            .filter(p => Files.isRegularFile(p))
+            .filter(p => extensions.exists(ext => p.toString.toLowerCase.endsWith(ext)))
+            .map { p =>
+              val filename = dir.relativize(p).toString
+              val content  = new String(Files.readAllBytes(p))
+              (filename, content)
+            }
+            .toSeq
+        )
+      }
+    }.toResult.left
+      .map(e => EvaluationError(s"Failed to load documents: ${e.message}"))
+      .flatMap(identity)
 
   /**
    * Detect dataset format from file.

--- a/modules/core/src/main/scala/org/llm4s/rag/evaluation/RAGASFactory.scala
+++ b/modules/core/src/main/scala/org/llm4s/rag/evaluation/RAGASFactory.scala
@@ -4,7 +4,6 @@ import org.llm4s.llmconnect.{ EmbeddingClient, LLMClient, LLMConnect }
 import org.llm4s.llmconnect.config.{ EmbeddingModelConfig, ModelDimensionRegistry, ProviderConfig }
 import org.llm4s.rag.evaluation.metrics._
 import org.llm4s.types.Result
-import scala.util.Try
 
 /**
  * Factory for creating RAGAS evaluators and individual metrics.
@@ -40,7 +39,7 @@ object RAGASFactory {
       llmClient <- LLMConnect.getClient(providerCfg)
       (providerName, embeddingConfig) = embedding
       embeddingClient <- EmbeddingClient.from(providerName, embeddingConfig)
-      dims              = Try(ModelDimensionRegistry.getDimension(providerName, embeddingConfig.model)).getOrElse(1536)
+      dims              = ModelDimensionRegistry.getDimension(providerName, embeddingConfig.model).getOrElse(1536)
       embeddingModelCfg = EmbeddingModelConfig(embeddingConfig.model, dims)
     } yield RAGASEvaluator(llmClient, embeddingClient, embeddingModelCfg)
 
@@ -110,7 +109,7 @@ object RAGASFactory {
       llmClient <- LLMConnect.getClient(providerCfg)
       (providerName, embeddingConfig) = embedding
       embeddingClient <- EmbeddingClient.from(providerName, embeddingConfig)
-      dims              = Try(ModelDimensionRegistry.getDimension(providerName, embeddingConfig.model)).getOrElse(1536)
+      dims              = ModelDimensionRegistry.getDimension(providerName, embeddingConfig.model).getOrElse(1536)
       embeddingModelCfg = EmbeddingModelConfig(embeddingConfig.model, dims)
     } yield RAGASEvaluator.basic(llmClient, embeddingClient, embeddingModelCfg)
 

--- a/modules/core/src/main/scala/org/llm4s/rag/permissions/pg/PgCollectionStore.scala
+++ b/modules/core/src/main/scala/org/llm4s/rag/permissions/pg/PgCollectionStore.scala
@@ -56,12 +56,12 @@ final class PgCollectionStore(
         stmt.setString(5, metadataJson)
 
         Using.resource(stmt.executeQuery()) { rs =>
-          if (rs.next()) rowToCollection(rs)
-          else throw new RuntimeException("Failed to create collection: no row returned")
+          if (rs.next()) Right(rowToCollection(rs))
+          else Left(ProcessingError("pg-collection-create", "Failed to create collection: no row returned"))
         }
       }
     }
-  }.toEither.left.map(e => ProcessingError("pg-collection-create", e.getMessage))
+  }.toEither.left.map(e => ProcessingError("pg-collection-create", e.getMessage)).flatMap(identity)
 
   private def markAsNonLeaf(path: CollectionPath): Result[Unit] = Try {
     withConnection { conn =>
@@ -230,12 +230,12 @@ final class PgCollectionStore(
         stmt.setString(2, path.value)
 
         Using.resource(stmt.executeQuery()) { rs =>
-          if (rs.next()) rowToCollection(rs)
-          else throw new RuntimeException(s"Collection not found: ${path.value}")
+          if (rs.next()) Right(rowToCollection(rs))
+          else Left(ProcessingError("pg-collection-update-perms", s"Collection not found: ${path.value}"))
         }
       }
     }
-  }.toEither.left.map(e => ProcessingError("pg-collection-update-perms", e.getMessage))
+  }.toEither.left.map(e => ProcessingError("pg-collection-update-perms", e.getMessage)).flatMap(identity)
 
   override def updateMetadata(
     path: CollectionPath,
@@ -254,12 +254,12 @@ final class PgCollectionStore(
         stmt.setString(2, path.value)
 
         Using.resource(stmt.executeQuery()) { rs =>
-          if (rs.next()) rowToCollection(rs)
-          else throw new RuntimeException(s"Collection not found: ${path.value}")
+          if (rs.next()) Right(rowToCollection(rs))
+          else Left(ProcessingError("pg-collection-update-metadata", s"Collection not found: ${path.value}"))
         }
       }
     }
-  }.toEither.left.map(e => ProcessingError("pg-collection-update-metadata", e.getMessage))
+  }.toEither.left.map(e => ProcessingError("pg-collection-update-metadata", e.getMessage)).flatMap(identity)
 
   override def delete(path: CollectionPath): Result[Unit] =
     for {

--- a/modules/core/src/main/scala/org/llm4s/rag/permissions/pg/PgPrincipalStore.scala
+++ b/modules/core/src/main/scala/org/llm4s/rag/permissions/pg/PgPrincipalStore.scala
@@ -50,14 +50,14 @@ final class PgPrincipalStore(getConnection: () => Connection) extends PrincipalS
         stmt.setString(1, external.externalId)
         Using.resource(stmt.executeQuery()) { rs =>
           if (rs.next()) {
-            PrincipalId(rs.getInt("id"))
+            Right(PrincipalId(rs.getInt("id")))
           } else {
-            throw new RuntimeException(s"Failed to create principal: no ID returned")
+            Left(ProcessingError("pg-principal-create", "Failed to create principal: no ID returned"))
           }
         }
       }
     }
-  }.toEither.left.map(e => ProcessingError("pg-principal-create", e.getMessage))
+  }.toEither.left.map(e => ProcessingError("pg-principal-create", e.getMessage)).flatMap(identity)
 
   override def getOrCreateBatch(externals: Seq[ExternalPrincipal]): Result[Map[ExternalPrincipal, PrincipalId]] =
     // First lookup all existing

--- a/modules/core/src/main/scala/org/llm4s/vectorstore/PgKeywordIndex.scala
+++ b/modules/core/src/main/scala/org/llm4s/vectorstore/PgKeywordIndex.scala
@@ -1,7 +1,7 @@
 package org.llm4s.vectorstore
 
 import org.llm4s.types.Result
-import org.llm4s.error.ProcessingError
+import org.llm4s.error.{ LLMError, ProcessingError }
 import org.llm4s.util.SqlIdentifier
 
 import com.zaxxer.hikari.{ HikariConfig, HikariDataSource }
@@ -115,13 +115,16 @@ final class PgKeywordIndex private (
             case scala.util.Success(_) =>
               conn.commit()
               conn.setAutoCommit(true)
+              Right(())
             case scala.util.Failure(e) =>
               conn.rollback()
               conn.setAutoCommit(true)
-              throw e
+              Left(ProcessingError("pg-keyword-index", s"Index batch failed: ${e.getMessage}"))
           }
         }
-      }.toEither.left.map(e => ProcessingError("pg-keyword-index", s"Index batch failed: ${e.getMessage}"))
+      }.toEither.left
+        .map[LLMError](e => ProcessingError("pg-keyword-index", s"Index batch failed: ${e.getMessage}"))
+        .flatMap(identity)
 
   override def search(
     query: String,
@@ -330,17 +333,8 @@ final class PgKeywordIndex private (
   // Helper Methods
   // ============================================================
 
-  private def withConnection[A](f: Connection => A): A = {
-    val conn = dataSource.getConnection
-    Try(f(conn)) match {
-      case scala.util.Success(result) =>
-        conn.close()
-        result
-      case scala.util.Failure(e) =>
-        conn.close()
-        throw e
-    }
-  }
+  private def withConnection[A](f: Connection => A): A =
+    Using.resource(dataSource.getConnection)(f)
 
   private def collectResults(rs: ResultSet, includeHighlights: Boolean): Seq[KeywordSearchResult] = {
     val builder = ArrayBuffer.empty[KeywordSearchResult]

--- a/modules/core/src/main/scala/org/llm4s/vectorstore/PgVectorStore.scala
+++ b/modules/core/src/main/scala/org/llm4s/vectorstore/PgVectorStore.scala
@@ -169,13 +169,16 @@ final class PgVectorStore private (
             case scala.util.Success(_) =>
               conn.commit()
               conn.setAutoCommit(true)
+              Right(())
             case scala.util.Failure(e) =>
               conn.rollback()
               conn.setAutoCommit(true)
-              throw e
+              Left(ProcessingError("pgvector-store", s"Failed to upsert batch: ${e.getMessage}"))
           }
         }
-      }.toEither.left.map(e => ProcessingError("pgvector-store", s"Failed to upsert batch: ${e.getMessage}"))
+      }.toEither.left
+        .map[LLMError](e => ProcessingError("pgvector-store", s"Failed to upsert batch: ${e.getMessage}"))
+        .flatMap(identity)
 
   /**
    * Search for the most similar vectors.
@@ -448,17 +451,8 @@ final class PgVectorStore private (
   // Helper Methods
   // ============================================================
 
-  private def withConnection[A](f: Connection => A): A = {
-    val conn = dataSource.getConnection
-    Try(f(conn)) match {
-      case scala.util.Success(result) =>
-        conn.close()
-        result
-      case scala.util.Failure(e) =>
-        conn.close()
-        throw e
-    }
-  }
+  private def withConnection[A](f: Connection => A): A =
+    Using.resource(dataSource.getConnection)(f)
 
   private def rowToRecord(rs: ResultSet): Result[VectorRecord] = {
     val embeddingStr = rs.getString("embedding")

--- a/modules/core/src/test/scala/org/llm4s/config/Llm4sConfigTextModelSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/config/Llm4sConfigTextModelSpec.scala
@@ -43,7 +43,8 @@ class Llm4sConfigTextModelSpec extends AnyWordSpec with Matchers {
         pure.modelName shouldBe "text-embedding-3-small"
 
         // And explicitly via the registry as an extra safety check
-        val expectedDims = ModelDimensionRegistry.getDimension("openai", pure.modelName)
+        val expectedDims =
+          ModelDimensionRegistry.getDimension("openai", pure.modelName).fold(err => fail(err.formatted), identity)
         pure.dimensions shouldBe expectedDims
       }
     }

--- a/modules/core/src/test/scala/org/llm4s/embeddingsupport/EmbedxV2Spec.scala
+++ b/modules/core/src/test/scala/org/llm4s/embeddingsupport/EmbedxV2Spec.scala
@@ -224,8 +224,14 @@ class EmbedxV2Spec extends AnyFunSuite with Matchers {
     val audModel = ModelSelector.selectModel(Audio, localModels).fold(err => fail(err.formatted), identity)
     val vidModel = ModelSelector.selectModel(Video, localModels).fold(err => fail(err.formatted), identity)
 
-    imgModel.dimensions shouldBe ModelDimensionRegistry.getDimension("local", imgModel.name)
-    audModel.dimensions shouldBe ModelDimensionRegistry.getDimension("local", audModel.name)
-    vidModel.dimensions shouldBe ModelDimensionRegistry.getDimension("local", vidModel.name)
+    imgModel.dimensions shouldBe ModelDimensionRegistry
+      .getDimension("local", imgModel.name)
+      .fold(err => fail(err.formatted), identity)
+    audModel.dimensions shouldBe ModelDimensionRegistry
+      .getDimension("local", audModel.name)
+      .fold(err => fail(err.formatted), identity)
+    vidModel.dimensions shouldBe ModelDimensionRegistry
+      .getDimension("local", vidModel.name)
+      .fold(err => fail(err.formatted), identity)
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/agent/ResearcherAgentExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/agent/ResearcherAgentExample.scala
@@ -2,13 +2,13 @@ package org.llm4s.samples.agent
 
 import org.llm4s.agent.Agent
 import org.llm4s.config.Llm4sConfig
-import com.typesafe.config.ConfigFactory
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.toolapi.ToolRegistry
 import org.llm4s.toolapi.builtin.search.{ BraveSearchTool, SafeSearch }
 import org.llm4s.toolapi.builtin.search.BraveSearchCategory
 import org.llm4s.toolapi.builtin.search.BraveSearchConfig
 import org.slf4j.LoggerFactory
+import pureconfig.ConfigSource
 
 /**
  * Researcher Agent Example - Demonstrates all four Brave Search tools in an intelligent research workflow.
@@ -33,8 +33,10 @@ object ResearcherAgentExample {
   private val logger = LoggerFactory.getLogger(getClass)
 
   def main(args: Array[String]): Unit = {
-    val config        = ConfigFactory.load()
-    val researchTopic = config.getString("llm4s.samples.agent.research-topic")
+    val researchTopic = ConfigSource.default
+      .at("llm4s.samples.agent.research-topic")
+      .load[String]
+      .getOrElse("artificial intelligence")
     logger.info("🔬 === Researcher Agent Example ===\n")
     logger.info("Research Topic: {}", researchTopic)
     logger.info("=" * 70)

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/ProviderFallbackExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/ProviderFallbackExample.scala
@@ -1,5 +1,6 @@
 package org.llm4s.samples.basic
 
+import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect._
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.config._
@@ -9,26 +10,22 @@ import org.slf4j.LoggerFactory
  * Provider fallback example demonstrating multi-provider support in LLM4S.
  *
  * This example shows:
- * - Configuring multiple LLM providers in code
+ * - Loading configuration via Llm4sConfig.provider()
  * - Attempting a request across providers using fallback logic
  * - Running the same prompt across providers without changing application code
  * - Using the first provider that successfully generates a response
  *
  * == Quick Start ==
  *
- * 1. This example demonstrates provider fallback using providers
- *    configured directly in `providerConfigs`. Providers are tried
- *    in the order listed there (not via `LLM_MODEL`).
- *
- * 2. (Optional) Set API keys for cloud providers:
+ * 1. Set `LLM_MODEL` and the corresponding API key for your primary provider:
  *    {{{
+ *    export LLM_MODEL=openai/gpt-4o-mini
  *    export OPENAI_API_KEY=sk-...
- *    export ANTHROPIC_API_KEY=sk-ant-...
  *    }}}
  *
- *    If API keys are not provided, LLM4S will automatically
- *    fall back to the next available provider (e.g. Ollama).
- *    Ensure that ollama is running locally if you intend to use it.
+ *    If the primary provider fails, the example falls back to a local
+ *    Ollama instance. Ensure that ollama is running locally if you intend
+ *    to use it as a fallback.
  *
  * 3. Run the example:
  *    {{{
@@ -50,28 +47,18 @@ object ProviderFallbackExample extends App {
 
   val logger = LoggerFactory.getLogger(this.getClass)
 
-  val providerConfigs = List(
-    (
-      "OpenAI",
-      OpenAIConfig(
-        apiKey = sys.env.getOrElse("OPENAI_API_KEY", ""),
-        model = "gpt-4o-mini",
-        organization = None,
-        baseUrl = "https://api.openai.com/v1",
-        contextWindow = 128000,
-        reserveCompletion = 4096
-      )
-    ),
-    (
-      "Anthropic",
-      AnthropicConfig(
-        apiKey = sys.env.getOrElse("ANTHROPIC_API_KEY", ""),
-        model = "claude-3-5-haiku",
-        baseUrl = "https://api.anthropic.com/v1",
-        contextWindow = 200000,
-        reserveCompletion = 4096
-      )
-    ),
+  // Build a list of candidate providers:
+  //   1. The provider configured via Llm4sConfig (LLM_MODEL env var)
+  //   2. A local Ollama fallback that requires no API key
+  val configuredProvider: List[(String, ProviderConfig)] =
+    Llm4sConfig.provider() match {
+      case Right(cfg) => List("Configured" -> cfg)
+      case Left(err) =>
+        logger.info(s"No primary provider configured: ${err.formatted}")
+        Nil
+    }
+
+  val ollamaFallback: List[(String, ProviderConfig)] = List(
     (
       "Ollama",
       OllamaConfig(
@@ -82,6 +69,9 @@ object ProviderFallbackExample extends App {
       )
     )
   )
+
+  val providerConfigs: List[(String, ProviderConfig)] =
+    configuredProvider ++ ollamaFallback
 
   val providers: Seq[(String, LLMClient)] =
     providerConfigs.flatMap { case (name, config) =>

--- a/modules/samples/src/main/scala/org/llm4s/samples/cache/SemanticCachingSample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/cache/SemanticCachingSample.scala
@@ -1,5 +1,6 @@
 package org.llm4s.samples.cache
 
+import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.caching.{ CacheConfig, CachingLLMClient }
 import org.llm4s.llmconnect.config.EmbeddingModelConfig
 import org.llm4s.llmconnect.model._
@@ -28,11 +29,14 @@ object SemanticCachingSample extends App {
   private val logger = LoggerFactory.getLogger(getClass)
 
   def runDemo(): Unit = {
-    // Check for API key
-    val apiKey = sys.env.get("OPENAI_API_KEY") match {
-      case Some(key) => key
-      case None =>
-        logger.error("OPENAI_API_KEY environment variable not set")
+    // Load provider config via Llm4sConfig and extract OpenAI API key
+    val apiKey = Llm4sConfig.provider() match {
+      case Right(cfg: OpenAIConfig) => cfg.apiKey
+      case Right(_) =>
+        logger.error("This sample requires an OpenAI provider (set LLM_MODEL=openai/<model>)")
+        return
+      case Left(err) =>
+        logger.error("Failed to load provider config: {}", err.formatted)
         return
     }
 

--- a/modules/samples/src/main/scala/org/llm4s/samples/embeddingsupport/EmbeddingExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/embeddingsupport/EmbeddingExample.scala
@@ -183,8 +183,13 @@ object EmbeddingExample {
     ui: EmbeddingUiSettings
   ): Option[Seq[Double]] = {
     if (query == null || query.trim.isEmpty) return None
-    val dims = org.llm4s.llmconnect.config.ModelDimensionRegistry.getDimension(provider.toLowerCase, modelName)
-    val req  = EmbeddingRequest(Seq(query), org.llm4s.llmconnect.config.EmbeddingModelConfig(modelName, dims))
+    val dims = org.llm4s.llmconnect.config.ModelDimensionRegistry.getDimension(provider.toLowerCase, modelName) match {
+      case Right(d) => d
+      case Left(err) =>
+        println(yellow(s"[WARN] Could not determine dimensions: ${err.formatted}")(ui))
+        return None
+    }
+    val req = EmbeddingRequest(Seq(query), org.llm4s.llmconnect.config.EmbeddingModelConfig(modelName, dims))
     client.embed(req) match {
       case Right(resp) if resp.embeddings.nonEmpty =>
         Some(l2Normalize(resp.embeddings.head))

--- a/modules/samples/src/main/scala/org/llm4s/samples/imagegeneration/ImageGenerationExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/imagegeneration/ImageGenerationExample.scala
@@ -1,5 +1,6 @@
 package org.llm4s.samples.imagegeneration
 
+import org.llm4s.config.Llm4sConfig
 import org.llm4s.imagegeneration._
 import org.slf4j.LoggerFactory
 import java.nio.file.Paths
@@ -167,13 +168,12 @@ object ImageGenerationExample {
   def openAIGptImageExample(): Unit = {
     logger.info("\n--- OpenAI GPT Image Example (Opt-In) ---")
 
-    val maybeApiKey = sys.env.get("OPENAI_API_KEY")
-    maybeApiKey match {
-      case None =>
-        logger.info("Skipping OpenAI GPT Image example (OPENAI_API_KEY not set)")
-      case Some(apiKey) =>
+    Llm4sConfig.provider() match {
+      case Left(_) =>
+        logger.info("Skipping OpenAI GPT Image example (provider config not available)")
+      case Right(providerCfg: org.llm4s.llmconnect.config.OpenAIConfig) =>
         val config = OpenAIConfig(
-          apiKey = apiKey,
+          apiKey = providerCfg.apiKey,
           model = "gpt-image-1.5"
         )
         val options = ImageGenerationOptions(
@@ -196,6 +196,8 @@ object ImageGenerationExample {
           case Left(error) =>
             logger.info(s"OpenAI generation failed: ${error.message}")
         }
+      case Right(_) =>
+        logger.info("Skipping OpenAI GPT Image example (configured provider is not OpenAI)")
     }
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/DocumentQAExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/DocumentQAExample.scala
@@ -88,7 +88,7 @@ object DocumentQAExample extends App {
       Llm4sConfig
         .embeddings()
         .flatMap { case (provider, cfg) =>
-          val dims     = scala.util.Try(ModelDimensionRegistry.getDimension(provider, cfg.model)).getOrElse(1536)
+          val dims     = ModelDimensionRegistry.getDimension(provider, cfg.model).getOrElse(1536)
           val modelCfg = EmbeddingModelConfig(cfg.model, dims)
           EmbeddingClient.from(provider, cfg).map(client => LLMEmbeddingService(client, modelCfg))
         } match {

--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/RAGASEvaluationExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/RAGASEvaluationExample.scala
@@ -67,7 +67,7 @@ object RAGASEvaluationExample extends App {
     embeddingResult <- Llm4sConfig.embeddings()
     (providerName, embeddingConfig) = embeddingResult
     embeddingClient <- EmbeddingClient.from(providerName, embeddingConfig)
-    dims        = ModelDimensionRegistry.getDimension(providerName, embeddingConfig.model)
+    dims            <- ModelDimensionRegistry.getDimension(providerName, embeddingConfig.model)
     modelConfig = EmbeddingModelConfig(embeddingConfig.model, dims)
     evaluator   = RAGASEvaluator(llmClient, embeddingClient, modelConfig)
     _           = logger.info("--- Running RAGAS Evaluation ---")

--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/S3LoaderExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/S3LoaderExample.scala
@@ -26,8 +26,9 @@ import scala.util.chaining._
  */
 object S3LoaderExample {
   private val logger = LoggerFactory.getLogger(getClass)
+  // S3/AWS config has no Llm4sConfig equivalent; sys.props/sys.env is acceptable here // scalafix:ok
   private def env(key: String): Option[String] =
-    sys.props.get(key).orElse(sys.env.get(key))
+    sys.props.get(key).orElse(sys.env.get(key)) // scalafix:ok NoSysEnv
   def main(args: Array[String]): Unit = {
     logger.info("=" * 60)
     logger.info("S3 Document Loader Example")
@@ -139,8 +140,9 @@ object S3LoaderExample {
  */
 object S3LoaderAdvancedExample {
   private val logger = LoggerFactory.getLogger(getClass)
+  // S3/AWS config has no Llm4sConfig equivalent; sys.props/sys.env is acceptable here // scalafix:ok
   private def env(key: String): Option[String] =
-    sys.props.get(key).orElse(sys.env.get(key))
+    sys.props.get(key).orElse(sys.env.get(key)) // scalafix:ok NoSysEnv
   def main(args: Array[String]): Unit = {
     logger.info("=" * 60)
     logger.info("S3 Document Loader - Advanced Configuration")

--- a/modules/workspace/workspaceClient/src/main/scala/org/llm4s/codegen/WorkspaceConfigSupport.scala
+++ b/modules/workspace/workspaceClient/src/main/scala/org/llm4s/codegen/WorkspaceConfigSupport.scala
@@ -37,9 +37,11 @@ object WorkspaceConfigSupport {
   /**
    * Load sandbox config from llm4s.workspace.sandbox.profile or use default.
    * Validates config; returns Left on validation failure.
+   *
+   * @param source PureConfig source; defaults to `ConfigSource.default`.
    */
-  def loadSandboxConfig(): Result[WorkspaceSandboxConfig] = {
-    val profileOpt = ConfigSource.default.at("llm4s.workspace.sandbox.profile").load[String].toOption
+  def loadSandboxConfig(source: ConfigSource = ConfigSource.default): Result[WorkspaceSandboxConfig] = {
+    val profileOpt = source.at("llm4s.workspace.sandbox.profile").load[String].toOption
 
     val baseConfig: Result[WorkspaceSandboxConfig] =
       profileOpt match {
@@ -64,8 +66,11 @@ object WorkspaceConfigSupport {
     }
   }
 
-  def load(): Result[WorkspaceSettings] = {
-    val rootEither = ConfigSource.default.at("llm4s").load[WorkspaceRoot]
+  /**
+   * @param source PureConfig source; defaults to `ConfigSource.default`.
+   */
+  def load(source: ConfigSource = ConfigSource.default): Result[WorkspaceSettings] = {
+    val rootEither = source.at("llm4s").load[WorkspaceRoot]
 
     rootEither.left
       .map { failures =>


### PR DESCRIPTION
## Summary

- **Replace `throw` with `Result[A]`** across 13 core files: MCPTransport (11 throws), PgCollectionStore, PgPrincipalStore, PgVectorStore, PgKeywordIndex, SessionManager, DatasetManager, ModelRegistry, ModelDimensionRegistry, StreamingResponseHandler
- **Migrate deprecated `isRecoverable`** usage in LLMClientRetry and ServiceError to `RecoverableError` trait pattern matching; make RecoverableError/NonRecoverableError traits public for external matching
- **Replace `sys.env`/`ConfigFactory.load()`** with `Llm4sConfig` in 5 sample files and make `WorkspaceConfigSupport` accept injectable `ConfigSource`

## Details

### Exception → Result conversions
- `MCPTransport.scala`: Restructured 11 `throw new RuntimeException(...)` into `Left(...)` returns, including fixing Scala 3 non-local return warnings in stdio transport
- `PgCollectionStore/PgPrincipalStore`: Replaced throws with `Left(ProcessingError(...))`
- `PgVectorStore/PgKeywordIndex`: Replaced `throw e` re-throws with `Left(ProcessingError(...))`, simplified `withConnection` using `Using.resource`
- `SessionManager`: Changed `sessionStateToJson` to return `Either[AssistantError, String]`
- `ModelDimensionRegistry`: Changed `getDimension` to return `Result[Int]`, updated all callers
- `StreamingResponseHandler`: Changed `forProvider` to return `Result[StreamingResponseHandler]`
- `DatasetManager/ModelRegistry`: Early-return `Left(...)` before Try blocks

### Deprecated API migration
- `LLMClientRetry`: Pattern match on `RecoverableError` trait instead of calling `isRecoverable`
- `ServiceError`: Simplified always-true `isRecoverable` check to direct `Some(2000)`

### Config standard compliance
- Samples now use `Llm4sConfig.provider()` instead of `sys.env.get`
- `S3LoaderExample`: Added `scalafix:ok` comments for AWS-specific env vars with no Llm4sConfig equivalent
- `WorkspaceConfigSupport`: Made `ConfigSource` injectable (matching `ProviderConfigLoader` pattern)

## Test plan
- [x] `sbt "core/compile"` passes (including Scala 3 `-Werror`)
- [x] `sbt "samples/compile"` passes
- [x] `sbt "workspaceClient/compile"` passes
- [x] All 5993 core tests pass
- [x] Pre-commit hooks pass