### PR TITLE
docs: use Result-based error handling in examples

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/chunking/SemanticChunker.scala
+++ b/modules/core/src/main/scala/org/llm4s/chunking/SemanticChunker.scala
@@ -22,13 +22,21 @@ import scala.util.matching.Regex
  * Usage:
  * {{{
  * val (provider, embeddingProviderCfg) = /* load embedding provider config */
- * val embeddingClient = EmbeddingClient.from(provider, embeddingProviderCfg).getOrElse(???)
- * val modelConfig = EmbeddingModelConfig("text-embedding-3-small", 1536)
- * val chunker = SemanticChunker(embeddingClient, modelConfig, similarityThreshold = 0.5)
- * val chunks = chunker.chunk(documentText, ChunkingConfig(targetSize = 800))
+ * val result = for {
+ *   embeddingClient <- EmbeddingClient.from(provider, embeddingProviderCfg)
+ * } yield {
+ *   val modelConfig = EmbeddingModelConfig("text-embedding-3-small", 1536)
+ *   val chunker = SemanticChunker(embeddingClient, modelConfig, similarityThreshold = 0.5)
+ *   chunker.chunk(documentText, ChunkingConfig(targetSize = 800))
+ * }
  *
- * chunks.foreach { c =>
- *   println(s"[$${c.index}] $${c.content.take(50)}...")
+ * result match {
+ *   case Right(chunks) =>
+ *     chunks.foreach { c =>
+ *       println(s"[$${c.index}] $${c.content.take(50)}...")
+ *     }
+ *   case Left(error) =>
+ *     println(s"Error: $${error.message}")
  * }
  * }}}
  *

--- a/modules/core/src/main/scala/org/llm4s/context/ConversationTokenCounter.scala
+++ b/modules/core/src/main/scala/org/llm4s/context/ConversationTokenCounter.scala
@@ -23,9 +23,18 @@ import org.slf4j.LoggerFactory
  *
  * @example
  * {{{
- * val counter = ConversationTokenCounter.forModel("gpt-4o").getOrElse(???)
- * val tokens = counter.countConversation(conversation)
- * println(s"Conversation uses \$tokens tokens")
+ * val result = for {
+ *   counter <- ConversationTokenCounter.forModel("gpt-4o")
+ * } yield {
+ *   counter.countConversation(conversation)
+ * }
+ *
+ * result match {
+ *   case Right(tokens) =>
+ *     println(s"Conversation uses $$tokens tokens")
+ *   case Left(error) =>
+ *     println(s"Error: $${error.message}")
+ * }
  * }}}
  *
  * @see [[ConversationTokenCounter.forModel]] for model-aware counter creation


### PR DESCRIPTION
## What does this PR do?
Updates two Scaladoc examples to use idiomatic `Result`-based error handling instead of `getOrElse(???)`.

This removes a non-idiomatic pattern from:
- `SemanticChunker`
- `ConversationTokenCounter`

The change is needed because LLM4S promotes explicit `Result[A]` handling rather than exception-style fallbacks. These examples are part of the developer learning path, so they should model the framework's recommended style and avoid encouraging `NotImplementedError` crashes in copied code.

## Related issue
Fixes #873 

## How was this tested?
Validated the edited examples against the current method signatures in the source files.

Commands run:
```bash
sbt core/compile
git diff -- modules/core/src/main/scala/org/llm4s/chunking/SemanticChunker.scala modules/core/src/main/scala/org/llm4s/context/ConversationTokenCounter.scala
