### PR TITLE
fix(samples): thread ModelRegistryService through ModularRAGExample

### DIFF
--- a/modules/samples/src/main/scala/org/llm4s/samples/rag/modular/ModularRAGExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/rag/modular/ModularRAGExample.scala
@@ -4,6 +4,7 @@ import org.llm4s.chunking.ChunkerFactory
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.error.ConfigurationError
 import org.llm4s.llmconnect.{ LLMClient, LLMConnect }
+import org.llm4s.model.ModelRegistryService
 import org.llm4s.rag.{ RAG, RAGSearchResult }
 import org.llm4s.rag.RAG.RAGConfigOps
 import org.llm4s.types.Result
@@ -99,37 +100,39 @@ object ModularRAGExample extends App {
       }
     }
 
-  private def buildModules(): Result[(RAG, IngestionModule, RetrievalModule, Option[GenerationModule])] = {
-    val maybeLlm = loadOptionalLlmClient()
+  private def buildModules(): Result[(RAG, IngestionModule, RetrievalModule, Option[GenerationModule])] =
+    Llm4sConfig.modelRegistryService().flatMap { registryService =>
+      given ModelRegistryService = registryService
+      val maybeLlm               = loadOptionalLlmClient()
 
-    for {
-      providerTuple <- Llm4sConfig.embeddings()
-      (providerName, embeddingCfg) = providerTuple
-      embeddingProvider <- ModularRAGSupport.toEmbeddingProvider(providerName)
-      rag <- {
-        val base = RAG
-          .builder()
-          .withEmbeddings(embeddingProvider, embeddingCfg.model)
-          .withChunking(ChunkerFactory.Strategy.Sentence, 800, 150)
-          .withTopK(defaultTopK)
-          .inMemory
+      for {
+        providerTuple <- Llm4sConfig.embeddings()
+        (providerName, embeddingCfg) = providerTuple
+        embeddingProvider <- ModularRAGSupport.toEmbeddingProvider(providerName)
+        rag <- {
+          val base = RAG
+            .builder()
+            .withEmbeddings(embeddingProvider, embeddingCfg.model)
+            .withChunking(ChunkerFactory.Strategy.Sentence, 800, 150)
+            .withTopK(defaultTopK)
+            .inMemory
 
-        val config = maybeLlm match {
-          case Some(client) => base.withLLM(client)
-          case None         => base
+          val config = maybeLlm match {
+            case Some(client) => base.withLLM(client)
+            case None         => base
+          }
+
+          config.build(_ => Right(embeddingCfg))
         }
-
-        config.build(_ => Right(embeddingCfg))
+      } yield {
+        val ingestion  = new DefaultIngestionModule(rag)
+        val retrieval  = new DefaultRetrievalModule(rag)
+        val generation = Option.when(maybeLlm.isDefined)(new DefaultGenerationModule(rag))
+        (rag, ingestion, retrieval, generation)
       }
-    } yield {
-      val ingestion  = new DefaultIngestionModule(rag)
-      val retrieval  = new DefaultRetrievalModule(rag)
-      val generation = Option.when(maybeLlm.isDefined)(new DefaultGenerationModule(rag))
-      (rag, ingestion, retrieval, generation)
     }
-  }
 
-  private def loadOptionalLlmClient(): Option[LLMClient] =
+  private def loadOptionalLlmClient()(using ModelRegistryService): Option[LLMClient] =
     Llm4sConfig.defaultProvider().flatMap(LLMConnect.getClient) match {
       case Right(client) =>
         logger.info("LLM provider detected; generation module will run.")


### PR DESCRIPTION
## Summary

`main` is currently red. PR #907 (Add `ModelRegistryService` trait) made `ModelRegistryService` a required given for `LLMConnect.getClient` and `RAG.RAGConfigOps.build`, but `ModularRAGExample` (added in PR #901) was not updated, so `samples` fails to compile:

```
[error] -- [E172] Type Error: ModularRAGExample.scala:122:46
[error] No given instance of type org.llm4s.model.ModelRegistryService was found
[error] for parameter x$3 of method build in class RAGConfigOps

[error] -- [E172] Type Error: ModularRAGExample.scala:133:62
[error] No given instance of type org.llm4s.model.ModelRegistryService was found
[error] for parameter x$2 of method getClient in object LLMConnect
```

This PR resolves a `ModelRegistryService` once at the entry point via `Llm4sConfig.modelRegistryService()`, brings it into scope as a `given`, and propagates it through `loadOptionalLlmClient` — matching the pattern used elsewhere in the codebase after #907.

## Test plan
- [x] `sbt samples/compile` compiles cleanly locally
- [x] `sbt scalafmtCheck` passes
- [x] Pre-commit `core/test` suite passes
- [ ] CI Quick Checks (`sbt compile`) goes green
- [ ] CI All Tests Pass goes green