### PR TITLE
fix(samples): repair build and clean up modular RAG example

### DIFF
--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/modular/ModularRAGExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/modular/ModularRAGExample.scala
@@ -119,24 +119,18 @@ object ModularRAGExample extends App {
           case None         => base
         }
 
-        config.build(requestedProvider =>
-          ModularRAGSupport.resolveEmbeddingProviderConfig(
-            requestedProvider,
-            providerName,
-            embeddingCfg
-          )
-        )
+        config.build(_ => Right(embeddingCfg))
       }
     } yield {
       val ingestion  = new DefaultIngestionModule(rag)
       val retrieval  = new DefaultRetrievalModule(rag)
-      val generation = maybeLlm.map(_ => new DefaultGenerationModule(rag))
+      val generation = Option.when(maybeLlm.isDefined)(new DefaultGenerationModule(rag))
       (rag, ingestion, retrieval, generation)
     }
   }
 
   private def loadOptionalLlmClient(): Option[LLMClient] =
-    Llm4sConfig.provider().flatMap(LLMConnect.getClient) match {
+    Llm4sConfig.defaultProvider().flatMap(LLMConnect.getClient) match {
       case Right(client) =>
         logger.info("LLM provider detected; generation module will run.")
         Some(client)

--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/modular/ModularRAGSupport.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/modular/ModularRAGSupport.scala
@@ -1,7 +1,6 @@
 package org.llm4s.samples.rag.modular
 
 import org.llm4s.error.ConfigurationError
-import org.llm4s.llmconnect.config.EmbeddingProviderConfig
 import org.llm4s.rag.EmbeddingProvider
 import org.llm4s.types.Result
 
@@ -15,21 +14,6 @@ object ModularRAGSupport {
           s"Unsupported embedding provider '$providerName'. Supported: ${EmbeddingProvider.values.map(_.name).mkString(", ")}"
         )
       )
-
-  def resolveEmbeddingProviderConfig(
-    requestedProvider: String,
-    configuredProvider: String,
-    embeddingCfg: EmbeddingProviderConfig
-  ): Result[EmbeddingProviderConfig] =
-    if (requestedProvider.equalsIgnoreCase(configuredProvider)) {
-      Right(embeddingCfg)
-    } else {
-      Left(
-        ConfigurationError(
-          s"RAG requested embedding provider '$requestedProvider', but sample is configured for '$configuredProvider'."
-        )
-      )
-    }
 
   def seedCorpus(ingestion: IngestionModule): Result[Int] = {
     val docs = Seq(

--- a/modules/samples/src/test/scala/org/llm4s/samples/rag/modular/ModularRAGExampleSpec.scala
+++ b/modules/samples/src/test/scala/org/llm4s/samples/rag/modular/ModularRAGExampleSpec.scala
@@ -1,11 +1,11 @@
 package org.llm4s.samples.rag.modular
 
 import org.llm4s.error.ConfigurationError
-import org.llm4s.llmconnect.config.EmbeddingProviderConfig
+import org.scalatest.EitherValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-class ModularRAGExampleSpec extends AnyFunSuite with Matchers {
+class ModularRAGExampleSpec extends AnyFunSuite with Matchers with EitherValues {
 
   test("toEmbeddingProvider should map supported providers and reject unknown ones") {
     ModularRAGSupport.toEmbeddingProvider("openai").toOption.map(_.name) shouldBe Some("openai")
@@ -13,23 +13,7 @@ class ModularRAGExampleSpec extends AnyFunSuite with Matchers {
     ModularRAGSupport.toEmbeddingProvider("ollama").toOption.map(_.name) shouldBe Some("ollama")
 
     val unknown = ModularRAGSupport.toEmbeddingProvider("not-a-provider")
-    unknown.left.toOption.get shouldBe a[ConfigurationError]
-  }
-
-  test("resolveEmbeddingProviderConfig should only return config for matching provider") {
-    val config = EmbeddingProviderConfig(
-      baseUrl = "https://api.openai.com/v1",
-      model = "text-embedding-3-small",
-      apiKey = "test-key"
-    )
-
-    val matchResult =
-      ModularRAGSupport.resolveEmbeddingProviderConfig("openai", "openai", config)
-    matchResult shouldBe Right(config)
-
-    val mismatchResult =
-      ModularRAGSupport.resolveEmbeddingProviderConfig("voyage", "openai", config)
-    mismatchResult.left.toOption.get shouldBe a[ConfigurationError]
+    unknown.left.value shouldBe a[ConfigurationError]
   }
 
   test("seedCorpus should ingest all seeded documents") {


### PR DESCRIPTION
## Summary

Follow-up to #901. Two things bundled here because they touch the same files:

1. **Build fix (priority).** PR #901 was authored before #903 renamed `Llm4sConfig.provider()` to `defaultProvider()`. After #901 merged, \`modules/samples\` no longer compiles against main. This swaps the call to match every other sample.
2. **Review cleanups** (from the #901 review):
   - Drop \`ModularRAGSupport.resolveEmbeddingProviderConfig\` and its test. The sample's own \`withEmbeddings(...)\` determines what provider RAG asks for, so the mismatch branch was unreachable and the test asserted against dead code. The resolver is now inlined as \`_ => Right(embeddingCfg)\`.
   - Replace \`maybeLlm.map(_ => new DefaultGenerationModule(rag))\` with \`Option.when(maybeLlm.isDefined)(...)\` so the discarded \`_\` no longer suggests the LLM client is being threaded through.
   - Mix in \`EitherValues\` so the remaining error-type assertion uses \`unknown.left.value\` instead of \`unknown.left.toOption.get\` (which fails with a useless message if the result flips to \`Right\`).

Net: -44/+6 lines.

## Test plan

- [x] \`sbt scalafmtAll\`
- [x] \`sbt samples/Test/compile\` — main compiles again
- [x] \`sbt "samples/testOnly org.llm4s.samples.rag.modular.ModularRAGExampleSpec"\` — 2/2 pass
- [x] Pre-commit hook (\`core/test\`) passed