### PR TITLE
[enhancement] Implement STT provider feature wiring for Vosk and Whisper

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/speech/stt/SpeechToText.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/stt/SpeechToText.scala
@@ -110,11 +110,30 @@ object STTOptions {
   }
 
   /**
-   * Batch-pass already-constructed STTOptions through. Each element has
-   * already cleared the case-class `require` checks at construction time, so
-   * this is a passthrough kept for symmetry with [[validate]].
+   * Validate a batch of options using the same stricter checks as [[validate]].
    */
-  def validateBatch(options: Seq[STTOptions]): Result[Seq[STTOptions]] = Right(options)
+  def validateBatch(options: Seq[STTOptions]): Result[Seq[STTOptions]] = {
+    val errors = options.zipWithIndex.flatMap { case (option, index) =>
+      validate(
+        language = option.language,
+        prompt = option.prompt,
+        enableTimestamps = option.enableTimestamps,
+        diarization = option.diarization,
+        confidenceThreshold = option.confidenceThreshold
+      ).left.toOption.map(error => s"options[$index]: ${error.message}")
+    }
+
+    if (errors.isEmpty) {
+      Right(options)
+    } else {
+      Left(
+        STTError.InvalidInput(
+          errors.mkString("; "),
+          context = Map("optionCount" -> options.size.toString)
+        )
+      )
+    }
+  }
 }
 
 /**
@@ -252,7 +271,7 @@ final case class Transcription(
    * Get word count (based on timestamps if available, otherwise estimate from text)
    */
   def wordCount: Int =
-    if (timestamps.nonEmpty) timestamps.length else text.split("\\s+").length
+    if (timestamps.nonEmpty) timestamps.length else text.trim.split("\\s+").count(_.nonEmpty)
 
   /**
    * Get average confidence of all timestamped words
@@ -386,7 +405,6 @@ trait SpeechToText {
    * @param input Audio data to transcribe
    * @param options Configuration for transcription
    * @return Result containing Transcription or STTError
-   * @throws STTError if transcription fails (wrapped in Result)
    */
   def transcribe(input: AudioInput, options: STTOptions = STTOptions()): Result[Transcription]
 

--- a/modules/core/src/main/scala/org/llm4s/speech/stt/VoskSpeechToText.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/stt/VoskSpeechToText.scala
@@ -11,6 +11,7 @@ import java.nio.file.Files
 import org.llm4s.core.safety.Safety
 import org.llm4s.speech.processing.AudioPreprocessing
 import org.slf4j.LoggerFactory
+import ujson.Value
 
 /**
  * Vosk-based speech-to-text implementation.
@@ -111,41 +112,39 @@ final class VoskSpeechToText(
     bufferSize: Int,
     options: STTOptions
   ): Transcription = {
+    recognizer.setWords(options.enableTimestamps || options.confidenceThreshold > 0.0)
 
     val buffer   = new Array[Byte](bufferSize)
-    val segments = List.newBuilder[String]
+    val segments = List.newBuilder[VoskSpeechToText.ParsedSegment]
 
     var bytesRead = audio.read(buffer)
 
     while (bytesRead > 0) {
       if (recognizer.acceptWaveForm(buffer, bytesRead)) {
-        segments += extractText(recognizer.getResult)
+        segments += VoskSpeechToText.parseSegment(recognizer.getResult)
       }
       bytesRead = audio.read(buffer)
     }
 
-    segments += extractText(recognizer.getFinalResult)
+    segments += VoskSpeechToText.parseSegment(recognizer.getFinalResult)
 
-    val finalText = segments.result().mkString(" ").trim
+    val parsedSegments    = segments.result()
+    val parsedWords       = parsedSegments.flatMap(_.words)
+    val filteredWords     = VoskSpeechToText.applyConfidenceThreshold(parsedWords, options.confidenceThreshold)
+    val retainedWords     = if (filteredWords.nonEmpty) filteredWords else parsedWords
+    val filteredText      = VoskSpeechToText.renderWords(filteredWords)
+    val unfilteredText    = parsedSegments.map(_.text).mkString(" ").trim
+    val finalText         = if (filteredText.nonEmpty) filteredText else unfilteredText
+    val overallConfidence = VoskSpeechToText.averageConfidence(retainedWords)
 
     Transcription(
       text = finalText,
-      language = options.language.orElse(Some("en")),
-      confidence = None,
-      timestamps = Nil,
+      language = options.language,
+      confidence = overallConfidence,
+      timestamps = if (options.enableTimestamps) retainedWords.toList else Nil,
       meta = None
     )
   }
-
-  /**
-   * Extract "text" field from Vosk JSON response.
-   *  Vosk returns JSON with format: {"text": "transcribed words"}
-   */
-  private def extractText(json: String): String =
-    "\"text\"\\s*:\\s*\"([^\"]*)\"".r
-      .findFirstMatchIn(json)
-      .map(_.group(1))
-      .getOrElse("")
 
   /**
    * Prepare audio input by converting to raw bytes and standardizing format.
@@ -186,4 +185,60 @@ object VoskSpeechToText {
 
   /** Default buffer size for audio processing (bytes) */
   val DEFAULT_BUFFER_SIZE: Int = 4096
+
+  final private[stt] case class ParsedSegment(
+    text: String,
+    words: List[WordTimestamp]
+  )
+
+  private[stt] def parseSegment(json: String): ParsedSegment =
+    Try(ujson.read(json)).toOption match {
+      case Some(value) =>
+        ParsedSegment(
+          text = stringField(value, "text").getOrElse("").trim,
+          words = arrayField(value, "result").flatMap(parseWord).toList
+        )
+      case None => ParsedSegment("", Nil)
+    }
+
+  private[stt] def applyConfidenceThreshold(
+    words: Seq[WordTimestamp],
+    threshold: Double
+  ): Seq[WordTimestamp] =
+    if (threshold <= 0.0) words else words.filter(_.meetsConfidence(threshold))
+
+  private[stt] def renderWords(words: Seq[WordTimestamp]): String =
+    words.map(_.word.trim).filter(_.nonEmpty).mkString(" ").trim
+
+  private[stt] def averageConfidence(words: Seq[WordTimestamp]): Option[Double] = {
+    val confidences = words.flatMap(_.confidence)
+    if (confidences.nonEmpty) Some(confidences.sum / confidences.size) else None
+  }
+
+  private def parseWord(value: Value): Option[WordTimestamp] =
+    for {
+      word  <- stringField(value, "word").map(_.trim).filter(_.nonEmpty)
+      start <- doubleField(value, "start")
+      end   <- doubleField(value, "end")
+      timestamp <- WordTimestamp
+        .validate(
+          word = word,
+          startSec = start,
+          endSec = end,
+          confidence = doubleField(value, "conf").orElse(doubleField(value, "confidence"))
+        )
+        .toOption
+    } yield timestamp
+
+  private def field(value: Value, key: String): Option[Value] =
+    Try(value(key)).toOption
+
+  private def stringField(value: Value, key: String): Option[String] =
+    field(value, key).flatMap(v => Try(v.str).toOption)
+
+  private def doubleField(value: Value, key: String): Option[Double] =
+    field(value, key).flatMap(v => Try(v.num).toOption)
+
+  private def arrayField(value: Value, key: String): Seq[Value] =
+    field(value, key).flatMap(v => Try(v.arr.toSeq).toOption).getOrElse(Seq.empty)
 }

--- a/modules/core/src/main/scala/org/llm4s/speech/stt/VoskSpeechToText.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/stt/VoskSpeechToText.scala
@@ -112,7 +112,7 @@ final class VoskSpeechToText(
     bufferSize: Int,
     options: STTOptions
   ): Transcription = {
-    recognizer.setWords(options.enableTimestamps || options.confidenceThreshold > 0.0)
+    recognizer.setWords(VoskSpeechToText.shouldRequestWordMetadata(options))
 
     val buffer   = new Array[Byte](bufferSize)
     val segments = List.newBuilder[VoskSpeechToText.ParsedSegment]
@@ -128,22 +128,7 @@ final class VoskSpeechToText(
 
     segments += VoskSpeechToText.parseSegment(recognizer.getFinalResult)
 
-    val parsedSegments    = segments.result()
-    val parsedWords       = parsedSegments.flatMap(_.words)
-    val filteredWords     = VoskSpeechToText.applyConfidenceThreshold(parsedWords, options.confidenceThreshold)
-    val retainedWords     = if (filteredWords.nonEmpty) filteredWords else parsedWords
-    val filteredText      = VoskSpeechToText.renderWords(filteredWords)
-    val unfilteredText    = parsedSegments.map(_.text).mkString(" ").trim
-    val finalText         = if (filteredText.nonEmpty) filteredText else unfilteredText
-    val overallConfidence = VoskSpeechToText.averageConfidence(retainedWords)
-
-    Transcription(
-      text = finalText,
-      language = options.language,
-      confidence = overallConfidence,
-      timestamps = if (options.enableTimestamps) retainedWords.toList else Nil,
-      meta = None
-    )
+    VoskSpeechToText.buildTranscription(segments.result(), options)
   }
 
   /**
@@ -191,6 +176,9 @@ object VoskSpeechToText {
     words: List[WordTimestamp]
   )
 
+  private[stt] def shouldRequestWordMetadata(options: STTOptions): Boolean =
+    options.enableTimestamps || options.confidenceThreshold > 0.0
+
   private[stt] def parseSegment(json: String): ParsedSegment =
     Try(ujson.read(json)).toOption match {
       case Some(value) =>
@@ -213,6 +201,27 @@ object VoskSpeechToText {
   private[stt] def averageConfidence(words: Seq[WordTimestamp]): Option[Double] = {
     val confidences = words.flatMap(_.confidence)
     if (confidences.nonEmpty) Some(confidences.sum / confidences.size) else None
+  }
+
+  private[stt] def buildTranscription(
+    parsedSegments: Seq[ParsedSegment],
+    options: STTOptions
+  ): Transcription = {
+    val parsedWords       = parsedSegments.flatMap(_.words)
+    val filteredWords     = applyConfidenceThreshold(parsedWords, options.confidenceThreshold)
+    val retainedWords     = if (filteredWords.nonEmpty) filteredWords else parsedWords
+    val filteredText      = renderWords(filteredWords)
+    val unfilteredText    = parsedSegments.map(_.text).mkString(" ").trim
+    val finalText         = if (filteredText.nonEmpty) filteredText else unfilteredText
+    val overallConfidence = averageConfidence(retainedWords)
+
+    Transcription(
+      text = finalText,
+      language = options.language,
+      confidence = overallConfidence,
+      timestamps = if (options.enableTimestamps) retainedWords.toList else Nil,
+      meta = None
+    )
   }
 
   private def parseWord(value: Value): Option[WordTimestamp] =

--- a/modules/core/src/main/scala/org/llm4s/speech/stt/WhisperSpeechToText.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/stt/WhisperSpeechToText.scala
@@ -11,6 +11,7 @@ import java.io.IOException
 import org.llm4s.core.safety.Safety
 import scala.util.Try
 import scala.sys.process._
+import ujson.Value
 
 /**
  * Enhanced Whisper integration via CLI (whisper.cpp or openai-whisper).
@@ -31,8 +32,9 @@ final class WhisperSpeechToText(
 
     val result = for {
       wavAndTemp <- wavResult
-      args = buildWhisperArgs(wavAndTemp._1, options)
-      output <- Safety
+      effectiveOutputFormat = WhisperSpeechToText.effectiveOutputFormat(outputFormat, options)
+      args                  = buildWhisperArgs(wavAndTemp._1, options)
+      stdout <- Safety
         .fromTry(Try(args.!!))
         .left
         .map {
@@ -41,6 +43,7 @@ final class WhisperSpeechToText(
             ProcessingError.audioValidation("Whisper CLI execution failed with non-zero exit code")
           case _ => ProcessingError.audioValidation("Whisper CLI execution failed")
         }
+      output = WhisperSpeechToText.resolveCliOutput(wavAndTemp._1, effectiveOutputFormat, stdout)
       transcription <- {
         val processingTimeMs = System.currentTimeMillis() - startTime
         parseWhisperOutput(output, options).map(_.copy(processingTimeMs = Some(processingTimeMs)))
@@ -75,18 +78,19 @@ final class WhisperSpeechToText(
     }
 
   private def buildWhisperArgs(inputPath: Path, options: STTOptions): Seq[String] = {
+    val effectiveFormat = WhisperSpeechToText.effectiveOutputFormat(outputFormat, options)
     val baseArgs = command ++ Seq(
       inputPath.toString,
       "--model",
       model,
       "--output_format",
-      outputFormat
+      effectiveFormat
     )
 
     val optFlags = List(
       options.language.map(l => Seq("--language", l)),
       options.prompt.map(p => Seq("--initial_prompt", p)),
-      if (options.enableTimestamps) Some(Seq("--word_timestamps", "True")) else None
+      if (options.enableTimestamps) Some(Seq("--word-timestamps")) else None
     ).flatten
 
     baseArgs ++ optFlags.combineAll
@@ -96,31 +100,158 @@ final class WhisperSpeechToText(
     output: String,
     options: STTOptions
   ): Result[Transcription] = {
-    val text = output.trim
+    val parsed = WhisperSpeechToText.parseOutput(output, options)
+    val text   = parsed.text.trim
     if (text.isEmpty) {
       Left(ProcessingError.audioValidation("Transcription produced empty text"))
     } else {
-      val confidence = extractConfidence(output)
-      val timestamps = if (options.enableTimestamps) extractTimestamps(output) else Nil
       Right(
         Transcription(
           text = text,
-          language = options.language,
-          confidence = confidence,
-          timestamps = timestamps,
+          language = parsed.language.orElse(options.language),
+          confidence = parsed.confidence,
+          timestamps = if (options.enableTimestamps) parsed.timestamps else Nil,
           meta = None
         )
       )
     }
   }
+}
 
-  private def extractConfidence(output: String): Option[Double] =
-    // Whisper CLI may output confidence scores in some formats
-    // This is a placeholder - actual parsing depends on Whisper version
-    None
+object WhisperSpeechToText {
 
-  private def extractTimestamps(output: String): List[WordTimestamp] =
-    // Parse word-level timestamps if available
-    // Format varies by Whisper version and output format
-    Nil
+  final private[stt] case class ParsedOutput(
+    text: String,
+    language: Option[String],
+    confidence: Option[Double],
+    timestamps: List[WordTimestamp]
+  )
+
+  private[stt] def effectiveOutputFormat(
+    configuredOutputFormat: String,
+    options: STTOptions
+  ): String =
+    if (options.enableTimestamps) "json" else configuredOutputFormat
+
+  private[stt] def parseOutput(
+    output: String,
+    options: STTOptions
+  ): ParsedOutput =
+    Try(ujson.read(output)).toOption match {
+      case Some(json) =>
+        val parsedWords   = extractWordTimestamps(json)
+        val filteredWords = applyConfidenceThreshold(parsedWords, options.confidenceThreshold)
+        val retainedWords = if (filteredWords.nonEmpty) filteredWords else parsedWords
+        val text =
+          if (filteredWords.nonEmpty) renderWords(filteredWords)
+          else stringField(json, "text").getOrElse(renderWords(parsedWords)).trim
+
+        ParsedOutput(
+          text = text,
+          language = stringField(json, "language"),
+          confidence = extractConfidence(json, retainedWords),
+          timestamps = retainedWords
+        )
+      case None =>
+        ParsedOutput(
+          text = output.trim,
+          language = None,
+          confidence = None,
+          timestamps = Nil
+        )
+    }
+
+  private[stt] def resolveCliOutput(
+    inputPath: Path,
+    outputFormat: String,
+    stdout: String
+  ): String = {
+    val candidates = outputPathCandidates(inputPath, outputFormat)
+    candidates.collectFirst(Function.unlift(readIfExists)).getOrElse(stdout)
+  }
+
+  private def outputPathCandidates(inputPath: Path, outputFormat: String): List[Path] = {
+    val fileName = inputPath.getFileName.toString
+    val stem =
+      if (fileName.contains(".")) fileName.substring(0, fileName.lastIndexOf('.'))
+      else fileName
+
+    List(
+      inputPath.resolveSibling(s"$fileName.$outputFormat"),
+      inputPath.resolveSibling(s"$stem.$outputFormat")
+    ).distinct
+  }
+
+  private def readIfExists(path: Path): Option[String] =
+    if (Files.exists(path)) Try(Files.readString(path)).toOption else None
+
+  private def extractWordTimestamps(json: Value): List[WordTimestamp] = {
+    val rootWords = arrayField(json, "words").flatMap(parseWord)
+    if (rootWords.nonEmpty) {
+      rootWords.toList
+    } else {
+      arrayField(json, "segments").flatMap(segment => arrayField(segment, "words").flatMap(parseWord)).toList
+    }
+  }
+
+  private def parseWord(value: Value): Option[WordTimestamp] =
+    for {
+      word  <- stringField(value, "word").map(_.trim).filter(_.nonEmpty)
+      start <- extractTimestamp(value, List("start", "start_sec", "from"))
+      end   <- extractTimestamp(value, List("end", "end_sec", "to"))
+      timestamp <- WordTimestamp
+        .validate(
+          word = word,
+          startSec = start,
+          endSec = end,
+          confidence = extractConfidenceValue(value)
+        )
+        .toOption
+    } yield timestamp
+
+  private def extractTimestamp(value: Value, keys: List[String]): Option[Double] =
+    keys.iterator.map(doubleField(value, _)).collectFirst { case Some(v) => v }
+
+  private def extractConfidenceValue(value: Value): Option[Double] =
+    List("confidence", "probability", "prob", "score").iterator
+      .map(doubleField(value, _))
+      .collectFirst { case Some(v) => v }
+
+  private def extractConfidence(json: Value, words: Seq[WordTimestamp]): Option[Double] = {
+    val wordConfidence = averageConfidence(words)
+    wordConfidence.orElse {
+      val segmentConfidence = arrayField(json, "segments").flatMap { segment =>
+        List("confidence", "probability", "prob", "score").iterator
+          .map(doubleField(segment, _))
+          .collectFirst { case Some(v) => v }
+      }
+      if (segmentConfidence.nonEmpty) Some(segmentConfidence.sum / segmentConfidence.size) else None
+    }
+  }
+
+  private def applyConfidenceThreshold(
+    words: Seq[WordTimestamp],
+    threshold: Double
+  ): List[WordTimestamp] =
+    if (threshold <= 0.0) words.toList else words.filter(_.meetsConfidence(threshold)).toList
+
+  private def averageConfidence(words: Seq[WordTimestamp]): Option[Double] = {
+    val confidences = words.flatMap(_.confidence)
+    if (confidences.nonEmpty) Some(confidences.sum / confidences.size) else None
+  }
+
+  private def renderWords(words: Seq[WordTimestamp]): String =
+    words.map(_.word.trim).filter(_.nonEmpty).mkString(" ").trim
+
+  private def field(value: Value, key: String): Option[Value] =
+    Try(value(key)).toOption
+
+  private def stringField(value: Value, key: String): Option[String] =
+    field(value, key).flatMap(v => Try(v.str).toOption)
+
+  private def doubleField(value: Value, key: String): Option[Double] =
+    field(value, key).flatMap(v => Try(v.num).toOption)
+
+  private def arrayField(value: Value, key: String): Seq[Value] =
+    field(value, key).flatMap(v => Try(v.arr.toSeq).toOption).getOrElse(Seq.empty)
 }

--- a/modules/core/src/main/scala/org/llm4s/speech/stt/WhisperSpeechToText.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/stt/WhisperSpeechToText.scala
@@ -78,44 +78,14 @@ final class WhisperSpeechToText(
     }
 
   private def buildWhisperArgs(inputPath: Path, options: STTOptions): Seq[String] = {
-    val effectiveFormat = WhisperSpeechToText.effectiveOutputFormat(outputFormat, options)
-    val baseArgs = command ++ Seq(
-      inputPath.toString,
-      "--model",
-      model,
-      "--output_format",
-      effectiveFormat
-    )
-
-    val optFlags = List(
-      options.language.map(l => Seq("--language", l)),
-      options.prompt.map(p => Seq("--initial_prompt", p)),
-      if (options.enableTimestamps) Some(Seq("--word-timestamps")) else None
-    ).flatten
-
-    baseArgs ++ optFlags.combineAll
+    WhisperSpeechToText.buildArgs(command, model, outputFormat, inputPath, options)
   }
 
   private def parseWhisperOutput(
     output: String,
     options: STTOptions
-  ): Result[Transcription] = {
-    val parsed = WhisperSpeechToText.parseOutput(output, options)
-    val text   = parsed.text.trim
-    if (text.isEmpty) {
-      Left(ProcessingError.audioValidation("Transcription produced empty text"))
-    } else {
-      Right(
-        Transcription(
-          text = text,
-          language = parsed.language.orElse(options.language),
-          confidence = parsed.confidence,
-          timestamps = if (options.enableTimestamps) parsed.timestamps else Nil,
-          meta = None
-        )
-      )
-    }
-  }
+  ): Result[Transcription] =
+    WhisperSpeechToText.toTranscription(output, options)
 }
 
 object WhisperSpeechToText {
@@ -132,6 +102,31 @@ object WhisperSpeechToText {
     options: STTOptions
   ): String =
     if (options.enableTimestamps) "json" else configuredOutputFormat
+
+  private[stt] def buildArgs(
+    command: Seq[String],
+    model: String,
+    configuredOutputFormat: String,
+    inputPath: Path,
+    options: STTOptions
+  ): Seq[String] = {
+    val effectiveFormat = effectiveOutputFormat(configuredOutputFormat, options)
+    val baseArgs = command ++ Seq(
+      inputPath.toString,
+      "--model",
+      model,
+      "--output_format",
+      effectiveFormat
+    )
+
+    val optFlags = List(
+      options.language.map(l => Seq("--language", l)),
+      options.prompt.map(p => Seq("--initial_prompt", p)),
+      if (options.enableTimestamps) Some(Seq("--word-timestamps")) else None
+    ).flatten
+
+    baseArgs ++ optFlags.combineAll
+  }
 
   private[stt] def parseOutput(
     output: String,
@@ -160,6 +155,27 @@ object WhisperSpeechToText {
           timestamps = Nil
         )
     }
+
+  private[stt] def toTranscription(
+    output: String,
+    options: STTOptions
+  ): Result[Transcription] = {
+    val parsed = parseOutput(output, options)
+    val text   = parsed.text.trim
+    if (text.isEmpty) {
+      Left(ProcessingError.audioValidation("Transcription produced empty text"))
+    } else {
+      Right(
+        Transcription(
+          text = text,
+          language = parsed.language.orElse(options.language),
+          confidence = parsed.confidence,
+          timestamps = if (options.enableTimestamps) parsed.timestamps else Nil,
+          meta = None
+        )
+      )
+    }
+  }
 
   private[stt] def resolveCliOutput(
     inputPath: Path,

--- a/modules/core/src/main/scala/org/llm4s/speech/stt/WhisperSpeechToText.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/stt/WhisperSpeechToText.scala
@@ -77,9 +77,8 @@ final class WhisperSpeechToText(
         }
     }
 
-  private def buildWhisperArgs(inputPath: Path, options: STTOptions): Seq[String] = {
+  private def buildWhisperArgs(inputPath: Path, options: STTOptions): Seq[String] =
     WhisperSpeechToText.buildArgs(command, model, outputFormat, inputPath, options)
-  }
 
   private def parseWhisperOutput(
     output: String,

--- a/modules/core/src/test/scala/org/llm4s/speech/stt/STTProviderFeatureWiringSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/speech/stt/STTProviderFeatureWiringSpec.scala
@@ -1,0 +1,111 @@
+package org.llm4s.speech.stt
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+
+class STTProviderFeatureWiringSpec extends AnyFlatSpec with Matchers {
+
+  "VoskSpeechToText.parseSegment" should "extract text and word timestamps from JSON" in {
+    val json =
+      """{
+        |  "text": "hello world",
+        |  "result": [
+        |    { "conf": 0.92, "start": 0.0, "end": 0.4, "word": "hello" },
+        |    { "conf": 0.61, "start": 0.5, "end": 0.9, "word": "world" }
+        |  ]
+        |}""".stripMargin
+
+    val parsed = VoskSpeechToText.parseSegment(json)
+
+    parsed.text shouldBe "hello world"
+    parsed.words.map(_.word) shouldBe List("hello", "world")
+    parsed.words.flatMap(_.confidence) shouldBe List(0.92, 0.61)
+  }
+
+  it should "filter timestamped words by confidence threshold" in {
+    val words = List(
+      WordTimestamp("hello", 0.0, 0.4, confidence = Some(0.92)),
+      WordTimestamp("world", 0.5, 0.9, confidence = Some(0.41)),
+      WordTimestamp("fallback", 1.0, 1.4, confidence = None)
+    )
+
+    val filtered = VoskSpeechToText.applyConfidenceThreshold(words, threshold = 0.5)
+
+    filtered.map(_.word) shouldBe List("hello", "fallback")
+  }
+
+  "WhisperSpeechToText.parseOutput" should "extract timestamps and confidence from JSON output" in {
+    val json =
+      """{
+        |  "text": "hello world",
+        |  "language": "en",
+        |  "segments": [
+        |    {
+        |      "words": [
+        |        { "word": "hello", "start": 0.0, "end": 0.3, "probability": 0.9 },
+        |        { "word": "world", "start": 0.4, "end": 0.8, "probability": 0.7 }
+        |      ]
+        |    }
+        |  ]
+        |}""".stripMargin
+
+    val parsed = WhisperSpeechToText.parseOutput(json, STTOptions(enableTimestamps = true))
+
+    parsed.text shouldBe "hello world"
+    parsed.language shouldBe Some("en")
+    parsed.timestamps.map(_.word) shouldBe List("hello", "world")
+    parsed.confidence shouldBe defined
+    parsed.confidence.get shouldBe 0.8 +- 0.0001
+  }
+
+  it should "apply the confidence threshold to parsed timestamp words" in {
+    val json =
+      """{
+        |  "text": "keep drop",
+        |  "words": [
+        |    { "word": "keep", "start": 0.0, "end": 0.2, "confidence": 0.91 },
+        |    { "word": "drop", "start": 0.3, "end": 0.5, "confidence": 0.2 }
+        |  ]
+        |}""".stripMargin
+
+    val parsed = WhisperSpeechToText.parseOutput(
+      json,
+      STTOptions(enableTimestamps = true, confidenceThreshold = 0.5)
+    )
+
+    parsed.text shouldBe "keep"
+    parsed.timestamps.map(_.word) shouldBe List("keep")
+    parsed.confidence shouldBe Some(0.91)
+  }
+
+  it should "force JSON output when timestamps are requested" in {
+    WhisperSpeechToText.effectiveOutputFormat("txt", STTOptions(enableTimestamps = true)) shouldBe "json"
+    WhisperSpeechToText.effectiveOutputFormat("txt", STTOptions()) shouldBe "txt"
+  }
+
+  it should "prefer generated CLI output files over stdout when present" in {
+    val inputPath  = Files.createTempFile("whisper-output", ".wav")
+    val outputPath = inputPath.resolveSibling(inputPath.getFileName.toString + ".json")
+    Files.writeString(outputPath, """{ "text": "from file" }""")
+
+    try WhisperSpeechToText.resolveCliOutput(inputPath, "json", "from stdout") shouldBe """{ "text": "from file" }"""
+    finally {
+      Files.deleteIfExists(outputPath)
+      Files.deleteIfExists(inputPath)
+    }
+  }
+
+  "STTOptions.validateBatch" should "re-run strict validation for every element" in {
+    val result = STTOptions.validateBatch(
+      Seq(
+        STTOptions(language = Some("en-US")),
+        STTOptions(language = Some("english"))
+      )
+    )
+
+    result.isLeft shouldBe true
+    result.left.toOption.map(_.message) shouldBe Some("options[1]: Language tag 'english' is not a valid BCP 47 tag")
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/speech/stt/STTProviderFeatureWiringSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/speech/stt/STTProviderFeatureWiringSpec.scala
@@ -36,6 +36,79 @@ class STTProviderFeatureWiringSpec extends AnyFlatSpec with Matchers {
     filtered.map(_.word) shouldBe List("hello", "fallback")
   }
 
+  it should "gracefully handle invalid json and missing confidence data" in {
+    val parsed = VoskSpeechToText.parseSegment("not-json")
+
+    parsed.text shouldBe ""
+    parsed.words shouldBe Nil
+    VoskSpeechToText.averageConfidence(parsed.words) shouldBe None
+    VoskSpeechToText.renderWords(parsed.words) shouldBe ""
+  }
+
+  it should "ignore invalid word entries while keeping valid ones" in {
+    val json =
+      """{
+        |  "text": "hello world",
+        |  "result": [
+        |    { "conf": 0.7, "start": 0.0, "end": 0.4, "word": "hello" },
+        |    { "conf": 1.4, "start": 0.5, "end": 0.9, "word": "world" },
+        |    { "start": 1.0, "end": 1.4, "word": "" }
+        |  ]
+        |}""".stripMargin
+
+    val parsed = VoskSpeechToText.parseSegment(json)
+
+    parsed.words.map(_.word) shouldBe List("hello")
+    VoskSpeechToText.applyConfidenceThreshold(parsed.words, threshold = 0.0).map(_.word) shouldBe List("hello")
+    VoskSpeechToText.averageConfidence(parsed.words) shouldBe Some(0.7)
+  }
+
+  it should "build transcription with timestamps and confidence from parsed segments" in {
+    val segments = Seq(
+      VoskSpeechToText.ParsedSegment(
+        "hello world",
+        List(
+          WordTimestamp("hello", 0.0, 0.4, confidence = Some(0.8)),
+          WordTimestamp("world", 0.5, 0.9, confidence = Some(0.6))
+        )
+      )
+    )
+
+    val transcription = VoskSpeechToText.buildTranscription(
+      segments,
+      STTOptions(language = Some("en-US"), enableTimestamps = true, confidenceThreshold = 0.5)
+    )
+
+    transcription.text shouldBe "hello world"
+    transcription.language shouldBe Some("en-US")
+    transcription.timestamps.map(_.word) shouldBe List("hello", "world")
+    transcription.confidence shouldBe Some(0.7)
+  }
+
+  it should "fall back to segment text when filtering removes all words" in {
+    val segments = Seq(
+      VoskSpeechToText.ParsedSegment(
+        "segment text",
+        List(WordTimestamp("drop", 0.0, 0.3, confidence = Some(0.2)))
+      )
+    )
+
+    val transcription = VoskSpeechToText.buildTranscription(
+      segments,
+      STTOptions(enableTimestamps = false, confidenceThreshold = 0.5)
+    )
+
+    transcription.text shouldBe "segment text"
+    transcription.timestamps shouldBe Nil
+    transcription.confidence shouldBe Some(0.2)
+  }
+
+  it should "decide when Vosk should request word metadata" in {
+    VoskSpeechToText.shouldRequestWordMetadata(STTOptions()) shouldBe false
+    VoskSpeechToText.shouldRequestWordMetadata(STTOptions(enableTimestamps = true)) shouldBe true
+    VoskSpeechToText.shouldRequestWordMetadata(STTOptions(confidenceThreshold = 0.1)) shouldBe true
+  }
+
   "WhisperSpeechToText.parseOutput" should "extract timestamps and confidence from JSON output" in {
     val json =
       """{
@@ -80,9 +153,95 @@ class STTProviderFeatureWiringSpec extends AnyFlatSpec with Matchers {
     parsed.confidence shouldBe Some(0.91)
   }
 
+  it should "fall back to segment confidence and raw text when no word confidences survive" in {
+    val json =
+      """{
+        |  "text": "segment text",
+        |  "segments": [
+        |    {
+        |      "confidence": 0.66,
+        |      "words": [
+        |        { "word": "drop", "start": 0.0, "end": 0.2, "confidence": 0.2 }
+        |      ]
+        |    }
+        |  ]
+        |}""".stripMargin
+
+    val parsed = WhisperSpeechToText.parseOutput(
+      json,
+      STTOptions(enableTimestamps = true, confidenceThreshold = 0.5)
+    )
+
+    parsed.text shouldBe "segment text"
+    parsed.timestamps.map(_.word) shouldBe List("drop")
+    parsed.confidence shouldBe Some(0.2)
+  }
+
+  it should "fall back to plain text output when stdout is not json" in {
+    val parsed = WhisperSpeechToText.parseOutput("plain text output", STTOptions())
+
+    parsed.text shouldBe "plain text output"
+    parsed.language shouldBe None
+    parsed.confidence shouldBe None
+    parsed.timestamps shouldBe Nil
+  }
+
+  it should "use segment confidence when words do not provide any" in {
+    val json =
+      """{
+        |  "text": "segment only",
+        |  "segments": [
+        |    {
+        |      "probability": 0.73,
+        |      "words": [
+        |        { "word": "segment", "start": 0.0, "end": 0.4 }
+        |      ]
+        |    }
+        |  ]
+        |}""".stripMargin
+
+    val parsed = WhisperSpeechToText.parseOutput(json, STTOptions(enableTimestamps = true))
+
+    parsed.text shouldBe "segment"
+    parsed.confidence shouldBe Some(0.73)
+  }
+
   it should "force JSON output when timestamps are requested" in {
     WhisperSpeechToText.effectiveOutputFormat("txt", STTOptions(enableTimestamps = true)) shouldBe "json"
     WhisperSpeechToText.effectiveOutputFormat("txt", STTOptions()) shouldBe "txt"
+  }
+
+  it should "build whisper cli args from options" in {
+    val inputPath = Files.createTempFile("whisper-args", ".wav")
+    try {
+      val args = WhisperSpeechToText.buildArgs(
+        command = Seq("whisper"),
+        model = "base",
+        configuredOutputFormat = "txt",
+        inputPath = inputPath,
+        options = STTOptions(
+          language = Some("en"),
+          prompt = Some("hello"),
+          enableTimestamps = true
+        )
+      )
+
+      args should contain inOrderOnly (
+        "whisper",
+        inputPath.toString,
+        "--model",
+        "base",
+        "--output_format",
+        "json",
+        "--language",
+        "en",
+        "--initial_prompt",
+        "hello",
+        "--word-timestamps"
+      )
+    } finally {
+      Files.deleteIfExists(inputPath)
+    }
   }
 
   it should "prefer generated CLI output files over stdout when present" in {
@@ -97,6 +256,23 @@ class STTProviderFeatureWiringSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "fall back to the stem-based output path and finally stdout" in {
+    val inputPath     = Files.createTempFile("whisper-stem", ".wav")
+    val stemOutput    = inputPath.resolveSibling(inputPath.getFileName.toString.stripSuffix(".wav") + ".json")
+    val stdoutPayload = "from stdout"
+
+    Files.writeString(stemOutput, """{ "text": "from stem file" }""")
+
+    try {
+      WhisperSpeechToText.resolveCliOutput(inputPath, "json", stdoutPayload) shouldBe """{ "text": "from stem file" }"""
+      Files.deleteIfExists(stemOutput)
+      WhisperSpeechToText.resolveCliOutput(inputPath, "json", stdoutPayload) shouldBe stdoutPayload
+    } finally {
+      Files.deleteIfExists(stemOutput)
+      Files.deleteIfExists(inputPath)
+    }
+  }
+
   "STTOptions.validateBatch" should "re-run strict validation for every element" in {
     val result = STTOptions.validateBatch(
       Seq(
@@ -107,5 +283,41 @@ class STTProviderFeatureWiringSpec extends AnyFlatSpec with Matchers {
 
     result.isLeft shouldBe true
     result.left.toOption.map(_.message) shouldBe Some("options[1]: Language tag 'english' is not a valid BCP 47 tag")
+  }
+
+  it should "succeed for a fully valid batch" in {
+    val options = Seq(
+      STTOptions(language = Some("en-US"), confidenceThreshold = 0.3),
+      STTOptions(language = Some("fr-FR"), prompt = Some("medical terms"))
+    )
+
+    STTOptions.validateBatch(options) shouldBe Right(options)
+  }
+
+  "WhisperSpeechToText.toTranscription" should "return an error for empty parsed text" in {
+    val result = WhisperSpeechToText.toTranscription("""{ "text": "   " }""", STTOptions())
+
+    result.isLeft shouldBe true
+  }
+
+  it should "build a transcription from parsed whisper output" in {
+    val json =
+      """{
+        |  "text": "hello world",
+        |  "language": "en",
+        |  "words": [
+        |    { "word": "hello", "start": 0.0, "end": 0.3, "confidence": 0.9 },
+        |    { "word": "world", "start": 0.4, "end": 0.7, "confidence": 0.8 }
+        |  ]
+        |}""".stripMargin
+
+    val result = WhisperSpeechToText.toTranscription(json, STTOptions(enableTimestamps = true))
+
+    result.isRight shouldBe true
+    val transcription = result.toOption.get
+    transcription.language shouldBe Some("en")
+    transcription.timestamps.map(_.word) shouldBe List("hello", "world")
+    transcription.confidence shouldBe defined
+    transcription.confidence.get shouldBe 0.85 +- 0.0001
   }
 }

--- a/modules/core/src/test/scala/org/llm4s/speech/stt/STTProviderFeatureWiringSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/speech/stt/STTProviderFeatureWiringSpec.scala
@@ -226,7 +226,7 @@ class STTProviderFeatureWiringSpec extends AnyFlatSpec with Matchers {
         )
       )
 
-      args should contain inOrderOnly (
+      (args should contain).inOrderOnly(
         "whisper",
         inputPath.toString,
         "--model",
@@ -239,9 +239,7 @@ class STTProviderFeatureWiringSpec extends AnyFlatSpec with Matchers {
         "hello",
         "--word-timestamps"
       )
-    } finally {
-      Files.deleteIfExists(inputPath)
-    }
+    } finally Files.deleteIfExists(inputPath)
   }
 
   it should "prefer generated CLI output files over stdout when present" in {


### PR DESCRIPTION
## What does this PR do?
Implements issue #910 tasks 1, 2, and 5 together by wiring provider-specific STT features into the current transcription flow.

This PR:
- makes `VoskSpeechToText` parse structured Vosk JSON instead of only extracting plain text
- wires `enableTimestamps` and `confidenceThreshold` into the Vosk provider
- makes `WhisperSpeechToText` request and parse JSON output when timestamps are enabled
- extracts Whisper timestamps, language, and confidence from structured output
- upgrades `STTOptions.validateBatch` from a passthrough to real per-item validation
- adds focused regression tests for provider feature wiring

Why this is needed:
the STT domain model already exposed timestamps and confidence-related options, but the provider implementations were still ignoring most of that surface area. This change closes that gap and makes the existing API behave as advertised.

## Related issue
Fixes #910

## How was this tested?
Ran:
- `sbt scalafmtAll`
- `sbt "core/testOnly org.llm4s.speech.stt.STTProviderFeatureWiringSpec"`

Added test coverage for:
- Vosk JSON segment parsing
- Vosk confidence-threshold filtering
- Whisper JSON parsing for timestamps/confidence/language
- Whisper forced JSON mode when timestamps are requested
- `STTOptions.validateBatch` per-item validation

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt test` — tests pass on Scala 3
- [x] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why""
