### PR TITLE
fix(speech): WavFileGenerator memory inefficiency and missing AudioMeta validation

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/speech/io/WavFileGenerator.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/io/WavFileGenerator.scala
@@ -8,7 +8,7 @@ import org.llm4s.resource.ManagedResource
 import java.io.{ ByteArrayOutputStream, DataOutputStream }
 import java.nio.file.{ Path, Files }
 import javax.sound.sampled.{ AudioFileFormat, AudioFormat => JAudioFormat, AudioSystem }
-import scala.util.Try
+import scala.util.{ Try, Using }
 import org.llm4s.types.TryOps
 
 /**
@@ -38,6 +38,22 @@ object WavFileGenerator {
     ManagedResource.tempFile(prefix, ".wav")
 
   /**
+   * Validate AudioMeta values before file generation to catch bad parameters early.
+   */
+  def validateMetadata(meta: AudioMeta): Result[AudioMeta] = {
+    val validBitDepths = Set(8, 16, 24, 32)
+    val errors = List(
+      Option.when(meta.sampleRate <= 0)(s"sampleRate must be positive, got ${meta.sampleRate}"),
+      Option.when(meta.numChannels <= 0)(s"numChannels must be positive, got ${meta.numChannels}"),
+      Option.when(!validBitDepths.contains(meta.bitDepth))(
+        s"bitDepth must be one of $validBitDepths, got ${meta.bitDepth}"
+      )
+    ).flatten
+    if (errors.isEmpty) Right(meta)
+    else Left(WavGenerationFailed(errors.mkString("; ")))
+  }
+
+  /**
    * Create a Java AudioFormat from AudioMeta
    */
   def createJavaAudioFormat(meta: AudioMeta): JAudioFormat =
@@ -63,10 +79,11 @@ object WavFileGenerator {
   /**
    * Save raw PCM data as WAV file (eliminates duplication from AudioIO.saveRawPcm16)
    */
-  def saveRawPcmAsWav(data: Array[Byte], meta: AudioMeta, path: Path): Result[Path] = {
-    val audio = GeneratedAudio(data, meta, AudioFormat.WavPcm16)
-    saveAsWav(audio, path)
-  }
+  def saveRawPcmAsWav(data: Array[Byte], meta: AudioMeta, path: Path): Result[Path] =
+    for {
+      validMeta <- validateMetadata(meta)
+      result    <- saveAsWav(GeneratedAudio(data, validMeta, AudioFormat.WavPcm16), path)
+    } yield result
 
   /**
    * Create WAV file from raw bytes with metadata
@@ -82,30 +99,27 @@ object WavFileGenerator {
    */
   def writeToTempWav(data: Array[Byte], meta: AudioMeta, prefix: String = "llm4s-audio"): Result[Path] =
     for {
-      tempPath <- createTempWavFile(prefix)
-      audio = GeneratedAudio(data, meta, AudioFormat.WavPcm16)
-      savedPath <- saveAsWav(audio, tempPath)
+      validMeta <- validateMetadata(meta)
+      tempPath  <- createTempWavFile(prefix)
+      savedPath <- saveAsWav(GeneratedAudio(data, validMeta, AudioFormat.WavPcm16), tempPath)
     } yield savedPath
 
   /**
-   * Read WAV file and return GeneratedAudio, parsing actual RIFF/WAV header fields.
+   * Read WAV file and return GeneratedAudio.
    *
-   * WAV header layout (little-endian):
-   *   Offset 22: NumChannels (Short)
-   *   Offset 24: SampleRate (Int)
-   *   Offset 34: BitsPerSample (Short)
-   *   Offset 44+: audio data
+   * Uses AudioSystem.getAudioInputStream to delegate format parsing to the JDK,
+   * which handles non-standard chunk layouts and avoids loading the entire file
+   * into memory before we know where the audio data starts.
    */
   def readWavFile(path: Path): Result[GeneratedAudio] =
-    Try {
-      val bytes = Files.readAllBytes(path)
-      import BinaryReader._
-      val (numChannels, _)   = bytes.read[Short](22)
-      val (sampleRate, _)    = bytes.read[Int](24)
-      val (bitsPerSample, _) = bytes.read[Short](34)
-      val audioData          = bytes.drop(44)
-      val meta               = AudioMeta(sampleRate = sampleRate, numChannels = numChannels, bitDepth = bitsPerSample)
-      GeneratedAudio(audioData, meta, AudioFormat.WavPcm16)
+    Using(AudioSystem.getAudioInputStream(path.toFile)) { ais =>
+      val fmt  = ais.getFormat
+      val meta = AudioMeta(
+        sampleRate  = fmt.getSampleRate.toInt,
+        numChannels = fmt.getChannels,
+        bitDepth    = fmt.getSampleSizeInBits
+      )
+      GeneratedAudio(ais.readAllBytes(), meta, AudioFormat.WavPcm16)
     }.toResult.left.map(_ => WavGenerationFailed(s"Failed to read WAV file: $path"))
 
   /**

--- a/modules/core/src/test/scala/org/llm4s/speech/io/WavFileGeneratorSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/speech/io/WavFileGeneratorSpec.scala
@@ -49,6 +49,32 @@ class WavFileGeneratorSpec extends AnyFlatSpec with Matchers {
     chunkSize shouldBe dataSize + 36
   }
 
+  "validateMetadata" should "accept valid AudioMeta" in {
+    val meta = AudioMeta(sampleRate = 44100, numChannels = 2, bitDepth = 16)
+    WavFileGenerator.validateMetadata(meta) shouldBe Right(meta)
+  }
+
+  it should "reject non-positive sampleRate" in {
+    val result = WavFileGenerator.validateMetadata(AudioMeta(sampleRate = 0, numChannels = 1, bitDepth = 16))
+    result.isLeft shouldBe true
+  }
+
+  it should "reject non-positive numChannels" in {
+    val result = WavFileGenerator.validateMetadata(AudioMeta(sampleRate = 44100, numChannels = -1, bitDepth = 16))
+    result.isLeft shouldBe true
+  }
+
+  it should "reject unsupported bitDepth" in {
+    val result = WavFileGenerator.validateMetadata(AudioMeta(sampleRate = 44100, numChannels = 1, bitDepth = 12))
+    result.isLeft shouldBe true
+  }
+
+  it should "accept all standard bit depths" in {
+    Seq(8, 16, 24, 32).foreach { bd =>
+      WavFileGenerator.validateMetadata(AudioMeta(sampleRate = 44100, numChannels = 1, bitDepth = bd)).isRight shouldBe true
+    }
+  }
+
   "writeToTempWav + readWavFile" should "roundtrip AudioMeta correctly" in {
     // Stereo 16-bit PCM, small size for fast test
     val sampleCount = 1024


### PR DESCRIPTION
## What was the issue

Issue #850 reported several bugs in `WavFileGenerator`. Most were already addressed in prior commits (little-endian encoding via `BinaryWriter`, actual header parsing in `readWavFile`, removal of unsafe casts). Two problems were still present in the code:

**1. `readWavFile` loaded the entire file into memory and used a hardcoded offset**

```scala
// Before
val bytes = Files.readAllBytes(path)  // entire file in memory
val audioData = bytes.drop(44)        // hardcoded offset — only valid for simple 44-byte headers
```

This works for basic WAV files but silently corrupts audio data for any file that contains optional metadata chunks (e.g. `LIST`, `INFO`) before the `data` chunk, since those push the audio data past byte 44.

**2. No validation of `AudioMeta` before writing**

`writeToTempWav` and `saveRawPcmAsWav` accepted any `AudioMeta` values without checking them. Passing `sampleRate = 0`, `numChannels = -1`, or an unsupported `bitDepth` would silently write a malformed WAV file with no error returned.

## What this PR fixes

**`WavFileGenerator.scala`**

- `readWavFile` now uses `AudioSystem.getAudioInputStream` wrapped in `scala.util.Using`. The JDK correctly locates the audio data regardless of how many chunks precede it, and `Using` ensures the stream is always closed.
- Added `validateMetadata(meta: AudioMeta): Result[AudioMeta]` which validates `sampleRate > 0`, `numChannels > 0`, and `bitDepth` is one of `{8, 16, 24, 32}`. Returns a `Left(WavGenerationFailed(...))` with a clear message on failure.
- `writeToTempWav` and `saveRawPcmAsWav` now call `validateMetadata` before doing any I/O.

**`WavFileGeneratorSpec.scala`**

- Added 5 tests covering `validateMetadata`: accepts valid input, rejects zero `sampleRate`, rejects negative `numChannels`, rejects unsupported `bitDepth`, accepts all standard bit depths (8/16/24/32).
- Existing 8 tests (header structure + roundtrip) all continue to pass.

```
Total: 13 tests, 0 failures
```

Closes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)