### PR TITLE
[ENHANCEMENT] Add Scala 2.13 cross-compilation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,11 @@ jobs:
       - name: Check formatting
         run: sbt scalafmtCheckAll
       
-      - name: Compile
+      - name: Compile (Scala 3.x)
         run: sbt compile
+
+      - name: Compile (Cross-version: Scala 2.13 + 3.x)
+        run: sbt +compile
 
   # Code coverage (runs on one configuration to avoid duplication)
   coverage:


### PR DESCRIPTION
## What does this PR do?
This PR updates the CI pipeline to explicitly verify cross-compilation for all supported Scala versions.  
In the `quick-checks` job of `.github/workflows/ci.yml`, it:
- Renames the existing compile step to `Compile (Scala 3.x)` running `sbt compile`
- Adds a new step `Compile (Cross-version: Scala 2.13 + 3.x)` running `sbt +compile`

This ensures that both Scala 2.13 and Scala 3.x are compiled on every PR and push, preventing version-specific compilation issues from silently slipping into `main`.

## Related issue
Fixes #874

## How was this tested?
Locally in the project root:

- `sbt compile`  
  - Verifies the default Scala (3.x) codebase compiles successfully.
- `sbt +compile`  
  - Verifies that all configured Scala versions (including 2.13 and 3.x) compile successfully.

No Scala source or test code was modified in this PR; only the CI workflow was changed.

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt test` — tests pass on Scala 3
- [x] New code includes tests (not applicable; CI workflow only)
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"