### PR TITLE
Fix ReDoS in regex handling across workspace and core (#891)

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/agent/guardrails/builtin/RegexValidator.scala
+++ b/modules/core/src/main/scala/org/llm4s/agent/guardrails/builtin/RegexValidator.scala
@@ -5,6 +5,7 @@ import org.llm4s.error.ValidationError
 import org.llm4s.security.RegexSafetyManager
 import org.llm4s.types.Result
 
+import java.util.regex.Pattern
 import scala.util.matching.Regex
 
 /**
@@ -18,23 +19,33 @@ import scala.util.matching.Regex
  * @param errorMessage Optional custom error message
  */
 class RegexValidator(
-  pattern: Regex,
+  compiledPattern: Pattern,
+  patternDescription: String,
   errorMessage: Option[String] = None,
   fallbackError: Option[String] = None
 ) extends InputGuardrail
     with OutputGuardrail {
 
+  def this(pattern: Regex, errorMessage: Option[String], fallbackError: Option[String]) =
+    this(pattern.pattern, pattern.toString, errorMessage, fallbackError)
+
+  def this(pattern: Regex, errorMessage: Option[String]) =
+    this(pattern.pattern, pattern.toString, errorMessage, None)
+
+  def this(pattern: Regex) =
+    this(pattern.pattern, pattern.toString, None, None)
+
   def validate(value: String): Result[String] =
     fallbackError match {
       case Some(error) => Left(ValidationError.invalid("value", error))
       case None =>
-        RegexSafetyManager.safeFind(pattern.pattern, value) match {
+        RegexSafetyManager.safeFind(compiledPattern, value) match {
           case Right(true) => Right(value)
           case Right(false) =>
             Left(
               ValidationError.invalid(
                 "value",
-                errorMessage.getOrElse(s"Value does not match pattern: $pattern")
+                errorMessage.getOrElse(s"Value does not match pattern: $patternDescription")
               )
             )
           case Left(error) =>
@@ -45,7 +56,7 @@ class RegexValidator(
   val name: String = "RegexValidator"
 
   override val description: Option[String] = Some(
-    s"Validates against pattern: $pattern"
+    s"Validates against pattern: $patternDescription"
   )
 
   // Resolve conflicting transform methods from both traits
@@ -59,10 +70,11 @@ object RegexValidator {
    */
   def apply(pattern: String): RegexValidator =
     RegexSafetyManager.safeCompile(pattern) match {
-      case Right(compiled) => new RegexValidator(compiled.pattern().r)
+      case Right(compiled) => new RegexValidator(compiled, pattern)
       case Left(error) =>
         new RegexValidator(
-          "(?!)".r,
+          Pattern.compile("(?!)"),
+          pattern,
           fallbackError = Some(s"Invalid or unsafe regex pattern: $error")
         )
     }
@@ -78,10 +90,11 @@ object RegexValidator {
    */
   def apply(pattern: String, errorMessage: String): RegexValidator =
     RegexSafetyManager.safeCompile(pattern) match {
-      case Right(compiled) => new RegexValidator(compiled.pattern().r, Some(errorMessage))
+      case Right(compiled) => new RegexValidator(compiled, pattern, Some(errorMessage))
       case Left(error) =>
         new RegexValidator(
-          "(?!)".r,
+          Pattern.compile("(?!)"),
+          pattern,
           Some(errorMessage),
           Some(s"Invalid or unsafe regex pattern: $error")
         )

--- a/modules/core/src/main/scala/org/llm4s/agent/guardrails/builtin/RegexValidator.scala
+++ b/modules/core/src/main/scala/org/llm4s/agent/guardrails/builtin/RegexValidator.scala
@@ -2,6 +2,7 @@ package org.llm4s.agent.guardrails.builtin
 
 import org.llm4s.agent.guardrails.{ InputGuardrail, OutputGuardrail }
 import org.llm4s.error.ValidationError
+import org.llm4s.security.RegexSafetyManager
 import org.llm4s.types.Result
 
 import scala.util.matching.Regex
@@ -18,20 +19,27 @@ import scala.util.matching.Regex
  */
 class RegexValidator(
   pattern: Regex,
-  errorMessage: Option[String] = None
+  errorMessage: Option[String] = None,
+  fallbackError: Option[String] = None
 ) extends InputGuardrail
     with OutputGuardrail {
 
   def validate(value: String): Result[String] =
-    if (pattern.findFirstIn(value).isDefined) {
-      Right(value)
-    } else {
-      Left(
-        ValidationError.invalid(
-          "value",
-          errorMessage.getOrElse(s"Value does not match pattern: $pattern")
-        )
-      )
+    fallbackError match {
+      case Some(error) => Left(ValidationError.invalid("value", error))
+      case None =>
+        RegexSafetyManager.safeFind(pattern.pattern, value) match {
+          case Right(true) => Right(value)
+          case Right(false) =>
+            Left(
+              ValidationError.invalid(
+                "value",
+                errorMessage.getOrElse(s"Value does not match pattern: $pattern")
+              )
+            )
+          case Left(error) =>
+            Left(ValidationError.invalid("value", s"Regex security error: $error"))
+        }
     }
 
   val name: String = "RegexValidator"
@@ -50,7 +58,14 @@ object RegexValidator {
    * Create a regex validator from a pattern string.
    */
   def apply(pattern: String): RegexValidator =
-    new RegexValidator(pattern.r)
+    RegexSafetyManager.safeCompile(pattern) match {
+      case Right(compiled) => new RegexValidator(compiled.pattern().r)
+      case Left(error) =>
+        new RegexValidator(
+          "(?!)".r,
+          fallbackError = Some(s"Invalid or unsafe regex pattern: $error")
+        )
+    }
 
   /**
    * Create a regex validator from a Regex object.
@@ -62,7 +77,15 @@ object RegexValidator {
    * Create a regex validator with custom error message.
    */
   def apply(pattern: String, errorMessage: String): RegexValidator =
-    new RegexValidator(pattern.r, Some(errorMessage))
+    RegexSafetyManager.safeCompile(pattern) match {
+      case Right(compiled) => new RegexValidator(compiled.pattern().r, Some(errorMessage))
+      case Left(error) =>
+        new RegexValidator(
+          "(?!)".r,
+          Some(errorMessage),
+          Some(s"Invalid or unsafe regex pattern: $error")
+        )
+    }
 
   /**
    * Validator for email addresses (basic pattern).

--- a/modules/core/src/main/scala/org/llm4s/rag/loader/internal/GlobPatternMatcher.scala
+++ b/modules/core/src/main/scala/org/llm4s/rag/loader/internal/GlobPatternMatcher.scala
@@ -1,5 +1,7 @@
 package org.llm4s.rag.loader.internal
 
+import org.llm4s.security.RegexSafetyManager
+
 import java.util.regex.Pattern
 import scala.collection.mutable
 
@@ -95,7 +97,10 @@ object GlobPatternMatcher {
       i += 1
     }
 
-    Pattern.compile(sb.toString, Pattern.CASE_INSENSITIVE)
+    RegexSafetyManager.safeCompile(sb.toString, Pattern.CASE_INSENSITIVE) match {
+      case Right(regex) => regex
+      case Left(_)      => RegexSafetyManager.compileLiteral(glob, Pattern.CASE_INSENSITIVE)
+    }
   }
 
   /**

--- a/modules/core/src/main/scala/org/llm4s/security/RegexSafetyManager.scala
+++ b/modules/core/src/main/scala/org/llm4s/security/RegexSafetyManager.scala
@@ -1,48 +1,68 @@
 package org.llm4s.security
 
 import java.util.regex.{ Matcher, Pattern, PatternSyntaxException }
-import scala.util.control.NonFatal
+import scala.util.Try
 
 /**
  * Safety wrapper for user-supplied regex compilation and matching.
  *
- * This manager blocks known catastrophic patterns and enforces basic bounds
- * so we can avoid relying on interruption-based regex timeouts.
+ * ReDoS is mitigated by two complementary defences:
+ *
+ *   1. A cheap pre-screen ([[safeCompile]]) rejects null/empty/oversized
+ *      patterns and a set of well-known catastrophic-backtracking shapes before
+ *      they are ever compiled.
+ *   2. A hard execution bound ([[safeFind]]/[[safeMatches]]) caps the number of
+ *      character accesses the backtracking engine may perform for a single
+ *      match. Catastrophic backtracking explores an exponential number of paths,
+ *      each of which reads characters, so a step ceiling deterministically
+ *      bounds worst-case runtime - even for dangerous patterns the pre-screen
+ *      misses - without relying on thread interruption or wall-clock timeouts.
+ *
+ * The step bound is the real security boundary: any pattern that reaches the
+ * matching helpers is safe regardless of how it was constructed. The shape
+ * blocklist is only a fast early-reject and must not be relied on for safety.
+ *
+ * NOTE: kept intentionally in sync with
+ * `org.llm4s.runner.WorkspaceRegexSafetyManager`, which duplicates this logic
+ * because the workspace runner module cannot depend on `core`. Changes to the
+ * heuristics or bounds here should be mirrored there.
  */
 object RegexSafetyManager {
 
-  private val MaxPatternLength            = 1000
-  private val MaxInputLength              = 100000
-  private val DefaultCompilationTimeoutMs = 1000L
-  private val DefaultMatchingTimeoutMs    = 250L
+  private val MaxPatternLength = 1000
+  private val MaxInputLength   = 100000
+
+  /**
+   * Upper bound on character accesses for a single match. Comfortably above
+   * what legitimate linear/quadratic matching needs for inputs up to
+   * [[MaxInputLength]], but far below the exponential blow-up of catastrophic
+   * backtracking, which trips the ceiling almost immediately.
+   */
+  private val DefaultMaxMatchSteps = 10000000L
+
   private val DefaultCaseInsensitiveFlags = Pattern.CASE_INSENSITIVE
 
-  // Common catastrophic-backtracking shapes.
+  // Common catastrophic-backtracking shapes (cheap early-reject only).
   private val DangerousPatternShapes = List(
     "\\(\\([^)]*[+*][^)]*\\)[+*][^)]*\\)[+*]", // ((x+)+)+ or ((x*)*)*
     "\\([^)]*[+*][^)]*\\)[+*]",                // (x+)+, (x*)*, (x+)*
-    "\\([^)]*\\|[^)]*\\)\\*"                   // (x|y)*
+    "\\([^)]*\\|[^)]*\\)[+*]"                  // (x|y)*, (x|y)+
   ).map(_.r)
 
-  def safeCompile(
-    pattern: String,
-    flags: Int = 0,
-    timeoutMs: Long = DefaultCompilationTimeoutMs
-  ): Either[String, Pattern] =
+  /** Raised when a match exceeds its step budget (likely catastrophic backtracking). */
+  final class RegexComplexityException(message: String) extends RuntimeException(message)
+
+  def safeCompile(pattern: String, flags: Int = 0): Either[String, Pattern] =
     for {
       _ <- validatePattern(pattern)
-      p <- compileSafely(pattern, flags, timeoutMs)
+      p <- compileSafely(pattern, flags)
     } yield p
 
-  def safeFind(pattern: Pattern, input: String, timeoutMs: Long = DefaultMatchingTimeoutMs): Either[String, Boolean] =
-    withInputValidation(input).flatMap(_ => findSafely(pattern, input, timeoutMs))
+  def safeFind(pattern: Pattern, input: String, maxSteps: Long = DefaultMaxMatchSteps): Either[String, Boolean] =
+    withInputValidation(input).flatMap(_ => guardMatch(boundedMatcher(pattern, input, maxSteps).find()))
 
-  def safeMatches(
-    pattern: Pattern,
-    input: String,
-    timeoutMs: Long = DefaultMatchingTimeoutMs
-  ): Either[String, Boolean] =
-    withInputValidation(input).flatMap(_ => matchesSafely(pattern, input, timeoutMs))
+  def safeMatches(pattern: Pattern, input: String, maxSteps: Long = DefaultMaxMatchSteps): Either[String, Boolean] =
+    withInputValidation(input).flatMap(_ => guardMatch(boundedMatcher(pattern, input, maxSteps).matches()))
 
   def compileLiteral(pattern: String, flags: Int = 0): Pattern =
     Pattern.compile(Pattern.quote(pattern), flags)
@@ -57,6 +77,8 @@ object RegexSafetyManager {
       Left(s"Pattern too long: ${pattern.length} > $MaxPatternLength")
     else if (DangerousPatternShapes.exists(_.findFirstIn(pattern).isDefined))
       Left("Regex pattern contains nested quantifiers/overlap and may cause ReDoS")
+    else if (hasOverlappingAlternationWithQuantifier(pattern))
+      Left("Regex pattern contains quantified overlapping alternation and may cause ReDoS")
     else Right(())
 
   private def withInputValidation(input: String): Either[String, Unit] =
@@ -65,31 +87,31 @@ object RegexSafetyManager {
       Left(s"Input too large: ${input.length} > $MaxInputLength")
     else Right(())
 
-  private def compileSafely(pattern: String, flags: Int, timeoutMs: Long): Either[String, Pattern] =
-    try {
-      // timeoutMs kept for API compatibility; execution safety comes from pre-checks.
-      val _ = timeoutMs
-      Right(Pattern.compile(pattern, flags))
-    } catch {
-      case e: PatternSyntaxException => Left(s"Invalid regex syntax: ${e.getMessage}")
-      case NonFatal(e)               => Left(s"Regex compilation failed: ${e.getMessage}")
+  private def compileSafely(pattern: String, flags: Int): Either[String, Pattern] =
+    Try(Pattern.compile(pattern, flags)).toEither.left.map {
+      case e: PatternSyntaxException => s"Invalid regex syntax: ${e.getMessage}"
+      case e                         => s"Regex compilation failed: ${e.getMessage}"
     }
 
-  private def findSafely(pattern: Pattern, input: String, timeoutMs: Long): Either[String, Boolean] =
-    try {
-      val _ = timeoutMs
-      Right(pattern.matcher(input).find())
-    } catch {
-      case NonFatal(e) => Left(s"Regex matching failed: ${e.getMessage}")
+  private def boundedMatcher(pattern: Pattern, input: String, maxSteps: Long): Matcher =
+    pattern.matcher(new StepBoundedCharSequence(input, maxSteps))
+
+  private def guardMatch(matchOp: => Boolean): Either[String, Boolean] =
+    Try(matchOp).toEither.left.map {
+      case _: RegexComplexityException => "Regex matching aborted: exceeded complexity budget (possible ReDoS)"
+      case e                           => s"Regex matching failed: ${e.getMessage}"
     }
 
-  private def matchesSafely(pattern: Pattern, input: String, timeoutMs: Long): Either[String, Boolean] =
-    try {
-      val _ = timeoutMs
-      Right(pattern.matcher(input).matches())
-    } catch {
-      case NonFatal(e) => Left(s"Regex matching failed: ${e.getMessage}")
+  private def hasOverlappingAlternationWithQuantifier(pattern: String): Boolean = {
+    val quantifiedAlt = "\\(([^)]*\\|[^)]*)\\)([+*])".r
+    quantifiedAlt.findAllMatchIn(pattern).exists { m =>
+      val alternatives = m.group(1).split("\\|").map(_.trim).filter(_.nonEmpty)
+      alternatives.combinations(2).exists {
+        case Array(a, b) => a.startsWith(b) || b.startsWith(a)
+        case _           => false
+      }
     }
+  }
 
   def replaceAllLiteral(
     input: String,
@@ -111,5 +133,34 @@ object RegexSafetyManager {
     val flags   = if (caseInsensitive) Pattern.CASE_INSENSITIVE else 0
     val pattern = compileLiteral(literalPattern, flags)
     pattern.matcher(input).replaceFirst(Matcher.quoteReplacement(replacement))
+  }
+
+  /**
+   * A [[CharSequence]] that counts character accesses and aborts once the step
+   * budget is exhausted, giving the backtracking engine a hard ceiling. The
+   * counter is shared with any subsequences the engine derives so the bound
+   * cannot be reset mid-match.
+   */
+  final private class StepBoundedCharSequence(
+    inner: CharSequence,
+    maxSteps: Long,
+    counter: Array[Long]
+  ) extends CharSequence {
+
+    def this(inner: CharSequence, maxSteps: Long) = this(inner, maxSteps, Array(0L))
+
+    override def length(): Int = inner.length()
+
+    override def charAt(index: Int): Char = {
+      counter(0) += 1L
+      if (counter(0) > maxSteps)
+        throw new RegexComplexityException(s"Regex matching exceeded step budget of $maxSteps")
+      inner.charAt(index)
+    }
+
+    override def subSequence(start: Int, end: Int): CharSequence =
+      new StepBoundedCharSequence(inner.subSequence(start, end), maxSteps, counter)
+
+    override def toString: String = inner.toString
   }
 }

--- a/modules/core/src/main/scala/org/llm4s/security/RegexSafetyManager.scala
+++ b/modules/core/src/main/scala/org/llm4s/security/RegexSafetyManager.scala
@@ -1,13 +1,13 @@
 package org.llm4s.security
 
-import java.util.concurrent.{ Executors, TimeUnit, TimeoutException }
 import java.util.regex.{ Matcher, Pattern, PatternSyntaxException }
+import scala.util.control.NonFatal
 
 /**
  * Safety wrapper for user-supplied regex compilation and matching.
  *
- * This manager blocks known catastrophic patterns, enforces basic bounds,
- * and time-boxes compile/match operations to reduce ReDoS risk.
+ * This manager blocks known catastrophic patterns and enforces basic bounds
+ * so we can avoid relying on interruption-based regex timeouts.
  */
 object RegexSafetyManager {
 
@@ -31,18 +31,18 @@ object RegexSafetyManager {
   ): Either[String, Pattern] =
     for {
       _ <- validatePattern(pattern)
-      p <- compileWithTimeout(pattern, flags, timeoutMs)
+      p <- compileSafely(pattern, flags, timeoutMs)
     } yield p
 
   def safeFind(pattern: Pattern, input: String, timeoutMs: Long = DefaultMatchingTimeoutMs): Either[String, Boolean] =
-    withInputValidation(input).flatMap(_ => findWithTimeout(pattern, input, timeoutMs))
+    withInputValidation(input).flatMap(_ => findSafely(pattern, input, timeoutMs))
 
   def safeMatches(
     pattern: Pattern,
     input: String,
     timeoutMs: Long = DefaultMatchingTimeoutMs
   ): Either[String, Boolean] =
-    withInputValidation(input).flatMap(_ => matchesWithTimeout(pattern, input, timeoutMs))
+    withInputValidation(input).flatMap(_ => matchesSafely(pattern, input, timeoutMs))
 
   def compileLiteral(pattern: String, flags: Int = 0): Pattern =
     Pattern.compile(Pattern.quote(pattern), flags)
@@ -65,45 +65,31 @@ object RegexSafetyManager {
       Left(s"Input too large: ${input.length} > $MaxInputLength")
     else Right(())
 
-  private def compileWithTimeout(pattern: String, flags: Int, timeoutMs: Long): Either[String, Pattern] = {
-    val executor = Executors.newSingleThreadExecutor()
+  private def compileSafely(pattern: String, flags: Int, timeoutMs: Long): Either[String, Pattern] =
     try {
-      val future = executor.submit(new java.util.concurrent.Callable[Pattern] {
-        override def call(): Pattern = Pattern.compile(pattern, flags)
-      })
-      Right(future.get(timeoutMs, TimeUnit.MILLISECONDS))
+      // timeoutMs kept for API compatibility; execution safety comes from pre-checks.
+      val _ = timeoutMs
+      Right(Pattern.compile(pattern, flags))
     } catch {
-      case _: TimeoutException       => Left(s"Regex compilation timeout after ${timeoutMs}ms")
       case e: PatternSyntaxException => Left(s"Invalid regex syntax: ${e.getMessage}")
-      case e: Exception              => Left(s"Regex compilation failed: ${e.getMessage}")
-    } finally executor.shutdownNow()
-  }
+      case NonFatal(e)               => Left(s"Regex compilation failed: ${e.getMessage}")
+    }
 
-  private def findWithTimeout(pattern: Pattern, input: String, timeoutMs: Long): Either[String, Boolean] = {
-    val executor = Executors.newSingleThreadExecutor()
+  private def findSafely(pattern: Pattern, input: String, timeoutMs: Long): Either[String, Boolean] =
     try {
-      val future = executor.submit(new java.util.concurrent.Callable[Boolean] {
-        override def call(): Boolean = pattern.matcher(input).find()
-      })
-      Right(future.get(timeoutMs, TimeUnit.MILLISECONDS))
+      val _ = timeoutMs
+      Right(pattern.matcher(input).find())
     } catch {
-      case _: TimeoutException => Left(s"Regex matching timeout after ${timeoutMs}ms")
-      case e: Exception        => Left(s"Regex matching failed: ${e.getMessage}")
-    } finally executor.shutdownNow()
-  }
+      case NonFatal(e) => Left(s"Regex matching failed: ${e.getMessage}")
+    }
 
-  private def matchesWithTimeout(pattern: Pattern, input: String, timeoutMs: Long): Either[String, Boolean] = {
-    val executor = Executors.newSingleThreadExecutor()
+  private def matchesSafely(pattern: Pattern, input: String, timeoutMs: Long): Either[String, Boolean] =
     try {
-      val future = executor.submit(new java.util.concurrent.Callable[Boolean] {
-        override def call(): Boolean = pattern.matcher(input).matches()
-      })
-      Right(future.get(timeoutMs, TimeUnit.MILLISECONDS))
+      val _ = timeoutMs
+      Right(pattern.matcher(input).matches())
     } catch {
-      case _: TimeoutException => Left(s"Regex matching timeout after ${timeoutMs}ms")
-      case e: Exception        => Left(s"Regex matching failed: ${e.getMessage}")
-    } finally executor.shutdownNow()
-  }
+      case NonFatal(e) => Left(s"Regex matching failed: ${e.getMessage}")
+    }
 
   def replaceAllLiteral(
     input: String,

--- a/modules/core/src/main/scala/org/llm4s/security/RegexSafetyManager.scala
+++ b/modules/core/src/main/scala/org/llm4s/security/RegexSafetyManager.scala
@@ -1,0 +1,129 @@
+package org.llm4s.security
+
+import java.util.concurrent.{ Executors, TimeUnit, TimeoutException }
+import java.util.regex.{ Matcher, Pattern, PatternSyntaxException }
+
+/**
+ * Safety wrapper for user-supplied regex compilation and matching.
+ *
+ * This manager blocks known catastrophic patterns, enforces basic bounds,
+ * and time-boxes compile/match operations to reduce ReDoS risk.
+ */
+object RegexSafetyManager {
+
+  private val MaxPatternLength            = 1000
+  private val MaxInputLength              = 100000
+  private val DefaultCompilationTimeoutMs = 1000L
+  private val DefaultMatchingTimeoutMs    = 250L
+  private val DefaultCaseInsensitiveFlags = Pattern.CASE_INSENSITIVE
+
+  // Common catastrophic-backtracking shapes.
+  private val DangerousPatternShapes = List(
+    "\\(\\([^)]*[+*][^)]*\\)[+*][^)]*\\)[+*]", // ((x+)+)+ or ((x*)*)*
+    "\\([^)]*[+*][^)]*\\)[+*]",                // (x+)+, (x*)*, (x+)*
+    "\\([^)]*\\|[^)]*\\)\\*"                   // (x|y)*
+  ).map(_.r)
+
+  def safeCompile(
+    pattern: String,
+    flags: Int = 0,
+    timeoutMs: Long = DefaultCompilationTimeoutMs
+  ): Either[String, Pattern] =
+    for {
+      _ <- validatePattern(pattern)
+      p <- compileWithTimeout(pattern, flags, timeoutMs)
+    } yield p
+
+  def safeFind(pattern: Pattern, input: String, timeoutMs: Long = DefaultMatchingTimeoutMs): Either[String, Boolean] =
+    withInputValidation(input).flatMap(_ => findWithTimeout(pattern, input, timeoutMs))
+
+  def safeMatches(
+    pattern: Pattern,
+    input: String,
+    timeoutMs: Long = DefaultMatchingTimeoutMs
+  ): Either[String, Boolean] =
+    withInputValidation(input).flatMap(_ => matchesWithTimeout(pattern, input, timeoutMs))
+
+  def compileLiteral(pattern: String, flags: Int = 0): Pattern =
+    Pattern.compile(Pattern.quote(pattern), flags)
+
+  def compileLiteralCaseInsensitive(pattern: String): Pattern =
+    compileLiteral(pattern, DefaultCaseInsensitiveFlags)
+
+  private def validatePattern(pattern: String): Either[String, Unit] =
+    if (pattern == null) Left("Pattern cannot be null")
+    else if (pattern.trim.isEmpty) Left("Pattern cannot be empty")
+    else if (pattern.length > MaxPatternLength)
+      Left(s"Pattern too long: ${pattern.length} > $MaxPatternLength")
+    else if (DangerousPatternShapes.exists(_.findFirstIn(pattern).isDefined))
+      Left("Regex pattern contains nested quantifiers/overlap and may cause ReDoS")
+    else Right(())
+
+  private def withInputValidation(input: String): Either[String, Unit] =
+    if (input == null) Left("Input cannot be null")
+    else if (input.length > MaxInputLength)
+      Left(s"Input too large: ${input.length} > $MaxInputLength")
+    else Right(())
+
+  private def compileWithTimeout(pattern: String, flags: Int, timeoutMs: Long): Either[String, Pattern] = {
+    val executor = Executors.newSingleThreadExecutor()
+    try {
+      val future = executor.submit(new java.util.concurrent.Callable[Pattern] {
+        override def call(): Pattern = Pattern.compile(pattern, flags)
+      })
+      Right(future.get(timeoutMs, TimeUnit.MILLISECONDS))
+    } catch {
+      case _: TimeoutException       => Left(s"Regex compilation timeout after ${timeoutMs}ms")
+      case e: PatternSyntaxException => Left(s"Invalid regex syntax: ${e.getMessage}")
+      case e: Exception              => Left(s"Regex compilation failed: ${e.getMessage}")
+    } finally executor.shutdownNow()
+  }
+
+  private def findWithTimeout(pattern: Pattern, input: String, timeoutMs: Long): Either[String, Boolean] = {
+    val executor = Executors.newSingleThreadExecutor()
+    try {
+      val future = executor.submit(new java.util.concurrent.Callable[Boolean] {
+        override def call(): Boolean = pattern.matcher(input).find()
+      })
+      Right(future.get(timeoutMs, TimeUnit.MILLISECONDS))
+    } catch {
+      case _: TimeoutException => Left(s"Regex matching timeout after ${timeoutMs}ms")
+      case e: Exception        => Left(s"Regex matching failed: ${e.getMessage}")
+    } finally executor.shutdownNow()
+  }
+
+  private def matchesWithTimeout(pattern: Pattern, input: String, timeoutMs: Long): Either[String, Boolean] = {
+    val executor = Executors.newSingleThreadExecutor()
+    try {
+      val future = executor.submit(new java.util.concurrent.Callable[Boolean] {
+        override def call(): Boolean = pattern.matcher(input).matches()
+      })
+      Right(future.get(timeoutMs, TimeUnit.MILLISECONDS))
+    } catch {
+      case _: TimeoutException => Left(s"Regex matching timeout after ${timeoutMs}ms")
+      case e: Exception        => Left(s"Regex matching failed: ${e.getMessage}")
+    } finally executor.shutdownNow()
+  }
+
+  def replaceAllLiteral(
+    input: String,
+    literalPattern: String,
+    replacement: String,
+    caseInsensitive: Boolean
+  ): String = {
+    val flags   = if (caseInsensitive) Pattern.CASE_INSENSITIVE else 0
+    val pattern = compileLiteral(literalPattern, flags)
+    pattern.matcher(input).replaceAll(Matcher.quoteReplacement(replacement))
+  }
+
+  def replaceFirstLiteral(
+    input: String,
+    literalPattern: String,
+    replacement: String,
+    caseInsensitive: Boolean
+  ): String = {
+    val flags   = if (caseInsensitive) Pattern.CASE_INSENSITIVE else 0
+    val pattern = compileLiteral(literalPattern, flags)
+    pattern.matcher(input).replaceFirst(Matcher.quoteReplacement(replacement))
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/agent/guardrails/builtin/SimpleValidatorSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/guardrails/builtin/SimpleValidatorSpec.scala
@@ -229,6 +229,20 @@ class SimpleValidatorSpec extends AnyFlatSpec with Matchers {
     validator.validate("hello") shouldBe Right("hello")
   }
 
+  it should "not throw for invalid regex patterns in apply(String)" in {
+    val validator = RegexValidator("(")
+    val result    = validator.validate("anything")
+    result.isLeft shouldBe true
+    result.swap.toOption.get.message should include("Invalid or unsafe regex pattern")
+  }
+
+  it should "reject known ReDoS regex patterns safely" in {
+    val validator = RegexValidator("((a+)+)+b")
+    val result    = validator.validate("a" * 28 + "X")
+    result.isLeft shouldBe true
+    result.swap.toOption.get.message should include("Invalid or unsafe regex pattern")
+  }
+
   it should "create with custom error message via apply(String, String)" in {
     val validator = RegexValidator("^[0-9]+$", "Numbers only please")
     val result    = validator.validate("abc")

--- a/modules/core/src/test/scala/org/llm4s/agent/guardrails/builtin/SimpleValidatorSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/guardrails/builtin/SimpleValidatorSpec.scala
@@ -249,6 +249,29 @@ class SimpleValidatorSpec extends AnyFlatSpec with Matchers {
     result.swap.toOption.get.message should include("Numbers only please")
   }
 
+  it should "create from Regex via apply(Regex)" in {
+    val validator = RegexValidator("^[a-z]+$".r)
+    validator.validate("letters") shouldBe Right("letters")
+    validator.validate("letters123").isLeft shouldBe true
+  }
+
+  it should "support constructor with custom error message" in {
+    val validator = new RegexValidator("^[0-9]+$".r, Some("Digits required"))
+    val result    = validator.validate("abc")
+    result.swap.toOption.get.message should include("Digits required")
+  }
+
+  it should "return fallback error when constructor receives one" in {
+    val validator = new RegexValidator(
+      "^[0-9]+$".r,
+      Some("Digits required"),
+      Some("Forced fallback path")
+    )
+    val result = validator.validate("123")
+    result.isLeft shouldBe true
+    result.swap.toOption.get.message should include("Forced fallback path")
+  }
+
   // -- Phone preset --
 
   "RegexValidator.phone" should "accept valid phone numbers" in {

--- a/modules/core/src/test/scala/org/llm4s/rag/loader/internal/GlobPatternMatcherSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/rag/loader/internal/GlobPatternMatcherSpec.scala
@@ -41,6 +41,12 @@ class GlobPatternMatcherSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     GlobPatternMatcher.matches("http://example.com/PAGE", "http://example.com/*") shouldBe true
   }
 
+  it should "fallback to literal matching for overlong patterns" in {
+    val longPattern = "A" * 1200
+    GlobPatternMatcher.matches(longPattern, longPattern) shouldBe true
+    GlobPatternMatcher.matches("different", longPattern) shouldBe false
+  }
+
   "GlobPatternMatcher.matchesAny" should "return true if any pattern matches" in {
     val patterns = Seq("http://a.com/*", "http://b.com/*", "http://c.com/*")
     GlobPatternMatcher.matchesAny("http://b.com/page", patterns) shouldBe true

--- a/modules/core/src/test/scala/org/llm4s/security/ReDoSVulnerabilitySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/security/ReDoSVulnerabilitySpec.scala
@@ -52,6 +52,23 @@ class ReDoSVulnerabilitySpec extends AnyFlatSpec with Matchers {
     validator.validate("hello123").isLeft shouldBe true
   }
 
+  it should "bound catastrophic patterns supplied to RegexValidator as a Regex" in {
+    // A dangerous pattern constructed directly as a Regex bypasses the
+    // apply(String) pre-screen, but validation is still bounded at match time,
+    // so a malicious input fails safely instead of hanging.
+    val validator = new RegexValidator("(.*a){25}b".r)
+    val result    = validator.validate("a" * 40)
+    result.isLeft shouldBe true
+    result.swap.toOption.get.message should include("Regex security error")
+  }
+
+  it should "fall back safely when apply(String, String) receives an invalid pattern" in {
+    val validator = RegexValidator("(", "Numbers only please")
+    val result    = validator.validate("anything")
+    result.isLeft shouldBe true
+    result.swap.toOption.get.message should include("Invalid or unsafe regex pattern")
+  }
+
   it should "reject null, empty and oversized patterns" in {
     RegexSafetyManager.safeCompile(null).left.toOption.get should include("Pattern cannot be null")
     RegexSafetyManager.safeCompile("   ").left.toOption.get should include("Pattern cannot be empty")

--- a/modules/core/src/test/scala/org/llm4s/security/ReDoSVulnerabilitySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/security/ReDoSVulnerabilitySpec.scala
@@ -22,16 +22,28 @@ class ReDoSVulnerabilitySpec extends AnyFlatSpec with Matchers {
     dangerous.foreach(pattern => RegexSafetyManager.safeCompile(pattern).isLeft shouldBe true)
   }
 
-  it should "complete potentially malicious matching attempts within a hard timeout" in {
+  it should "reject blocklisted ReDoS patterns at validation time" in {
+    // ((a+)+)+b matches the dangerous-shape blocklist, so it is rejected before
+    // it is ever compiled or matched.
     val validator = RegexValidator("((a+)+)+b")
-    val attack    = "a" * 28 + "X"
+    validator.validate("a" * 28 + "X").isLeft shouldBe true
+  }
 
-    val eventual = Future {
-      validator.validate(attack)
-    }
+  it should "bound matching for catastrophic patterns the blocklist does not catch" in {
+    // (.*a){25}b is genuinely catastrophic in the JDK engine but bypasses the
+    // shape blocklist (the group is quantified with {25}, not +/*), so it
+    // compiles successfully...
+    val compiled = RegexSafetyManager.safeCompile("(.*a){25}b")
+    compiled.isRight shouldBe true
 
-    val result = Await.result(eventual, 2.seconds)
+    // ...but on a malicious input the catastrophic backtracking is aborted by the
+    // step budget instead of hanging. Without the bound this match never returns
+    // and the Await below would time out.
+    val attack   = "a" * 40
+    val eventual = Future(RegexSafetyManager.safeFind(compiled.toOption.get, attack))
+    val result   = Await.result(eventual, 10.seconds)
     result.isLeft shouldBe true
+    result.left.toOption.get should include("complexity budget")
   }
 
   it should "still allow normal regex usage" in {

--- a/modules/core/src/test/scala/org/llm4s/security/ReDoSVulnerabilitySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/security/ReDoSVulnerabilitySpec.scala
@@ -39,4 +39,61 @@ class ReDoSVulnerabilitySpec extends AnyFlatSpec with Matchers {
     validator.validate("hello") shouldBe Right("hello")
     validator.validate("hello123").isLeft shouldBe true
   }
+
+  it should "reject null, empty and oversized patterns" in {
+    RegexSafetyManager.safeCompile(null).left.toOption.get should include("Pattern cannot be null")
+    RegexSafetyManager.safeCompile("   ").left.toOption.get should include("Pattern cannot be empty")
+    RegexSafetyManager
+      .safeCompile("a" * 1001)
+      .left
+      .toOption
+      .get should include("Pattern too long")
+  }
+
+  it should "report syntax errors for invalid regex patterns" in {
+    val result = RegexSafetyManager.safeCompile("(")
+    result.isLeft shouldBe true
+    result.left.toOption.get should include("Invalid regex syntax")
+  }
+
+  it should "reject null and oversized inputs for safe find/matches" in {
+    val compiled = RegexSafetyManager.safeCompile("^abc$").toOption.get
+
+    RegexSafetyManager.safeFind(compiled, null).left.toOption.get should include("Input cannot be null")
+    RegexSafetyManager
+      .safeMatches(compiled, "a" * 100001)
+      .left
+      .toOption
+      .get should include("Input too large")
+  }
+
+  it should "support safeMatches for positive and negative cases" in {
+    val compiled = RegexSafetyManager.safeCompile("^[a-z]+$").toOption.get
+
+    RegexSafetyManager.safeMatches(compiled, "hello") shouldBe Right(true)
+    RegexSafetyManager.safeMatches(compiled, "hello123") shouldBe Right(false)
+  }
+
+  it should "compile case-insensitive literal patterns" in {
+    val literal = RegexSafetyManager.compileLiteralCaseInsensitive("hello")
+    literal.matcher("HeLLo world").find() shouldBe true
+  }
+
+  it should "perform literal replacement with escaped replacement text" in {
+    val replacedAll = RegexSafetyManager.replaceAllLiteral(
+      input = "a+b a+b",
+      literalPattern = "a+b",
+      replacement = "$1",
+      caseInsensitive = false
+    )
+    replacedAll shouldBe "$1 $1"
+
+    val replacedFirst = RegexSafetyManager.replaceFirstLiteral(
+      input = "Token token TOKEN",
+      literalPattern = "token",
+      replacement = "X$Y",
+      caseInsensitive = true
+    )
+    replacedFirst shouldBe "X$Y token TOKEN"
+  }
 }

--- a/modules/core/src/test/scala/org/llm4s/security/ReDoSVulnerabilitySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/security/ReDoSVulnerabilitySpec.scala
@@ -1,0 +1,42 @@
+package org.llm4s.security
+
+import org.llm4s.agent.guardrails.builtin.RegexValidator
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ReDoSVulnerabilitySpec extends AnyFlatSpec with Matchers {
+
+  "RegexSafetyManager" should "reject dangerous nested-quantifier patterns" in {
+    val dangerous = List(
+      "((a+)+)+b",
+      "(a+)+b",
+      "(a*)*b",
+      "(a+)*b",
+      "(a|a)*b"
+    )
+
+    dangerous.foreach(pattern => RegexSafetyManager.safeCompile(pattern).isLeft shouldBe true)
+  }
+
+  it should "complete potentially malicious matching attempts within a hard timeout" in {
+    val validator = RegexValidator("((a+)+)+b")
+    val attack    = "a" * 28 + "X"
+
+    val eventual = Future {
+      validator.validate(attack)
+    }
+
+    val result = Await.result(eventual, 2.seconds)
+    result.isLeft shouldBe true
+  }
+
+  it should "still allow normal regex usage" in {
+    val validator = RegexValidator("^[a-z]+$")
+    validator.validate("hello") shouldBe Right("hello")
+    validator.validate("hello123").isLeft shouldBe true
+  }
+}

--- a/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceAgentInterfaceImpl.scala
+++ b/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceAgentInterfaceImpl.scala
@@ -1,6 +1,7 @@
 package org.llm4s.runner
 
 import org.llm4s.shared._
+import org.slf4j.LoggerFactory
 
 import java.io.{ BufferedWriter, PrintWriter }
 import java.nio.charset.{ Charset, StandardCharsets }
@@ -28,6 +29,8 @@ class WorkspaceAgentInterfaceImpl(
   isWindows: Boolean,
   sandboxConfig: Option[WorkspaceSandboxConfig] = None
 ) extends WorkspaceAgentInterface {
+
+  private val logger = LoggerFactory.getLogger(getClass)
 
   private val rootPath = Paths.get(workspaceRoot).toAbsolutePath.normalize()
 
@@ -441,52 +444,45 @@ class WorkspaceAgentInterfaceImpl(
             result
           }
 
+          val caseInsensitive = patternFlags.contains("i")
+          val replaceGlobally = patternFlags.contains("g")
+
+          // Literal-replacement fallback used when a pattern is rejected up front
+          // or a per-line match aborts (e.g. exceeds the ReDoS step budget). This
+          // changes regex semantics to plain substring replacement, so it is
+          // logged (once) rather than applied silently.
+          def literalReplace(line: String): String =
+            if (replaceGlobally)
+              WorkspaceRegexSafetyManager.replaceAllLiteral(line, pattern, replacement, caseInsensitive)
+            else
+              WorkspaceRegexSafetyManager.replaceFirstLiteral(line, pattern, replacement, caseInsensitive)
+
           WorkspaceRegexSafetyManager.safeCompile(pattern, regexFlags) match {
             case Right(regex) =>
+              var loggedRuntimeFallback = false
               currentLines.map { line =>
-                if (patternFlags.contains("g")) {
-                  WorkspaceRegexSafetyManager
-                    .safeReplaceAll(regex, line, replacement)
-                    .getOrElse(
-                      WorkspaceRegexSafetyManager.replaceAllLiteral(
-                        line,
-                        pattern,
-                        replacement,
-                        patternFlags.contains("i")
+                val replaced =
+                  if (replaceGlobally) WorkspaceRegexSafetyManager.safeReplaceAll(regex, line, replacement)
+                  else WorkspaceRegexSafetyManager.safeReplaceFirst(regex, line, replacement)
+                replaced match {
+                  case Right(result) => result
+                  case Left(err) =>
+                    if (!loggedRuntimeFallback) {
+                      logger.warn(
+                        s"Regex replace aborted at runtime ($err) for pattern '$pattern'; " +
+                          "falling back to literal replacement for affected lines."
                       )
-                    )
-                } else {
-                  WorkspaceRegexSafetyManager
-                    .safeReplaceFirst(regex, line, replacement)
-                    .getOrElse(
-                      WorkspaceRegexSafetyManager.replaceFirstLiteral(
-                        line,
-                        pattern,
-                        replacement,
-                        patternFlags.contains("i")
-                      )
-                    )
+                      loggedRuntimeFallback = true
+                    }
+                    literalReplace(line)
                 }
               }
-            case Left(_) =>
-              // Degrade to literal replacement for unsafe/invalid regex patterns.
-              currentLines.map { line =>
-                if (patternFlags.contains("g")) {
-                  WorkspaceRegexSafetyManager.replaceAllLiteral(
-                    line,
-                    pattern,
-                    replacement,
-                    patternFlags.contains("i")
-                  )
-                } else {
-                  WorkspaceRegexSafetyManager.replaceFirstLiteral(
-                    line,
-                    pattern,
-                    replacement,
-                    patternFlags.contains("i")
-                  )
-                }
-              }
+            case Left(err) =>
+              logger.warn(
+                s"Rejected unsafe or invalid replace regex '$pattern' ($err); " +
+                  "falling back to literal replacement."
+              )
+              currentLines.map(literalReplace)
           }
       }
     }
@@ -514,16 +510,26 @@ class WorkspaceAgentInterfaceImpl(
       )
     }
 
-    // Prepare regex pattern
+    // Prepare regex pattern. An unsafe/invalid regex degrades to literal
+    // substring search, which changes match semantics, so we log it rather than
+    // failing silently.
     val pattern = if (searchType == "literal") {
       WorkspaceRegexSafetyManager.compileLiteral(query)
     } else {
       WorkspaceRegexSafetyManager.safeCompile(query) match {
         case Right(p) => p
-        case Left(_)  => WorkspaceRegexSafetyManager.compileLiteral(query)
+        case Left(err) =>
+          logger.warn(
+            s"Rejected unsafe or invalid search regex '$query' ($err); " +
+              "falling back to literal substring search."
+          )
+          WorkspaceRegexSafetyManager.compileLiteral(query)
       }
     }
     val literalFallbackPattern = WorkspaceRegexSafetyManager.compileLiteral(query)
+    // Set once if any per-line match aborts (e.g. exceeds the step budget) and we
+    // fall back to literal matching for that line.
+    var loggedRuntimeFallback = false
 
     // Collect all files to search
     val filesToSearch = paths.flatMap { path =>
@@ -569,8 +575,17 @@ class WorkspaceAgentInterfaceImpl(
       Try(Files.readAllLines(file, StandardCharsets.UTF_8).asScala.toList).toOption.foreach { lines =>
         for ((line, lineIndex) <- lines.zipWithIndex if !done) {
           val isMatch =
-            WorkspaceRegexSafetyManager.safeFind(pattern, line).getOrElse {
-              literalFallbackPattern.matcher(line).find()
+            WorkspaceRegexSafetyManager.safeFind(pattern, line) match {
+              case Right(m) => m
+              case Left(err) =>
+                if (!loggedRuntimeFallback) {
+                  logger.warn(
+                    s"Regex search aborted at runtime ($err) for query '$query'; " +
+                      "falling back to literal substring match for affected lines."
+                  )
+                  loggedRuntimeFallback = true
+                }
+                literalFallbackPattern.matcher(line).find()
             }
 
           if (isMatch) {

--- a/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceAgentInterfaceImpl.scala
+++ b/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceAgentInterfaceImpl.scala
@@ -441,15 +441,35 @@ class WorkspaceAgentInterfaceImpl(
             result
           }
 
-          val regex = Pattern.compile(pattern, regexFlags)
-
-          currentLines.map { line =>
-            val matcher = regex.matcher(line)
-            if (patternFlags.contains("g")) {
-              matcher.replaceAll(replacement)
-            } else {
-              matcher.replaceFirst(replacement)
-            }
+          WorkspaceRegexSafetyManager.safeCompile(pattern, regexFlags) match {
+            case Right(regex) =>
+              currentLines.map { line =>
+                val matcher = regex.matcher(line)
+                if (patternFlags.contains("g")) {
+                  matcher.replaceAll(replacement)
+                } else {
+                  matcher.replaceFirst(replacement)
+                }
+              }
+            case Left(_) =>
+              // Degrade to literal replacement for unsafe/invalid regex patterns.
+              currentLines.map { line =>
+                if (patternFlags.contains("g")) {
+                  WorkspaceRegexSafetyManager.replaceAllLiteral(
+                    line,
+                    pattern,
+                    replacement,
+                    patternFlags.contains("i")
+                  )
+                } else {
+                  WorkspaceRegexSafetyManager.replaceFirstLiteral(
+                    line,
+                    pattern,
+                    replacement,
+                    patternFlags.contains("i")
+                  )
+                }
+              }
           }
       }
     }
@@ -479,16 +499,11 @@ class WorkspaceAgentInterfaceImpl(
 
     // Prepare regex pattern
     val pattern = if (searchType == "literal") {
-      Pattern.compile(Pattern.quote(query))
+      WorkspaceRegexSafetyManager.compileLiteral(query)
     } else {
-      Try(Pattern.compile(query)) match {
-        case Success(p) => p
-        case Failure(e) =>
-          throw new WorkspaceAgentException(
-            s"Invalid regex pattern: ${e.getMessage}",
-            "INVALID_ARGUMENT",
-            None
-          )
+      WorkspaceRegexSafetyManager.safeCompile(query) match {
+        case Right(p) => p
+        case Left(_)  => WorkspaceRegexSafetyManager.compileLiteral(query)
       }
     }
 

--- a/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceAgentInterfaceImpl.scala
+++ b/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceAgentInterfaceImpl.scala
@@ -444,11 +444,28 @@ class WorkspaceAgentInterfaceImpl(
           WorkspaceRegexSafetyManager.safeCompile(pattern, regexFlags) match {
             case Right(regex) =>
               currentLines.map { line =>
-                val matcher = regex.matcher(line)
                 if (patternFlags.contains("g")) {
-                  matcher.replaceAll(replacement)
+                  WorkspaceRegexSafetyManager
+                    .safeReplaceAll(regex, line, replacement)
+                    .getOrElse(
+                      WorkspaceRegexSafetyManager.replaceAllLiteral(
+                        line,
+                        pattern,
+                        replacement,
+                        patternFlags.contains("i")
+                      )
+                    )
                 } else {
-                  matcher.replaceFirst(replacement)
+                  WorkspaceRegexSafetyManager
+                    .safeReplaceFirst(regex, line, replacement)
+                    .getOrElse(
+                      WorkspaceRegexSafetyManager.replaceFirstLiteral(
+                        line,
+                        pattern,
+                        replacement,
+                        patternFlags.contains("i")
+                      )
+                    )
                 }
               }
             case Left(_) =>
@@ -506,6 +523,7 @@ class WorkspaceAgentInterfaceImpl(
         case Left(_)  => WorkspaceRegexSafetyManager.compileLiteral(query)
       }
     }
+    val literalFallbackPattern = WorkspaceRegexSafetyManager.compileLiteral(query)
 
     // Collect all files to search
     val filesToSearch = paths.flatMap { path =>
@@ -550,9 +568,12 @@ class WorkspaceAgentInterfaceImpl(
 
       Try(Files.readAllLines(file, StandardCharsets.UTF_8).asScala.toList).toOption.foreach { lines =>
         for ((line, lineIndex) <- lines.zipWithIndex if !done) {
-          val matcher = pattern.matcher(line)
+          val isMatch =
+            WorkspaceRegexSafetyManager.safeFind(pattern, line).getOrElse {
+              literalFallbackPattern.matcher(line).find()
+            }
 
-          if (matcher.find()) {
+          if (isMatch) {
             totalMatches += 1
 
             if (matches.size < defaultLimits.maxSearchResults) {

--- a/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceRegexSafetyManager.scala
+++ b/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceRegexSafetyManager.scala
@@ -1,7 +1,7 @@
 package org.llm4s.runner
 
-import java.util.concurrent.{ Executors, TimeUnit, TimeoutException }
 import java.util.regex.{ Matcher, Pattern, PatternSyntaxException }
+import scala.util.control.NonFatal
 
 /**
  * Workspace-runner local regex safety helper used for user-supplied patterns.
@@ -9,19 +9,47 @@ import java.util.regex.{ Matcher, Pattern, PatternSyntaxException }
 object WorkspaceRegexSafetyManager {
 
   private val MaxPatternLength            = 1000
+  private val MaxInputLength              = 100000
   private val DefaultCompilationTimeoutMs = 1000L
 
   private val DangerousPatternShapes = List(
     "\\(\\([^)]*[+*][^)]*\\)[+*][^)]*\\)[+*]",
     "\\([^)]*[+*][^)]*\\)[+*]",
-    "\\([^)]*\\|[^)]*\\)\\*"
+    "\\([^)]*\\|[^)]*\\)[+*]"
   ).map(_.r)
 
   def safeCompile(pattern: String, flags: Int = 0): Either[String, Pattern] =
     for {
       _ <- validatePattern(pattern)
-      p <- compileWithTimeout(pattern, flags, DefaultCompilationTimeoutMs)
+      p <- compileSafely(pattern, flags, DefaultCompilationTimeoutMs)
     } yield p
+
+  def safeFind(pattern: Pattern, input: String): Either[String, Boolean] =
+    withInputValidation(input).flatMap(_ =>
+      try
+        Right(pattern.matcher(input).find())
+      catch {
+        case NonFatal(e) => Left(s"Regex matching failed: ${e.getMessage}")
+      }
+    )
+
+  def safeReplaceAll(pattern: Pattern, input: String, replacement: String): Either[String, String] =
+    withInputValidation(input).flatMap(_ =>
+      try
+        Right(pattern.matcher(input).replaceAll(replacement))
+      catch {
+        case NonFatal(e) => Left(s"Regex replacement failed: ${e.getMessage}")
+      }
+    )
+
+  def safeReplaceFirst(pattern: Pattern, input: String, replacement: String): Either[String, String] =
+    withInputValidation(input).flatMap(_ =>
+      try
+        Right(pattern.matcher(input).replaceFirst(replacement))
+      catch {
+        case NonFatal(e) => Left(s"Regex replacement failed: ${e.getMessage}")
+      }
+    )
 
   def compileLiteral(pattern: String, flags: Int = 0): Pattern =
     Pattern.compile(Pattern.quote(pattern), flags)
@@ -55,19 +83,33 @@ object WorkspaceRegexSafetyManager {
       Left(s"Pattern too long: ${pattern.length} > $MaxPatternLength")
     else if (DangerousPatternShapes.exists(_.findFirstIn(pattern).isDefined))
       Left("Regex pattern contains nested quantifiers/overlap and may cause ReDoS")
+    else if (hasOverlappingAlternationWithQuantifier(pattern))
+      Left("Regex pattern contains quantified overlapping alternation and may cause ReDoS")
     else Right(())
 
-  private def compileWithTimeout(pattern: String, flags: Int, timeoutMs: Long): Either[String, Pattern] = {
-    val executor = Executors.newSingleThreadExecutor()
+  private def withInputValidation(input: String): Either[String, Unit] =
+    if (input == null) Left("Input cannot be null")
+    else if (input.length > MaxInputLength)
+      Left(s"Input too large: ${input.length} > $MaxInputLength")
+    else Right(())
+
+  private def compileSafely(pattern: String, flags: Int, timeoutMs: Long): Either[String, Pattern] =
     try {
-      val future = executor.submit(new java.util.concurrent.Callable[Pattern] {
-        override def call(): Pattern = Pattern.compile(pattern, flags)
-      })
-      Right(future.get(timeoutMs, TimeUnit.MILLISECONDS))
+      val _ = timeoutMs // preserved for API stability
+      Right(Pattern.compile(pattern, flags))
     } catch {
-      case _: TimeoutException       => Left(s"Regex compilation timeout after ${timeoutMs}ms")
       case e: PatternSyntaxException => Left(s"Invalid regex syntax: ${e.getMessage}")
-      case e: Exception              => Left(s"Regex compilation failed: ${e.getMessage}")
-    } finally executor.shutdownNow()
+      case NonFatal(e)               => Left(s"Regex compilation failed: ${e.getMessage}")
+    }
+
+  private def hasOverlappingAlternationWithQuantifier(pattern: String): Boolean = {
+    val quantifiedAlt = "\\(([^)]*\\|[^)]*)\\)([+*])".r
+    quantifiedAlt.findAllMatchIn(pattern).exists { m =>
+      val alternatives = m.group(1).split("\\|").map(_.trim).filter(_.nonEmpty)
+      alternatives.combinations(2).exists {
+        case Array(a, b) => a.startsWith(b) || b.startsWith(a)
+        case _           => false
+      }
+    }
   }
 }

--- a/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceRegexSafetyManager.scala
+++ b/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceRegexSafetyManager.scala
@@ -1,16 +1,40 @@
 package org.llm4s.runner
 
 import java.util.regex.{ Matcher, Pattern, PatternSyntaxException }
-import scala.util.control.NonFatal
+import scala.util.Try
 
 /**
- * Workspace-runner local regex safety helper used for user-supplied patterns.
+ * Workspace-runner local regex safety helper for user-supplied patterns.
+ *
+ * ReDoS is mitigated by two complementary defences:
+ *
+ *   1. A cheap pre-screen ([[safeCompile]]) rejects null/empty/oversized
+ *      patterns and well-known catastrophic-backtracking shapes before they are
+ *      compiled.
+ *   2. A hard execution bound ([[safeFind]]/[[safeReplaceAll]]/[[safeReplaceFirst]])
+ *      caps the number of character accesses the backtracking engine may perform
+ *      for a single operation. A step ceiling deterministically bounds worst-case
+ *      runtime even for dangerous patterns the pre-screen misses, without relying
+ *      on thread interruption or wall-clock timeouts.
+ *
+ * The step bound is the real security boundary; the shape blocklist is only a
+ * fast early-reject.
+ *
+ * NOTE: kept intentionally in sync with `org.llm4s.security.RegexSafetyManager`
+ * in `core`. This module cannot depend on `core`, so the logic is duplicated;
+ * changes to the heuristics or bounds in either place should be mirrored.
  */
 object WorkspaceRegexSafetyManager {
 
-  private val MaxPatternLength            = 1000
-  private val MaxInputLength              = 100000
-  private val DefaultCompilationTimeoutMs = 1000L
+  private val MaxPatternLength = 1000
+  private val MaxInputLength   = 100000
+
+  /**
+   * Upper bound on character accesses for a single match/replace. Comfortably
+   * above legitimate matching for inputs up to [[MaxInputLength]], but far below
+   * the exponential blow-up of catastrophic backtracking.
+   */
+  private val DefaultMaxMatchSteps = 10000000L
 
   private val DangerousPatternShapes = List(
     "\\(\\([^)]*[+*][^)]*\\)[+*][^)]*\\)[+*]",
@@ -18,38 +42,33 @@ object WorkspaceRegexSafetyManager {
     "\\([^)]*\\|[^)]*\\)[+*]"
   ).map(_.r)
 
+  /** Raised when an operation exceeds its step budget (likely catastrophic backtracking). */
+  final class RegexComplexityException(message: String) extends RuntimeException(message)
+
   def safeCompile(pattern: String, flags: Int = 0): Either[String, Pattern] =
     for {
       _ <- validatePattern(pattern)
-      p <- compileSafely(pattern, flags, DefaultCompilationTimeoutMs)
+      p <- compileSafely(pattern, flags)
     } yield p
 
-  def safeFind(pattern: Pattern, input: String): Either[String, Boolean] =
-    withInputValidation(input).flatMap(_ =>
-      try
-        Right(pattern.matcher(input).find())
-      catch {
-        case NonFatal(e) => Left(s"Regex matching failed: ${e.getMessage}")
-      }
-    )
+  def safeFind(pattern: Pattern, input: String, maxSteps: Long = DefaultMaxMatchSteps): Either[String, Boolean] =
+    withInputValidation(input).flatMap(_ => guard(boundedMatcher(pattern, input, maxSteps).find()))
 
-  def safeReplaceAll(pattern: Pattern, input: String, replacement: String): Either[String, String] =
-    withInputValidation(input).flatMap(_ =>
-      try
-        Right(pattern.matcher(input).replaceAll(replacement))
-      catch {
-        case NonFatal(e) => Left(s"Regex replacement failed: ${e.getMessage}")
-      }
-    )
+  def safeReplaceAll(
+    pattern: Pattern,
+    input: String,
+    replacement: String,
+    maxSteps: Long = DefaultMaxMatchSteps
+  ): Either[String, String] =
+    withInputValidation(input).flatMap(_ => guard(boundedMatcher(pattern, input, maxSteps).replaceAll(replacement)))
 
-  def safeReplaceFirst(pattern: Pattern, input: String, replacement: String): Either[String, String] =
-    withInputValidation(input).flatMap(_ =>
-      try
-        Right(pattern.matcher(input).replaceFirst(replacement))
-      catch {
-        case NonFatal(e) => Left(s"Regex replacement failed: ${e.getMessage}")
-      }
-    )
+  def safeReplaceFirst(
+    pattern: Pattern,
+    input: String,
+    replacement: String,
+    maxSteps: Long = DefaultMaxMatchSteps
+  ): Either[String, String] =
+    withInputValidation(input).flatMap(_ => guard(boundedMatcher(pattern, input, maxSteps).replaceFirst(replacement)))
 
   def compileLiteral(pattern: String, flags: Int = 0): Pattern =
     Pattern.compile(Pattern.quote(pattern), flags)
@@ -93,13 +112,19 @@ object WorkspaceRegexSafetyManager {
       Left(s"Input too large: ${input.length} > $MaxInputLength")
     else Right(())
 
-  private def compileSafely(pattern: String, flags: Int, timeoutMs: Long): Either[String, Pattern] =
-    try {
-      val _ = timeoutMs // preserved for API stability
-      Right(Pattern.compile(pattern, flags))
-    } catch {
-      case e: PatternSyntaxException => Left(s"Invalid regex syntax: ${e.getMessage}")
-      case NonFatal(e)               => Left(s"Regex compilation failed: ${e.getMessage}")
+  private def compileSafely(pattern: String, flags: Int): Either[String, Pattern] =
+    Try(Pattern.compile(pattern, flags)).toEither.left.map {
+      case e: PatternSyntaxException => s"Invalid regex syntax: ${e.getMessage}"
+      case e                         => s"Regex compilation failed: ${e.getMessage}"
+    }
+
+  private def boundedMatcher(pattern: Pattern, input: String, maxSteps: Long): Matcher =
+    pattern.matcher(new StepBoundedCharSequence(input, maxSteps))
+
+  private def guard[A](op: => A): Either[String, A] =
+    Try(op).toEither.left.map {
+      case _: RegexComplexityException => "Regex operation aborted: exceeded complexity budget (possible ReDoS)"
+      case e                           => s"Regex operation failed: ${e.getMessage}"
     }
 
   private def hasOverlappingAlternationWithQuantifier(pattern: String): Boolean = {
@@ -111,5 +136,33 @@ object WorkspaceRegexSafetyManager {
         case _           => false
       }
     }
+  }
+
+  /**
+   * A [[CharSequence]] that counts character accesses and aborts once the step
+   * budget is exhausted, giving the backtracking engine a hard ceiling. The
+   * counter is shared with any subsequences the engine derives.
+   */
+  final private class StepBoundedCharSequence(
+    inner: CharSequence,
+    maxSteps: Long,
+    counter: Array[Long]
+  ) extends CharSequence {
+
+    def this(inner: CharSequence, maxSteps: Long) = this(inner, maxSteps, Array(0L))
+
+    override def length(): Int = inner.length()
+
+    override def charAt(index: Int): Char = {
+      counter(0) += 1L
+      if (counter(0) > maxSteps)
+        throw new RegexComplexityException(s"Regex operation exceeded step budget of $maxSteps")
+      inner.charAt(index)
+    }
+
+    override def subSequence(start: Int, end: Int): CharSequence =
+      new StepBoundedCharSequence(inner.subSequence(start, end), maxSteps, counter)
+
+    override def toString: String = inner.toString
   }
 }

--- a/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceRegexSafetyManager.scala
+++ b/modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceRegexSafetyManager.scala
@@ -1,0 +1,73 @@
+package org.llm4s.runner
+
+import java.util.concurrent.{ Executors, TimeUnit, TimeoutException }
+import java.util.regex.{ Matcher, Pattern, PatternSyntaxException }
+
+/**
+ * Workspace-runner local regex safety helper used for user-supplied patterns.
+ */
+object WorkspaceRegexSafetyManager {
+
+  private val MaxPatternLength            = 1000
+  private val DefaultCompilationTimeoutMs = 1000L
+
+  private val DangerousPatternShapes = List(
+    "\\(\\([^)]*[+*][^)]*\\)[+*][^)]*\\)[+*]",
+    "\\([^)]*[+*][^)]*\\)[+*]",
+    "\\([^)]*\\|[^)]*\\)\\*"
+  ).map(_.r)
+
+  def safeCompile(pattern: String, flags: Int = 0): Either[String, Pattern] =
+    for {
+      _ <- validatePattern(pattern)
+      p <- compileWithTimeout(pattern, flags, DefaultCompilationTimeoutMs)
+    } yield p
+
+  def compileLiteral(pattern: String, flags: Int = 0): Pattern =
+    Pattern.compile(Pattern.quote(pattern), flags)
+
+  def replaceAllLiteral(
+    input: String,
+    literalPattern: String,
+    replacement: String,
+    caseInsensitive: Boolean
+  ): String = {
+    val flags   = if (caseInsensitive) Pattern.CASE_INSENSITIVE else 0
+    val pattern = compileLiteral(literalPattern, flags)
+    pattern.matcher(input).replaceAll(Matcher.quoteReplacement(replacement))
+  }
+
+  def replaceFirstLiteral(
+    input: String,
+    literalPattern: String,
+    replacement: String,
+    caseInsensitive: Boolean
+  ): String = {
+    val flags   = if (caseInsensitive) Pattern.CASE_INSENSITIVE else 0
+    val pattern = compileLiteral(literalPattern, flags)
+    pattern.matcher(input).replaceFirst(Matcher.quoteReplacement(replacement))
+  }
+
+  private def validatePattern(pattern: String): Either[String, Unit] =
+    if (pattern == null) Left("Pattern cannot be null")
+    else if (pattern.trim.isEmpty) Left("Pattern cannot be empty")
+    else if (pattern.length > MaxPatternLength)
+      Left(s"Pattern too long: ${pattern.length} > $MaxPatternLength")
+    else if (DangerousPatternShapes.exists(_.findFirstIn(pattern).isDefined))
+      Left("Regex pattern contains nested quantifiers/overlap and may cause ReDoS")
+    else Right(())
+
+  private def compileWithTimeout(pattern: String, flags: Int, timeoutMs: Long): Either[String, Pattern] = {
+    val executor = Executors.newSingleThreadExecutor()
+    try {
+      val future = executor.submit(new java.util.concurrent.Callable[Pattern] {
+        override def call(): Pattern = Pattern.compile(pattern, flags)
+      })
+      Right(future.get(timeoutMs, TimeUnit.MILLISECONDS))
+    } catch {
+      case _: TimeoutException       => Left(s"Regex compilation timeout after ${timeoutMs}ms")
+      case e: PatternSyntaxException => Left(s"Invalid regex syntax: ${e.getMessage}")
+      case e: Exception              => Left(s"Regex compilation failed: ${e.getMessage}")
+    } finally executor.shutdownNow()
+  }
+}

--- a/modules/workspace/workspaceRunner/src/test/scala/org/llm4s/runner/WorkspaceAgentInterfaceImplTest.scala
+++ b/modules/workspace/workspaceRunner/src/test/scala/org/llm4s/runner/WorkspaceAgentInterfaceImplTest.scala
@@ -150,7 +150,9 @@ class WorkspaceAgentInterfaceImplTest extends AnyFlatSpec with Matchers with org
     response.matches.exists(_.path == "redos-alt-search.txt") shouldBe true
   }
 
-  it should "complete malicious regex search within bounded time" in {
+  it should "complete blocklisted regex search within bounded time" in {
+    // ((a+)+)+b is rejected by the shape blocklist, so the search degrades to a
+    // literal substring match and never runs the dangerous regex.
     interface.writeFile("redos-time.txt", "a" * 28 + "X")
 
     val eventual = Future {
@@ -164,6 +166,41 @@ class WorkspaceAgentInterfaceImplTest extends AnyFlatSpec with Matchers with org
 
     val response = Await.result(eventual, 2.seconds)
     response.matches shouldBe empty
+  }
+
+  it should "bound regex search for catastrophic patterns the blocklist misses" in {
+    // (.*a){25}b is genuinely catastrophic in the JDK engine but slips past the
+    // shape blocklist (the group is quantified with {25}, not +/*), so it
+    // compiles as a real regex. The per-line step budget must abort the
+    // catastrophic match rather than hang. Without the bound this search never
+    // returns and the Await below would time out.
+    interface.writeFile("redos-brace-search.txt", "a" * 40)
+
+    val eventual = Future {
+      interface.searchFiles(
+        paths = List("redos-brace-search.txt"),
+        query = "(.*a){25}b",
+        searchType = "regex",
+        recursive = Some(false)
+      )
+    }
+
+    val response = Await.result(eventual, 10.seconds)
+    response.matches shouldBe empty
+  }
+
+  it should "bound regexReplace for catastrophic patterns the blocklist misses" in {
+    interface.writeFile("redos-brace-replace.txt", "a" * 40)
+
+    val op = RegexReplaceOperation(
+      pattern = "(.*a){25}b",
+      replacement = "SAFE",
+      flags = Some("g")
+    )
+
+    val eventual = Future(interface.modifyFile("redos-brace-replace.txt", List(op)))
+    val result   = Await.result(eventual, 10.seconds)
+    result.success shouldBe true
   }
 
   it should "fallback to literal replacement for unsafe regexReplace operations" in {

--- a/modules/workspace/workspaceRunner/src/test/scala/org/llm4s/runner/WorkspaceAgentInterfaceImplTest.scala
+++ b/modules/workspace/workspaceRunner/src/test/scala/org/llm4s/runner/WorkspaceAgentInterfaceImplTest.scala
@@ -7,6 +7,9 @@ import org.scalatest.matchers.should.Matchers
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
@@ -119,6 +122,49 @@ class WorkspaceAgentInterfaceImplTest extends AnyFlatSpec with Matchers with org
     response.matches.exists(_.path == "test2.txt") shouldBe true
     // truncated should be false when number of hits is small
     response.isTruncated shouldBe false
+  }
+
+  it should "fallback to literal matching for unsafe regex in searchFiles" in {
+    interface.writeFile("redos-search.txt", "payload ((a+)+)+b marker")
+
+    val response = interface.searchFiles(
+      paths = List("."),
+      query = "((a+)+)+b",
+      searchType = "regex",
+      recursive = Some(true)
+    )
+
+    response.matches.exists(_.path == "redos-search.txt") shouldBe true
+  }
+
+  it should "complete malicious regex search within bounded time" in {
+    interface.writeFile("redos-time.txt", "a" * 28 + "X")
+
+    val eventual = Future {
+      interface.searchFiles(
+        paths = List("redos-time.txt"),
+        query = "((a+)+)+b",
+        searchType = "regex",
+        recursive = Some(false)
+      )
+    }
+
+    val response = Await.result(eventual, 2.seconds)
+    response.matches shouldBe empty
+  }
+
+  it should "fallback to literal replacement for unsafe regexReplace operations" in {
+    interface.writeFile("redos-replace.txt", "prefix ((a+)+)+b suffix ((a+)+)+b")
+
+    val op = RegexReplaceOperation(
+      pattern = "((a+)+)+b",
+      replacement = "SAFE",
+      flags = Some("g")
+    )
+
+    interface.modifyFile("redos-replace.txt", List(op)).success shouldBe true
+    val content = interface.readFile("redos-replace.txt").content
+    content should include("prefix SAFE suffix SAFE")
   }
 
   it should "set isTruncated when result cap is reached" in {

--- a/modules/workspace/workspaceRunner/src/test/scala/org/llm4s/runner/WorkspaceAgentInterfaceImplTest.scala
+++ b/modules/workspace/workspaceRunner/src/test/scala/org/llm4s/runner/WorkspaceAgentInterfaceImplTest.scala
@@ -137,6 +137,19 @@ class WorkspaceAgentInterfaceImplTest extends AnyFlatSpec with Matchers with org
     response.matches.exists(_.path == "redos-search.txt") shouldBe true
   }
 
+  it should "fallback to literal matching for overlapping alternation regex" in {
+    interface.writeFile("redos-alt-search.txt", "token (a|aa)+X token")
+
+    val response = interface.searchFiles(
+      paths = List("."),
+      query = "(a|aa)+X",
+      searchType = "regex",
+      recursive = Some(true)
+    )
+
+    response.matches.exists(_.path == "redos-alt-search.txt") shouldBe true
+  }
+
   it should "complete malicious regex search within bounded time" in {
     interface.writeFile("redos-time.txt", "a" * 28 + "X")
 


### PR DESCRIPTION
What does this PR do?
This PR fixes a ReDoS (Regular Expression Denial of Service) vulnerability in LLM4S by hardening regex handling paths that accept untrusted patterns.

Why this change is needed
User-supplied regex patterns could trigger catastrophic backtracking and cause CPU spikes or service stalls. This patch adds bounded regex processing and safe fallback behavior to prevent denial-of-service scenarios.

What changed
Added core regex safety manager:

modules/core/src/main/scala/org/llm4s/security/RegexSafetyManager.scala
validates patterns (null/empty/length)
detects dangerous nested quantifier shapes
applies timeout-bounded regex compile/match helpers
provides literal-safe replacement helpers
Added workspace regex safety manager:

modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceRegexSafetyManager.scala
Hardened workspace regex operations:
modules/workspace/workspaceRunner/src/main/scala/org/llm4s/runner/WorkspaceAgentInterfaceImpl.scala
searchFiles regex mode now safely compiles and falls back to literal matching for unsafe/invalid patterns
regex replace operation now safely compiles and falls back to literal replacement semantics when unsafe/invalid
Hardened guardrail and crawler regex usage:

modules/core/src/main/scala/org/llm4s/agent/guardrails/builtin/RegexValidator.scala
modules/core/src/main/scala/org/llm4s/rag/loader/internal/GlobPatternMatcher.scala
Added regression tests:

modules/core/src/test/scala/org/llm4s/security/ReDoSVulnerabilitySpec.scala
modules/core/src/test/scala/org/llm4s/agent/guardrails/builtin/SimpleValidatorSpec.scala
modules/core/src/test/scala/org/llm4s/rag/loader/internal/GlobPatternMatcherSpec.scala
modules/workspace/workspaceRunner/src/test/scala/org/llm4s/runner/WorkspaceAgentInterfaceImplTest.scala
Related issue
Fixes #891

How was this tested?
Executed:
sbt scalafmtAll
sbt workspaceRunner/testOnly org.llm4s.runner.WorkspaceAgentInterfaceImplTest
sbt core/testOnly org.llm4s.agent.guardrails.builtin.SimpleValidatorSpec org.llm4s.rag.loader.internal.GlobPatternMatcherSpec org.llm4s.security.ReDoSVulnerabilitySpec
sbt covReport
Results:

Targeted regression tests passed.
Full test run (via coverage alias) passed.
Coverage command completed but reported:
No coverage data, skipping reports
This appears to be environment/config behavior in current setup.
Checklist
 I have read the [Contributing Guide](vscode-file://vscode-app/c:/Users/ACER/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
 PR is small and focused — one change, one reason
 sbt scalafmtAll — code is formatted
 sbt test — tests pass on Scala 3
 New code includes tests
 No unrelated changes included (branched from main, not from another PR)
 Commit messages explain the "why"