### PR TITLE
Refactor AssistantAgent to use AgentContext in run-to-completion flow (Fixes #600)

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/assistant/AssistantAgent.scala
+++ b/modules/core/src/main/scala/org/llm4s/assistant/AssistantAgent.scala
@@ -1,6 +1,6 @@
 package org.llm4s.assistant
 
-import org.llm4s.agent.{ Agent, AgentState, AgentStatus }
+import org.llm4s.agent.{ Agent, AgentContext, AgentState, AgentStatus }
 import org.llm4s.llmconnect.LLMClient
 import org.llm4s.llmconnect.model._
 import org.llm4s.error.{ AssistantError, LLMError, ConfigurationError }
@@ -124,7 +124,7 @@ class AssistantAgent(
     logger.debug("Processing user query: {}", query.take(100))
     for {
       updatedState <- addUserMessage(query, state)
-      finalState <- runAgentToCompletion(updatedState).leftMap(llmError =>
+      finalState <- runAgentToCompletion(updatedState, AgentContext.Default).leftMap(llmError =>
         AssistantError.SessionError(
           s"Agent execution failed: ${llmError.message}",
           state.sessionId,
@@ -329,14 +329,17 @@ class AssistantAgent(
   /**
    * Runs the agent until completion or failure
    */
-  private[assistant] def runAgentToCompletion(state: SessionState): Either[LLMError, SessionState] =
+  private[assistant] def runAgentToCompletion(
+    state: SessionState,
+    context: AgentContext = AgentContext.Default
+  ): Either[LLMError, SessionState] =
     state.agentState match {
       case None => Left(ConfigurationError("No agent state to run"))
       case Some(agentState) =>
         def runSteps(currentState: AgentState): Either[org.llm4s.error.LLMError, AgentState] =
           currentState.status match {
             case AgentStatus.InProgress | AgentStatus.WaitingForTools =>
-              agent.runStep(currentState) match {
+              agent.runStep(currentState, context) match {
                 case Right(newState) => runSteps(newState)
                 case Left(error)     => Left(error)
               }

--- a/modules/core/src/test/scala/org/llm4s/assistant/AssistantAgentSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/assistant/AssistantAgentSpec.scala
@@ -2,7 +2,7 @@ package org.llm4s.assistant
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.llm4s.agent.{ AgentState, AgentStatus }
+import org.llm4s.agent.{ AgentContext, AgentState, AgentStatus }
 import org.llm4s.error.UnknownError
 import org.llm4s.llmconnect.LLMClient
 import org.llm4s.llmconnect.model._
@@ -202,6 +202,19 @@ class AssistantAgentSpec extends AnyFlatSpec with Matchers {
             }
           case Left(err) => fail(s"Expected Right but got: ${err.message}")
         }
+      case Left(err) => fail(s"Init failed: ${err.message}")
+    }
+  }
+
+  it should "support explicit AgentContext when running to completion" in {
+    val agent       = assistantAgent(mockClient("done with context"))
+    val emptyState  = emptySessionState()
+    val initialized = agent.addUserMessage("finish this", emptyState)
+
+    initialized match {
+      case Right(stateAfterInit) =>
+        val result = agent.runAgentToCompletion(stateAfterInit, AgentContext(debug = true))
+        result.isRight shouldBe true
       case Left(err) => fail(s"Init failed: ${err.message}")
     }
   }


### PR DESCRIPTION
## What does this PR do?
Introduces `AgentContext` propagation in `AssistantAgent` so cross-cutting agent execution settings (like tracing/debug/trace log path) are passed through the assistant run loop instead of relying on ad-hoc parameters. This aligns `AssistantAgent` with the new `AgentContext`-based API surface introduced for issue #600 and keeps future cross-cutting additions extensible.

## Related issue
Fixes #600

## How was this tested?
- `sbt scalafmtAll`
- `sbt test`
- Focused validation also run earlier:
  - `sbt "core/testOnly org.llm4s.assistant.AssistantAgentSpec"`

Added/updated test coverage:
- `AssistantAgentSpec` now includes:
  - `should support explicit AgentContext when running to completion`

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused - one change, one reason
- [x] `sbt scalafmtAll` - code is formatted
- [x] `sbt test` - tests pass on Scala 3
- [x] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"