### PR TITLE
feat(samples): add modular RAG example with guide and tests

### DIFF
--- a/docs/guide/modular-rag-example.md
+++ b/docs/guide/modular-rag-example.md
@@ -1,0 +1,57 @@
+---
+layout: page
+title: Modular RAG Example
+parent: User Guide
+---
+
+# Modular RAG Example
+
+This guide introduces a practical, modular Retrieval-Augmented Generation (RAG) example for LLM4S.
+
+The sample lives in:
+
+- `modules/samples/src/main/scala/org/llm4s/samples/rag/modular/ModularRAGExample.scala`
+- `modules/samples/src/main/scala/org/llm4s/samples/rag/modular/RAGModules.scala`
+
+## Architecture
+
+The example intentionally separates the pipeline into modules:
+
+1. `IngestionModule`: document ingestion from filesystem (`.txt`, `.md`, `.pdf`, `.docx`) or direct text.
+2. `RetrievalModule`: similarity retrieval (`topK`) from indexed chunks.
+3. `GenerationModule`: grounded answer generation from retrieved contexts.
+
+This keeps cross-cutting concerns small and makes each stage easy to evolve or test independently.
+
+## Run
+
+### 1) Retrieval + generation (if LLM provider configured)
+
+```bash
+sbt "samples/runMain org.llm4s.samples.rag.modular.ModularRAGExample"
+```
+
+If no document path is passed, the sample ingests a small built-in corpus.
+
+### 2) Use your own document directory
+
+```bash
+sbt "samples/runMain org.llm4s.samples.rag.modular.ModularRAGExample ./docs \"What are the key reliability patterns?\""
+```
+
+The ingestion stage supports file extraction through the core RAG API, including PDF.
+
+## Configuration
+
+The sample resolves embedding and LLM settings from `Llm4sConfig`:
+
+- Embeddings are required.
+- LLM is optional. If LLM config is missing, the sample still runs ingestion + retrieval and skips answer generation.
+
+## Why this pattern
+
+This modular RAG layout is useful for real applications because you can:
+
+- swap retrieval strategy without changing ingestion/generation wiring,
+- test retrieval quality independently,
+- run retrieval-only workflows when generation is disabled or unavailable.

--- a/modules/samples/src/main/resources/rag-module/llm4s-overview.txt
+++ b/modules/samples/src/main/resources/rag-module/llm4s-overview.txt
@@ -1,0 +1,3 @@
+LLM4S is a Scala toolkit for building production-grade language model applications.
+It provides typed APIs for LLM calls, embeddings, tools, agents, and observability.
+RAG pipelines in LLM4S use chunking, vector search, and optional reranking.

--- a/modules/samples/src/main/resources/rag-module/reliability-notes.md
+++ b/modules/samples/src/main/resources/rag-module/reliability-notes.md
@@ -1,0 +1,11 @@
+# Reliability Notes
+
+Retrieval-Augmented Generation (RAG) reduces hallucination risk by retrieving relevant context at query time.
+
+A practical modular pipeline includes:
+
+1. Ingestion module: Extract and chunk input documents (TXT, MD, PDF, DOCX).
+2. Retrieval module: Embed query and retrieve top-k chunks by semantic relevance.
+3. Generation module: Build grounded prompt from retrieved chunks and ask the LLM to answer.
+
+This decomposition keeps responsibilities clear and makes each stage independently testable.

--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/modular/ModularRAGExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/modular/ModularRAGExample.scala
@@ -1,0 +1,148 @@
+package org.llm4s.samples.rag.modular
+
+import org.llm4s.chunking.ChunkerFactory
+import org.llm4s.config.Llm4sConfig
+import org.llm4s.error.ConfigurationError
+import org.llm4s.llmconnect.{ LLMClient, LLMConnect }
+import org.llm4s.rag.{ RAG, RAGSearchResult }
+import org.llm4s.rag.RAG.RAGConfigOps
+import org.llm4s.types.Result
+import org.slf4j.LoggerFactory
+
+import java.io.File
+
+/**
+ * Modular RAG Example
+ *
+ * Demonstrates a practical RAG architecture split into independent modules:
+ * 1) IngestionModule
+ * 2) RetrievalModule
+ * 3) GenerationModule
+ *
+ * Usage:
+ *   sbt "samples/runMain org.llm4s.samples.rag.modular.ModularRAGExample"
+ *
+ *   # Use your own directory (supports .txt/.md/.pdf/.docx via RAG.ingest)
+ *   sbt "samples/runMain org.llm4s.samples.rag.modular.ModularRAGExample ./docs \"What does this system do?\""
+ */
+object ModularRAGExample extends App {
+  private val logger        = LoggerFactory.getLogger(getClass)
+  private val defaultTopK   = 4
+  private val defaultPrompt = "How does this RAG pipeline reduce hallucinations?"
+
+  private val docsPathArg = args.headOption
+  private val queryArg    = args.lift(1).getOrElse(defaultPrompt)
+
+  val outcome = buildModules().flatMap { case (rag, ingestion, retrieval, generation) =>
+    try runDemo(ingestion, retrieval, generation, docsPathArg, queryArg)
+    finally rag.close()
+  }
+
+  outcome match {
+    case Right(_) =>
+      logger.info("Modular RAG example finished successfully.")
+    case Left(err) =>
+      logger.error("Modular RAG example failed: {}", err.formatted)
+      System.exit(1)
+  }
+
+  private def runDemo(
+    ingestion: IngestionModule,
+    retrieval: RetrievalModule,
+    generation: Option[GenerationModule],
+    docsPath: Option[String],
+    question: String
+  ): Result[Unit] =
+    for {
+      chunksIngested <- ingestKnowledge(ingestion, docsPath)
+      _ = logger.info("Ingested {} chunks into the RAG index.", chunksIngested)
+      retrieved <- retrieval.retrieve(question, defaultTopK)
+      _ = printRetrievedContexts(retrieved)
+      _ <- generation match {
+        case Some(generationModule) =>
+          generationModule.answer(question, defaultTopK).map { answer =>
+            logger.info("Grounded answer:\n{}", answer.answer)
+          }
+        case None =>
+          logger.info("No LLM provider configured. Retrieval succeeded; answer generation skipped.")
+          Right(())
+      }
+    } yield ()
+
+  private[modular] def ingestKnowledge(ingestion: IngestionModule, docsPath: Option[String]): Result[Int] =
+    docsPath match {
+      case Some(path) if new File(path).exists() =>
+        logger.info("Ingesting documents from path: {}", path)
+        ingestion.ingestPath(path, metadata = Map("sourceType" -> "filesystem"))
+      case Some(path) =>
+        Left(ConfigurationError(s"Document path does not exist: $path"))
+      case None =>
+        logger.info("No path provided; ingesting bundled sample corpus.")
+        ModularRAGSupport.seedCorpus(ingestion)
+    }
+
+  private def printRetrievedContexts(contexts: Seq[RAGSearchResult]): Unit =
+    if (contexts.isEmpty) {
+      logger.info("No contexts were retrieved for the query.")
+      ()
+    } else {
+      logger.info("Retrieved {} context chunks:", contexts.size)
+      contexts.zipWithIndex.foreach { case (ctx, index) =>
+        val source = ctx.metadata.getOrElse("source", "unknown")
+        logger.info(
+          "[{}] score={} source={} text={}...",
+          Int.box(index + 1),
+          Double.box(ctx.score),
+          source,
+          ctx.content.take(100)
+        )
+      }
+    }
+
+  private def buildModules(): Result[(RAG, IngestionModule, RetrievalModule, Option[GenerationModule])] = {
+    val maybeLlm = loadOptionalLlmClient()
+
+    for {
+      providerTuple <- Llm4sConfig.embeddings()
+      (providerName, embeddingCfg) = providerTuple
+      embeddingProvider <- ModularRAGSupport.toEmbeddingProvider(providerName)
+      rag <- {
+        val base = RAG
+          .builder()
+          .withEmbeddings(embeddingProvider, embeddingCfg.model)
+          .withChunking(ChunkerFactory.Strategy.Sentence, 800, 150)
+          .withTopK(defaultTopK)
+          .inMemory
+
+        val config = maybeLlm match {
+          case Some(client) => base.withLLM(client)
+          case None         => base
+        }
+
+        config.build(requestedProvider =>
+          ModularRAGSupport.resolveEmbeddingProviderConfig(
+            requestedProvider,
+            providerName,
+            embeddingCfg
+          )
+        )
+      }
+    } yield {
+      val ingestion  = new DefaultIngestionModule(rag)
+      val retrieval  = new DefaultRetrievalModule(rag)
+      val generation = maybeLlm.map(_ => new DefaultGenerationModule(rag))
+      (rag, ingestion, retrieval, generation)
+    }
+  }
+
+  private def loadOptionalLlmClient(): Option[LLMClient] =
+    Llm4sConfig.provider().flatMap(LLMConnect.getClient) match {
+      case Right(client) =>
+        logger.info("LLM provider detected; generation module will run.")
+        Some(client)
+      case Left(_) =>
+        logger.info("LLM provider not configured; running ingestion + retrieval only.")
+        None
+    }
+
+}

--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/modular/ModularRAGSupport.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/modular/ModularRAGSupport.scala
@@ -1,0 +1,60 @@
+package org.llm4s.samples.rag.modular
+
+import org.llm4s.error.ConfigurationError
+import org.llm4s.llmconnect.config.EmbeddingProviderConfig
+import org.llm4s.rag.EmbeddingProvider
+import org.llm4s.types.Result
+
+object ModularRAGSupport {
+
+  def toEmbeddingProvider(providerName: String): Result[EmbeddingProvider] =
+    EmbeddingProvider
+      .fromString(providerName)
+      .toRight(
+        ConfigurationError(
+          s"Unsupported embedding provider '$providerName'. Supported: ${EmbeddingProvider.values.map(_.name).mkString(", ")}"
+        )
+      )
+
+  def resolveEmbeddingProviderConfig(
+    requestedProvider: String,
+    configuredProvider: String,
+    embeddingCfg: EmbeddingProviderConfig
+  ): Result[EmbeddingProviderConfig] =
+    if (requestedProvider.equalsIgnoreCase(configuredProvider)) {
+      Right(embeddingCfg)
+    } else {
+      Left(
+        ConfigurationError(
+          s"RAG requested embedding provider '$requestedProvider', but sample is configured for '$configuredProvider'."
+        )
+      )
+    }
+
+  def seedCorpus(ingestion: IngestionModule): Result[Int] = {
+    val docs = Seq(
+      (
+        "rag-intro",
+        "Retrieval-Augmented Generation combines retrieval with generation to ground answers in trusted context.",
+        Map("source" -> "seed/rag-intro.txt")
+      ),
+      (
+        "llm4s-reliability",
+        "In production, RAG improves reliability by forcing answers to reference retrieved passages instead of model priors.",
+        Map("source" -> "seed/llm4s-reliability.txt")
+      ),
+      (
+        "architecture",
+        "A modular RAG architecture usually separates ingestion, retrieval, and generation so each stage can evolve independently.",
+        Map("source" -> "seed/architecture.txt")
+      )
+    )
+
+    docs.foldLeft[Result[Int]](Right(0)) { case (acc, (docId, content, metadata)) =>
+      for {
+        total <- acc
+        added <- ingestion.ingestText(docId, content, metadata)
+      } yield total + added
+    }
+  }
+}

--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/modular/RAGModules.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/modular/RAGModules.scala
@@ -1,0 +1,44 @@
+package org.llm4s.samples.rag.modular
+
+import org.llm4s.rag.{ RAG, RAGAnswerResult, RAGSearchResult }
+import org.llm4s.types.Result
+
+trait IngestionModule {
+  def ingestPath(path: String, metadata: Map[String, String] = Map.empty): Result[Int]
+
+  def ingestText(
+    documentId: String,
+    content: String,
+    metadata: Map[String, String] = Map.empty
+  ): Result[Int]
+}
+
+final class DefaultIngestionModule(rag: RAG) extends IngestionModule {
+  override def ingestPath(path: String, metadata: Map[String, String]): Result[Int] =
+    rag.ingest(path, metadata)
+
+  override def ingestText(
+    documentId: String,
+    content: String,
+    metadata: Map[String, String]
+  ): Result[Int] =
+    rag.ingestText(content = content, documentId = documentId, metadata = metadata)
+}
+
+trait RetrievalModule {
+  def retrieve(query: String, topK: Int): Result[Seq[RAGSearchResult]]
+}
+
+final class DefaultRetrievalModule(rag: RAG) extends RetrievalModule {
+  override def retrieve(query: String, topK: Int): Result[Seq[RAGSearchResult]] =
+    rag.query(query, topK = Some(topK))
+}
+
+trait GenerationModule {
+  def answer(question: String, topK: Int): Result[RAGAnswerResult]
+}
+
+final class DefaultGenerationModule(rag: RAG) extends GenerationModule {
+  override def answer(question: String, topK: Int): Result[RAGAnswerResult] =
+    rag.queryWithAnswer(question, topK = Some(topK))
+}

--- a/modules/samples/src/test/scala/org/llm4s/samples/rag/modular/ModularRAGExampleSpec.scala
+++ b/modules/samples/src/test/scala/org/llm4s/samples/rag/modular/ModularRAGExampleSpec.scala
@@ -1,0 +1,62 @@
+package org.llm4s.samples.rag.modular
+
+import org.llm4s.error.ConfigurationError
+import org.llm4s.llmconnect.config.EmbeddingProviderConfig
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class ModularRAGExampleSpec extends AnyFunSuite with Matchers {
+
+  test("toEmbeddingProvider should map supported providers and reject unknown ones") {
+    ModularRAGSupport.toEmbeddingProvider("openai").toOption.map(_.name) shouldBe Some("openai")
+    ModularRAGSupport.toEmbeddingProvider("voyage").toOption.map(_.name) shouldBe Some("voyage")
+    ModularRAGSupport.toEmbeddingProvider("ollama").toOption.map(_.name) shouldBe Some("ollama")
+
+    val unknown = ModularRAGSupport.toEmbeddingProvider("not-a-provider")
+    unknown.left.toOption.get shouldBe a[ConfigurationError]
+  }
+
+  test("resolveEmbeddingProviderConfig should only return config for matching provider") {
+    val config = EmbeddingProviderConfig(
+      baseUrl = "https://api.openai.com/v1",
+      model = "text-embedding-3-small",
+      apiKey = "test-key"
+    )
+
+    val matchResult =
+      ModularRAGSupport.resolveEmbeddingProviderConfig("openai", "openai", config)
+    matchResult shouldBe Right(config)
+
+    val mismatchResult =
+      ModularRAGSupport.resolveEmbeddingProviderConfig("voyage", "openai", config)
+    mismatchResult.left.toOption.get shouldBe a[ConfigurationError]
+  }
+
+  test("seedCorpus should ingest all seeded documents") {
+    final class RecordingIngestionModule extends IngestionModule {
+      var ingestedDocumentIds: Vector[String] = Vector.empty
+
+      override def ingestPath(path: String, metadata: Map[String, String]) =
+        Right(0)
+
+      override def ingestText(
+        documentId: String,
+        content: String,
+        metadata: Map[String, String]
+      ) = {
+        ingestedDocumentIds = ingestedDocumentIds :+ documentId
+        Right(1)
+      }
+    }
+
+    val ingestion = new RecordingIngestionModule
+    val result    = ModularRAGSupport.seedCorpus(ingestion)
+
+    result shouldBe Right(3)
+    ingestion.ingestedDocumentIds should contain theSameElementsInOrderAs Seq(
+      "rag-intro",
+      "llm4s-reliability",
+      "architecture"
+    )
+  }
+}

--- a/modules/samples/src/test/scala/org/llm4s/samples/rag/modular/ModularRAGExampleSpec.scala
+++ b/modules/samples/src/test/scala/org/llm4s/samples/rag/modular/ModularRAGExampleSpec.scala
@@ -53,10 +53,12 @@ class ModularRAGExampleSpec extends AnyFunSuite with Matchers {
     val result    = ModularRAGSupport.seedCorpus(ingestion)
 
     result shouldBe Right(3)
-    ingestion.ingestedDocumentIds should contain theSameElementsInOrderAs Seq(
-      "rag-intro",
-      "llm4s-reliability",
-      "architecture"
+    (ingestion.ingestedDocumentIds should contain).theSameElementsInOrderAs(
+      Seq(
+        "rag-intro",
+        "llm4s-reliability",
+        "architecture"
+      )
     )
   }
 }


### PR DESCRIPTION
## What does this PR do?
Introduces a practical, modular Retrieval-Augmented Generation (RAG) example for LLM4S.

This PR adds:
- a new modular sample package at `org.llm4s.samples.rag.modular`
  - `IngestionModule`, `RetrievalModule`, `GenerationModule`
  - runnable `ModularRAGExample`
  - helper support object for provider/config mapping
- sample corpus files under `modules/samples/src/main/resources/rag-module/`
- guide documentation: `docs/guide/modular-rag-example.md`
- tests for modular helper behavior:
  - provider mapping
  - provider config matching
  - seeded corpus ingestion flow

Why needed:
- gives contributors a real-world, end-to-end RAG architecture pattern
- demonstrates grounding flow clearly (ingest → retrieve → generate)
- keeps components independently replaceable/testable for practical applications

## Related issue
Fixes #649

## How was this tested?
- `sbt scalafmtAll`
- `sbt test`
- `sbt samples/scalafmt samples/test`

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt test` — tests pass on Scala 3
- [x] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"