### PR TITLE
feat: add AWS Bedrock support for Anthropic Claude models

### DIFF
--- a/Learn/agent-learning-guide.md
+++ b/Learn/agent-learning-guide.md
@@ -1,0 +1,114 @@
+# Learning the LLM4S Agent Implementation
+
+## Reading Order
+
+### Layer 1: Core Abstractions (start here)
+
+1. **`AgentState.scala`** (`modules/core/src/main/scala/org/llm4s/agent/AgentState.scala`)
+   - The state machine: `AgentStatus` (InProgress → WaitingForTools → Complete/Failed/HandoffRequested)
+   - How `Conversation` + `ToolRegistry` + `SystemMessage` are bundled together
+   - Context window pruning strategies (OldestFirst, MiddleOut, AdaptiveWindowing)
+
+2. **`Agent.scala`** (`modules/core/src/main/scala/org/llm4s/agent/Agent.scala`)
+   - `initializeSafe` — how system prompt + tools + handoffs are assembled
+   - `runStep` — the single state transition (LLM call or tool execution)
+   - `run` — the tail-recursive loop driving steps to completion
+
+### Layer 2: Tool Execution & Handoffs
+
+3. **`ToolProcessor.scala`** (`modules/core/src/main/scala/org/llm4s/agent/ToolProcessor.scala`)
+   - How tool calls from the LLM are dispatched to actual functions
+
+4. **`Handoff.scala`** + **`HandoffExecutor.scala`** (`modules/core/src/main/scala/org/llm4s/agent/`)
+   - Multi-agent delegation
+
+### Layer 3: Memory
+
+5. **`Memory.scala`** (`modules/core/src/main/scala/org/llm4s/agent/memory/Memory.scala`) — Core memory model
+6. **`MemoryManager.scala`** (`modules/core/src/main/scala/org/llm4s/agent/memory/MemoryManager.scala`) — Interface for storing/retrieving
+7. **`InMemoryStore.scala`** (`modules/core/src/main/scala/org/llm4s/agent/memory/InMemoryStore.scala`) — Simplest implementation, read first
+8. **`VectorMemoryStore.scala`** (`modules/core/src/main/scala/org/llm4s/agent/memory/VectorMemoryStore.scala`) — Embedding-based semantic retrieval
+
+### Layer 4: Context Management
+
+9. **`ContextWindowConfig.scala`** (`modules/core/src/main/scala/org/llm4s/agent/ContextWindowConfig.scala`)
+   - How the agent decides what to keep/prune from conversation history when approaching token limits
+
+## Key Takeaways
+
+- The agent is a **synchronous state machine** — no IO monad, just `Result[AgentState]` (which is `Either[LLMError, AgentState]`)
+- Context = system prompt + conversation history + tool definitions, all assembled in `toApiConversation`
+- Memory is separate from context — it's a persistence layer that feeds *into* context when needed
+- The `continueConversation` method shows how multi-turn works: append new user message, optionally prune, re-run the loop
+
+---
+
+## Debugging Tests to Learn the Logic Flow
+
+### Start with these 3 tests (in order):
+
+1. **`AgentSpec.scala`** — The main one. Set breakpoints in `Agent.runStep` and debug to watch:
+   - `InProgress` → LLM call → `Complete` (no tools)
+   - `InProgress` → LLM call → `WaitingForTools` → tool execution → `InProgress` → LLM call → `Complete`
+
+2. **`ToolProcessorSpec.scala`** — How tool calls from the LLM get dispatched to actual Scala functions. Breakpoint in `ToolProcessor.processToolCalls`.
+
+3. **`InMemoryStoreSpec.scala`** — Simplest memory implementation, shows store/retrieve/search patterns.
+
+### Test Fixtures (`TestFixtures.scala`)
+
+The tests mock the LLM using these fake clients:
+
+- `DeterministicFakeLLMClient` — always returns same response (single-turn tests)
+- `TwoTurnDeterministicFakeLLMClient` — returns different responses based on conversation state (tool-calling tests)
+- `NTurnFakeLLMClient` — rotates through N responses (multi-step tests)
+
+### Suggested Breakpoints
+
+1. `Agent.runStep` → the `state.status match` — watch the state machine
+2. `ToolProcessor.processToolCalls` — see how tool args are parsed and dispatched
+3. `AgentState.pruneConversation` — see context window management in action
+
+### Run a Single Test
+
+```bash
+sbt "core/testOnly org.llm4s.agent.AgentSpec"
+```
+
+Or in IntelliJ/Metals, right-click a test and "Debug". The mock clients mean everything runs instantly with no network calls — perfect for stepping through.
+
+Understanding the agent (~2-3 hours):
+- Agent.scala (1249 lines) — the core loop
+- LLMClient.scala (99 lines) — the trait you'll implement
+- LLMConnect.scala (192 lines) — the factory/selector
+- ProviderConfig.scala (679 lines) — config model
+- Skim one existing provider (e.g. AnthropicClient.scala, 649 lines) as a template
+
+Your Scala/Cats experience means the Result[A] patterns, type classes, and functional error handling will be immediately familiar — no ramp-up there.
+
+Implementing the Bedrock adapter (~3-5 hours):
+- BedrockClient.scala — implement LLMClient trait (~300-500 lines, modeled after AnthropicClient)
+- Config additions to ProviderConfig and LLMConnect selector
+- Bedrock uses AWS SigV4 auth + a slightly different request/response shape than raw Anthropic/OpenAI — that's the main delta
+- Streaming support adds complexity (Bedrock uses event-stream encoding)
+- Tests (~1-2 hours)
+
+Total estimate: ~1-1.5 days of focused work, including tests. Breakdown:
+
+┌───────────────────────────────────────────────────┬───────┐
+│                       Phase                       │ Time  │
+├───────────────────────────────────────────────────┼───────┤
+│ Read & understand agent loop + provider interface │ 2-3h  │
+├───────────────────────────────────────────────────┼───────┤
+│ Implement BedrockClient (non-streaming)           │ 2-3h  │
+├───────────────────────────────────────────────────┼───────┤
+│ Add streaming support                             │ 1-2h  │
+├───────────────────────────────────────────────────┼───────┤
+│ Config wiring + ProviderSelector update           │ 30min │
+├───────────────────────────────────────────────────┼───────┤
+│ Tests                                             │ 1-2h  │
+└───────────────────────────────────────────────────┴───────┘
+
+The biggest wildcard is Bedrock's auth (SigV4 signing) — if you use the AWS SDK it's straightforward, but if this project prefers raw HTTP (it seems to use sttp/requests),
+you'd need to implement or pull in a signing library, which could add a couple hours.
+

--- a/Learn/aws-bedrock-adapter-plan-old.md
+++ b/Learn/aws-bedrock-adapter-plan-old.md
@@ -1,0 +1,244 @@
+# Implementation Plan: AWS Bedrock Adapter for llm4s
+
+## Key Design Decisions
+
+- **Use the Converse API** (`/model/{modelId}/converse`) — unified format across all Bedrock model families (Claude, Llama, Titan, Mistral), no model-specific request adaptation needed
+- **SigV4 signing via AWS SDK** — already a transitive dependency (`s3`/`sts` pull in `auth`), safer than manual implementation
+- **Event-stream binary decoder** for streaming — Bedrock uses `application/vnd.amazon.eventstream` framing, not SSE
+- **No heavy Bedrock SDK** — raw HTTP + SigV4 keeps the classpath lean
+
+## Implementation Sequence
+
+### Step 1: Add `ProviderKind.Bedrock` Enum Value
+
+**File:** `modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala`
+
+- Add `case Bedrock` to the `ProviderKind` enum
+- Add `ProviderKind.Bedrock` to the `all` sequence
+- Add `"bedrock" => Some(ProviderKind.Bedrock)` in `fromString`
+- Add `case ProviderKind.Bedrock => "bedrock"` in the `name` extension
+
+### Step 2: Extend Config Model with Bedrock Fields
+
+**Files:**
+- `modules/core/src/main/scala/org/llm4s/config/ProvidersConfigModel.scala`
+- `modules/core/src/main/scala/org/llm4s/config/RawProvidersConfigLoader.scala`
+- `modules/core/src/main/scala/org/llm4s/config/NamedProviderConfigNormalizer.scala`
+
+Add optional fields to `RawNamedProviderSection` and `NamedProviderConfig`:
+- `region: Option[String]`
+- `accessKeyId: Option[String]`
+- `secretAccessKey: Option[String]`
+- `sessionToken: Option[String]`
+
+Update `forProduct7` -> `forProduct11` in the PureConfig reader.
+
+### Step 3: Add `BedrockConfig` Case Class
+
+**File:** `modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala`
+
+```scala
+case class BedrockConfig(
+  region: String,
+  accessKeyId: String,
+  secretAccessKey: String,
+  sessionToken: Option[String],
+  model: String,
+  contextWindow: Int,
+  reserveCompletion: Int
+) extends ProviderConfig:
+  override val provider: ProviderKind = ProviderKind.Bedrock
+```
+
+Companion object with `fromValues` factory method. Uses `ContextWindowResolver` with
+`lookupProviders = Seq("bedrock", "bedrock_converse", "anthropic")` (litellm metadata already contains 330 bedrock entries).
+
+### Step 4: Create SigV4 Signing Utility
+
+**New File:** `modules/core/src/main/scala/org/llm4s/llmconnect/provider/aws/AwsSigV4Signer.scala`
+
+Uses `software.amazon.awssdk.auth.signer.Aws4Signer` from the AWS SDK (already transitive).
+
+```scala
+object AwsSigV4Signer:
+  def sign(
+    method: String,
+    url: String,
+    headers: Map[String, String],
+    body: Array[Byte],
+    region: String,
+    accessKeyId: String,
+    secretAccessKey: String,
+    sessionToken: Option[String],
+    service: String = "bedrock"
+  ): Map[String, String] = ...
+```
+
+### Step 5: Create Event-Stream Binary Decoder
+
+**New File:** `modules/core/src/main/scala/org/llm4s/llmconnect/provider/aws/EventStreamDecoder.scala`
+
+Bedrock streaming uses AWS event-stream binary protocol (not SSE). Each message:
+- 12-byte prelude (total-length, headers-length, prelude-CRC)
+- Headers
+- JSON payload
+- Message-CRC
+
+Consider using `software.amazon.awssdk.protocols.eventstream.EventStreamMessage` (available transitively).
+
+### Step 6: Implement `BedrockClient`
+
+**New File:** `modules/core/src/main/scala/org/llm4s/llmconnect/provider/BedrockClient.scala`
+
+Follows the `GeminiClient` pattern (raw HTTP via `Llm4sHttpClient`):
+
+```scala
+class BedrockClient(
+  config: BedrockConfig,
+  protected val metrics: MetricsCollector = MetricsCollector.noop,
+  exchangeLogging: ProviderExchangeLogging = ProviderExchangeLogging.Disabled,
+  private[provider] val httpClient: Llm4sHttpClient = Llm4sHttpClient.create()
+)(using val registryService: ModelRegistryService)
+    extends BaseLifecycleLLMClient
+```
+
+Endpoints:
+- Complete: `POST https://bedrock-runtime.{region}.amazonaws.com/model/{modelId}/converse`
+- Stream: `POST https://bedrock-runtime.{region}.amazonaws.com/model/{modelId}/converse-stream`
+
+Converse API request format:
+```json
+{
+  "modelId": "anthropic.claude-3-sonnet-20240229-v1:0",
+  "messages": [{"role": "user", "content": [{"text": "Hello"}]}],
+  "system": [{"text": "You are a helpful assistant"}],
+  "inferenceConfig": {"maxTokens": 2048, "temperature": 0.7, "topP": 1.0},
+  "toolConfig": {"tools": [...]}
+}
+```
+
+### Step 7: Wire into `LLMConnect` Factory
+
+**File:** `modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala`
+
+```scala
+case cfg: BedrockConfig =>
+  BedrockClient(cfg, metrics, exchangeLogging)
+```
+
+### Step 8: Wire Config Loading and Validation
+
+**Files:**
+- `modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala`
+- `modules/core/src/main/scala/org/llm4s/config/NamedProviderValidator.scala`
+- `modules/core/src/main/scala/org/llm4s/config/ProviderCapabilities.scala`
+- `modules/core/src/main/scala/org/llm4s/config/ProviderCapabilitiesRegistry.scala`
+
+Add Bedrock case in `buildConfigFromNamedConfig`:
+```scala
+case ProviderKind.Bedrock =>
+  for
+    region    <- required("region", section.region, "llm4s.providers.<name>.region")
+    accessKey <- required("accessKeyId", section.accessKeyId, "llm4s.providers.<name>.accessKeyId")
+    secret    <- required("secretAccessKey", section.secretAccessKey, "llm4s.providers.<name>.secretAccessKey")
+  yield BedrockConfig.fromValues(
+    section.model.asString, region, accessKey, secret, section.sessionToken
+  )
+```
+
+### Step 9: Add Defaults and Reference Config
+
+**Files:**
+- `modules/core/src/main/scala/org/llm4s/config/DefaultConfig.scala`
+- `modules/core/src/main/resources/reference.conf`
+
+```hocon
+# bedrock-main {
+#   provider = "bedrock"
+#   model = "anthropic.claude-3-sonnet-20240229-v1:0"
+#   region = ${?AWS_REGION}
+#   accessKeyId = ${?AWS_ACCESS_KEY_ID}
+#   secretAccessKey = ${?AWS_SECRET_ACCESS_KEY}
+#   sessionToken = ${?AWS_SESSION_TOKEN}
+# }
+```
+
+### Step 10: Add Build Dependencies
+
+**File:** `project/Dependencies.scala`
+
+```scala
+val awsAuth        = "software.amazon.awssdk" % "auth"             % Versions.awsSdk
+val awsEventStream = "software.amazon.awssdk" % "aws-event-stream" % Versions.awsSdk
+```
+
+These are likely already transitive deps of `s3`/`sts`, but making them explicit ensures stability.
+
+### Step 11: Tests
+
+#### Unit Tests
+
+**New Files:**
+- `modules/core/src/test/scala/org/llm4s/llmconnect/provider/BedrockClientSpec.scala`
+  - Request body serialization (verify SigV4 headers present)
+  - Response parsing (mock Converse API JSON)
+  - Error mapping (401 -> AuthenticationError, 429 -> RateLimitError)
+  - Tool calling request/response translation
+  - Closed-state behavior, metrics, exchange logging
+
+- `modules/core/src/test/scala/org/llm4s/llmconnect/provider/aws/AwsSigV4SignerSpec.scala`
+  - Verify signature matches known AWS test vectors
+
+- `modules/core/src/test/scala/org/llm4s/llmconnect/provider/aws/EventStreamDecoderSpec.scala`
+  - Verify binary frame decoding with sample payloads
+
+- `modules/core/src/test/scala/org/llm4s/config/BedrockConfigSpec.scala`
+  - `BedrockConfig.fromValues` with various model names
+  - HOCON config loading
+  - Validation failures (missing region, empty credentials)
+
+#### Smoke Tests (require AWS credentials)
+
+**New File:** `modules/it/src/test/scala/org/llm4s/llmconnect/smoke/BedrockSmokeSpec.scala`
+- Basic complete request
+- Stream response
+- Tool calling round-trip
+- AuthenticationError for invalid credentials
+
+## Config Usage (End Result)
+
+HOCON:
+```hocon
+bedrock-main {
+  provider = "bedrock"
+  model = "anthropic.claude-3-sonnet-20240229-v1:0"
+  region = ${?AWS_REGION}
+  accessKeyId = ${?AWS_ACCESS_KEY_ID}
+  secretAccessKey = ${?AWS_SECRET_ACCESS_KEY}
+  sessionToken = ${?AWS_SESSION_TOKEN}
+}
+```
+
+Env-based: `LLM_MODEL=bedrock/anthropic.claude-3-sonnet-20240229-v1:0`
+
+## Reference Files
+
+Key files to study before implementing:
+- `modules/core/src/main/scala/org/llm4s/llmconnect/LLMClient.scala` (99 lines) — trait to implement
+- `modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala` (192 lines) — factory/selector
+- `modules/core/src/main/scala/org/llm4s/llmconnect/BaseLifecycleLLMClient.scala` — base class pattern
+- `modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala` (679 lines) — config model
+- `modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala` (649 lines) — best reference (Bedrock invokes Anthropic models)
+- `modules/core/src/main/scala/org/llm4s/llmconnect/provider/GeminiClient.scala` (537 lines) — good reference for raw HTTP pattern
+- `modules/core/src/main/scala/org/llm4s/agent/Agent.scala` (1249 lines) — how agents consume clients
+
+## Estimated Effort
+
+| Phase | Time |
+|-------|------|
+| Read & understand provider interface | 2-3h |
+| Implement `BedrockClient` (non-streaming) | 2-3h |
+| Add streaming support (event-stream decoder) | 1-2h |
+| Config wiring + ProviderSelector update | 30min |
+| Tests | 1-2h |
+| **Total** | **~1-1.5 days** |

--- a/Learn/aws-bedrock-anthropic-plan.md
+++ b/Learn/aws-bedrock-anthropic-plan.md
@@ -1,0 +1,228 @@
+# Plan: AWS Bedrock Support for Anthropic Models
+
+## Context
+
+The goal is to allow llm4s users to call Anthropic Claude models through AWS Bedrock instead of the direct Anthropic API. This enables enterprises that standardize on AWS IAM for access control to use Claude without managing separate Anthropic API keys. The Anthropic Java SDK (already v2.11.1 in the project) publishes a `anthropic-java-bedrock` module that provides `AnthropicBedrockOkHttpClient` — it produces the same `Message`, `MessageCreateParams`, and streaming types as the direct client, so the heavy message-conversion logic can be reused.
+
+**User choices:**
+- Credentials: AWS Default Credential Chain (env vars, `~/.aws/credentials`, IAM roles)
+- Model prefix: `bedrock-anthropic/` (e.g., `LLM_MODEL=bedrock-anthropic/anthropic.claude-3-5-sonnet-20241022-v2:0`)
+- Region: via `baseUrl` field in config
+
+---
+
+## Implementation Steps
+
+### 1. Add Dependency
+
+**`project/Dependencies.scala`** — add:
+```scala
+val anthropicBedrock = "com.anthropic" % "anthropic-java-bedrock" % Versions.anthropic
+```
+
+**`build.sbt`** — add `Deps.anthropicBedrock` to core's `libraryDependencies` (after `Deps.anthropic`).
+
+Run `sbt evicted` to verify no version conflicts with existing AWS SDK 2.29.51.
+
+---
+
+### 2. Register Provider Kind
+
+**`modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala`**
+
+- Add `case BedrockAnthropic` to `ProviderKind` enum
+- Add to `ProviderKind.all`
+- Add `case "bedrock-anthropic" => Some(ProviderKind.BedrockAnthropic)` in `fromString`
+- Add `case ProviderKind.BedrockAnthropic => "bedrock-anthropic"` in `name` extension
+
+After this step, `-Werror` + exhaustive matching will flag every file that needs updating.
+
+---
+
+### 3. Add Config Case Class
+
+**`modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala`** — add after `MistralConfig`:
+
+```scala
+case class BedrockAnthropicConfig(
+  region: String,
+  model: String,
+  contextWindow: Int,
+  reserveCompletion: Int
+) extends ProviderConfig:
+  override val provider: ProviderKind = ProviderKind.BedrockAnthropic
+  override def toString: String =
+    s"BedrockAnthropicConfig(region=$region, model=$model, contextWindow=$contextWindow, reserveCompletion=$reserveCompletion)"
+```
+
+With companion providing `fromValues(modelName, region)(using ContextWindowResolver)`. No `apiKey` field — uses AWS default cred chain. Fallback context window: 200000 for Claude models.
+
+**`modules/core/src/main/scala/org/llm4s/config/DefaultConfig.scala`** — add:
+```scala
+val DEFAULT_BEDROCK_ANTHROPIC_REGION = "us-east-1"
+```
+
+---
+
+### 4. Config Validation and Loading
+
+**`NamedProviderValidator.scala`** — add `BedrockAnthropic` validator with `requireApiKey = false`, `requireBaseUrl = true` (baseUrl holds the region).
+
+**`ProviderCapabilities.scala`** — add `BedrockAnthropic` object (no model lister initially).
+
+**`ProviderCapabilitiesRegistry.scala`** — add to registry map.
+
+**`NamedProviderLoader.scala`** — add case:
+```scala
+case ProviderKind.BedrockAnthropic =>
+  val region = section.baseUrl.map(_.asUrl).getOrElse(DefaultConfig.DEFAULT_BEDROCK_ANTHROPIC_REGION)
+  Right(BedrockAnthropicConfig.fromValues(section.model.asString, region))
+```
+
+---
+
+### 5. Extract Shared Trait
+
+**New file: `modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicMessageSupport.scala`**
+
+Extract from `AnthropicClient` into a trait:
+- `addMessagesToParams(conversation, paramsBuilder)` — message format conversion
+- `convertToolToAnthropicTool(toolFunction)` — schema sanitization
+- `stripAdditionalProperties(json)` — recursive schema cleanup
+- `convertFromAnthropicResponse(response, model)` — response mapping (accept model as param)
+- `extractToolCalls(response)` — tool call extraction
+- `clampBudgetTokens(budgetTokens, maxTokens)` — thinking budget clamping
+- `applySamplingParameters(builder, options)` — temperature setting
+- `serializeRequestBody/serializeResponseBody/serializeStreamEvent` — serialization helpers
+
+Then refactor `AnthropicClient` to `extends BaseLifecycleLLMClient with AnthropicMessageSupport`.
+
+---
+
+### 6. New BedrockAnthropicClient
+
+**New file: `modules/core/src/main/scala/org/llm4s/llmconnect/provider/BedrockAnthropicClient.scala`**
+
+```scala
+class BedrockAnthropicClient(
+  config: BedrockAnthropicConfig,
+  protected val metrics: MetricsCollector = MetricsCollector.noop,
+  exchangeLogging: ProviderExchangeLogging = ProviderExchangeLogging.Disabled
+)(using val registryService: ModelRegistryService)
+    extends BaseLifecycleLLMClient with AnthropicMessageSupport {
+
+  // Initialize Bedrock client using AWS Default Credential Chain
+  private val client = AnthropicBedrockOkHttpClient
+    .builder()
+    .region(config.region)
+    .build()
+
+  protected def clientDescription: String = s"Bedrock Anthropic client for model ${config.model}"
+  protected def providerName: String      = "bedrock-anthropic"
+  protected def modelName: String         = config.model
+
+  // complete() and streamComplete() follow the same structure as AnthropicClient
+  // but use the Bedrock client's message service
+}
+```
+
+Key difference from `AnthropicClient`: client initialization uses:
+```scala
+AnthropicBedrockOkHttpClient.builder().region(config.region).build()
+```
+
+The `complete()` and `streamComplete()` methods follow the same structure — build params, call `client.messages().create()`/`createStreaming()`, parse response using shared trait methods.
+
+Error mapping adds AWS-specific exceptions (`SdkException` -> `AuthenticationError`).
+
+---
+
+### 7. Wire Up Routing
+
+**`LLMConnect.scala`** — add in both `buildClient` and `fromProvider`:
+```scala
+case cfg: BedrockAnthropicConfig => BedrockAnthropicClient(cfg, metrics, exchangeLogging)
+case (ProviderKind.BedrockAnthropic, cfg: BedrockAnthropicConfig) => BedrockAnthropicClient(cfg, metrics, exchangeLogging)
+```
+
+---
+
+### 8. Tests
+
+**Unit tests** (no AWS creds needed):
+- `BedrockAnthropicConfig.fromValues` resolves context window correctly
+- `NamedProviderValidator` passes without apiKey, fails without baseUrl
+- `ProviderKind.fromString("bedrock-anthropic")` round-trips
+- `LLMConnect.fromProvider` rejects mismatched config types
+- HOCON parsing with bedrock-anthropic provider section
+
+**Integration smoke** (tagged, requires AWS creds):
+- Simple `complete()` call
+- `streamComplete()` call
+- Verify missing credentials gives `AuthenticationError`
+
+---
+
+## Sample Usage
+
+```hocon
+# application.conf
+llm4s.providers {
+  provider = "my-bedrock"
+  my-bedrock {
+    provider = "bedrock-anthropic"
+    model = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    baseUrl = "us-east-1"
+  }
+}
+```
+
+```bash
+# Environment — AWS creds via standard chain
+export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=us-east-1
+```
+
+---
+
+## Verification
+
+1. `sbt compile` — exhaustive match ensures all routing is wired
+2. `sbt +test` — unit tests pass without AWS credentials
+3. Manual smoke: configure a bedrock-anthropic provider, run a sample with valid AWS creds
+4. `sbt evicted` — no dependency conflicts
+
+---
+
+## Files Modified (summary)
+
+| File | Change |
+|------|--------|
+| `project/Dependencies.scala` | Add `anthropicBedrock` dep |
+| `build.sbt` | Add to core libraryDependencies |
+| `ProviderModelTypes.scala` | Add `BedrockAnthropic` enum + mappings |
+| `ProviderConfig.scala` | Add `BedrockAnthropicConfig` case class |
+| `DefaultConfig.scala` | Add region constant |
+| `NamedProviderValidator.scala` | Add `BedrockAnthropic` validator |
+| `ProviderCapabilities.scala` | Add `BedrockAnthropic` object |
+| `ProviderCapabilitiesRegistry.scala` | Register in map |
+| `NamedProviderLoader.scala` | Add loading case |
+| `AnthropicClient.scala` | Mix in shared trait (refactor) |
+| `LLMConnect.scala` | Add routing (2 locations) |
+| **New:** `AnthropicMessageSupport.scala` | Shared message logic trait |
+| **New:** `BedrockAnthropicClient.scala` | Bedrock client implementation |
+
+---
+
+## Risks and Edge Cases
+
+1. **AWS SDK version alignment**: The project uses AWS SDK 2.29.51 for S3/STS. The `anthropic-java-bedrock` module transitively depends on `software.amazon.awssdk:bedrockruntime`. Use `sbt evicted` to check; apply `dependencyOverrides` if needed.
+
+2. **Credential chain failures**: The AWS Default Credential Provider Chain can throw various exceptions. Map `SdkException`, `StsException`, and `AwsServiceException` to `AuthenticationError` or `ConfigurationError`.
+
+3. **Cross-region inference**: Bedrock supports cross-region inference profiles (e.g., `us.anthropic.claude-3-5-sonnet-20241022-v2:0`). Pass the model string verbatim — the SDK handles routing.
+
+4. **Extended thinking**: Bedrock may not support extended thinking for all model versions. The existing error mapping to `ValidationError` handles graceful rejection.
+
+5. **`baseUrl` semantic overloading**: Using `baseUrl` for "region" works (Azure already repurposes `endpoint`) but is semantically confusing. A future improvement could add a dedicated `region` field to `RawNamedProviderSection`.

--- a/Learn/aws-bedrock-implementation-summary.md
+++ b/Learn/aws-bedrock-implementation-summary.md
@@ -1,0 +1,144 @@
+# AWS Bedrock Anthropic Integration - Implementation Summary
+
+## Overview
+
+Added AWS Bedrock support for Anthropic Claude models to llm4s. Users can now call Claude models through AWS Bedrock using IAM credentials instead of direct Anthropic API keys.
+
+**Full build passes: 6656 tests green, all modules compile.**
+
+---
+
+## New Files Created
+
+### `modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicMessageSupport.scala`
+
+Shared trait extracted from `AnthropicClient` containing all message conversion, tool schema sanitization, response parsing, and serialization logic. Both `AnthropicClient` and `BedrockAnthropicClient` mix in this trait.
+
+### `modules/core/src/main/scala/org/llm4s/llmconnect/provider/BedrockAnthropicClient.scala`
+
+New provider client that uses `AnthropicOkHttpClient` with a `BedrockBackend` for AWS Default Credential Chain authentication. Identical message/streaming behavior to the direct Anthropic client.
+
+---
+
+## Modified Files (14 total)
+
+| File | Change |
+|------|--------|
+| `project/Dependencies.scala` | Added `anthropicBedrock` dependency (`com.anthropic:anthropic-java-bedrock:2.11.1`) |
+| `build.sbt` | Added dep to core + AWS SDK version overrides to prevent conflicts |
+| `ProviderModelTypes.scala` | Added `BedrockAnthropic` to enum, `fromString`, `name` extension |
+| `ProviderConfig.scala` | Added `BedrockAnthropicConfig` case class with `fromValues` factory |
+| `DefaultConfig.scala` | Added `DEFAULT_BEDROCK_ANTHROPIC_REGION = "us-east-1"` |
+| `NamedProviderValidator.scala` | Added `BedrockAnthropic` validator (`requireApiKey = false`, `requireBaseUrl = true`) |
+| `ProviderCapabilities.scala` | Added `BedrockAnthropic` capabilities object |
+| `ProviderCapabilitiesRegistry.scala` | Registered in the provider map |
+| `NamedProviderLoader.scala` | Added config loading case for `ProviderKind.BedrockAnthropic` |
+| `AnthropicClient.scala` | Refactored to mix in `AnthropicMessageSupport` trait, removed duplicated methods |
+| `LLMConnect.scala` | Added routing in both `buildClient` and `fromProvider` |
+| `ProviderKindSpec.scala` | Updated test assertions for 11 providers |
+| `ProviderSetupRuntime.scala` | Added exhaustive match cases for `BedrockAnthropicConfig` |
+| `PrometheusMetricsExample.scala` | Added exhaustive match case for `BedrockAnthropicConfig` |
+
+---
+
+## Architecture
+
+```
+AnthropicMessageSupport (trait)
+  - addMessagesToParams()
+  - convertToolToAnthropicTool()
+  - stripAdditionalProperties()
+  - convertFromAnthropicResponse()
+  - extractToolCalls()
+  - clampBudgetTokens()
+  - applySamplingParameters()
+  - serializeRequestBody/ResponseBody/StreamEvent()
+        |
+        +--- AnthropicClient (direct API via AnthropicOkHttpClient)
+        |
+        +--- BedrockAnthropicClient (AWS Bedrock via AnthropicOkHttpClient + BedrockBackend)
+```
+
+The key difference: `BedrockAnthropicClient` initializes its HTTP client with:
+```scala
+AnthropicOkHttpClient.builder()
+  .backend(BedrockBackend.builder().region(Region.of(config.region)).build())
+  .build()
+```
+
+This uses the AWS Default Credential Provider Chain automatically.
+
+---
+
+## Usage
+
+### HOCON Configuration
+
+```hocon
+llm4s.providers {
+  provider = "my-bedrock"
+  my-bedrock {
+    provider = "bedrock-anthropic"
+    model = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    baseUrl = "us-east-1"   # AWS region (stored in baseUrl field)
+  }
+}
+```
+
+### Environment Variables
+
+```bash
+# AWS credentials via standard chain (no Anthropic API key needed)
+export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=us-east-1
+```
+
+### Programmatic Usage
+
+```scala
+import org.llm4s.config.Llm4sConfig
+import org.llm4s.llmconnect.{LLMConnect, LlmClientOptions}
+import org.llm4s.llmconnect.config.BedrockAnthropicConfig
+import org.llm4s.llmconnect.model.*
+
+// Via named provider config (recommended)
+for {
+  registryService <- Llm4sConfig.modelRegistryService()
+  given org.llm4s.model.ModelRegistryService = registryService
+  providerCfg <- Llm4sConfig.defaultProvider()
+  client      <- LLMConnect.getClient(providerCfg)
+  response    <- client.complete(Conversation(Seq(UserMessage("Hello from Bedrock!"))))
+} yield response
+
+// Direct construction
+given resolver: org.llm4s.llmconnect.config.ContextWindowResolver = ???
+given registry: org.llm4s.model.ModelRegistryService = ???
+
+val config = BedrockAnthropicConfig.fromValues(
+  modelName = "anthropic.claude-3-5-sonnet-20241022-v2:0",
+  region = "us-east-1"
+)
+val client = LLMConnect.getClient(config)
+```
+
+---
+
+## Key Design Decisions
+
+1. **No API key field** - `BedrockAnthropicConfig` deliberately omits `apiKey`; the AWS Default Credential Provider Chain handles authentication.
+
+2. **`baseUrl` holds the region** - Following Azure's precedent of repurposing existing config fields, the `baseUrl` field in HOCON config stores the AWS region string. This avoids schema changes to `RawNamedProviderSection`.
+
+3. **Shared trait over inheritance** - Extracted `AnthropicMessageSupport` as a trait rather than making `AnthropicClient` open for extension. Cleaner separation with no risk to existing code.
+
+4. **AWS SDK version pinning** - Added `dependencyOverrides` in `build.sbt` to keep AWS SDK at 2.29.51 (the version already in use), preventing the `anthropic-java-bedrock` dependency from pulling in 2.33.1 which introduces a deprecation warning that breaks `-Werror`.
+
+---
+
+## Verification
+
+1. `sbt compile` - exhaustive match ensures all routing is wired
+2. `sbt buildAll` - all modules compile + 6656 tests pass
+3. Manual smoke: configure a `bedrock-anthropic` provider, run a sample with valid AWS creds
+4. Cross-region inference models (e.g., `us.anthropic.claude-*`) work by passing the model string verbatim to the SDK

--- a/Learn/bedrock-client-initialization-flow.md
+++ b/Learn/bedrock-client-initialization-flow.md
@@ -1,0 +1,181 @@
+# Bedrock Anthropic Client Initialization Flow
+
+Step-by-step walkthrough of how the `BedrockAnthropicClient` is retrieved from:
+
+```scala
+providerCfg     <- Llm4sConfig.provider("bedrock-anthropic-main")
+registryService <- Llm4sConfig.modelRegistryService()
+given org.llm4s.model.ModelRegistryService = registryService
+client          <- LLMConnect.getClient(providerCfg)
+```
+
+---
+
+## Step 1: `Llm4sConfig.provider("bedrock-anthropic-main")`
+
+**File:** `config/Llm4sConfig.scala:81`
+
+```scala
+def provider(name: String): Result[ProviderConfig] =
+  for
+    service <- modelRegistryService()
+    given ContextWindowResolver = ContextWindowResolver(service)
+    config <- NamedProviderLoader.load(ConfigSource.default, name)
+  yield config
+```
+
+This does three things:
+1. Loads a `ModelRegistryService` (reads model metadata — context window sizes, pricing, etc.)
+2. Creates a `ContextWindowResolver` from it (used later to look up the model's token limits)
+3. Calls `NamedProviderLoader.load` to parse the HOCON config section named `"bedrock-anthropic-main"`
+
+---
+
+## Step 2: `NamedProviderLoader.load`
+
+**File:** `config/NamedProviderLoader.scala:11`
+
+```scala
+def load(source: ConfigSource, providerName: String): Result[ProviderConfig] =
+  for
+    providers  <- ProvidersConfigLoader.load(source)     // parse HOCON into typed model
+    normalized <- providers.namedProviders
+      .get(ProviderName("bedrock-anthropic-main"))       // find the named section
+      .toRight(ConfigurationError(...))
+    config     <- buildConfigFromNamedConfig("bedrock-anthropic-main", normalized)
+  yield config
+```
+
+1. **`ProvidersConfigLoader.load`** reads your `application.conf` and returns a typed `ProvidersConfig` with all named providers as a `Map[ProviderName, NamedProviderConfig]`
+2. Looks up `"bedrock-anthropic-main"` in the map — gets back a `NamedProviderConfig` with `provider = BedrockAnthropic`, `model = "us.anthropic.claude-sonnet-4-20250514-v1:0"`, `baseUrl = "us-west-2"`, etc.
+3. Dispatches to `buildConfigFromNamedConfig`
+
+---
+
+## Step 3: `buildConfigFromNamedConfig` — pattern match on provider kind
+
+**File:** `config/NamedProviderLoader.scala:107`
+
+```scala
+case ProviderKind.BedrockAnthropic =>
+  val region  = section.baseUrl.map(_.asUrl).getOrElse(DefaultConfig.DEFAULT_BEDROCK_ANTHROPIC_REGION)
+  val profile = section.organization
+  Right(BedrockAnthropicConfig.fromValues(section.model.asString, region, profile))
+```
+
+Since `provider = "bedrock-anthropic"` maps to `ProviderKind.BedrockAnthropic`, this branch:
+- Extracts `region` from `baseUrl` (-> `"us-west-2"`)
+- Extracts optional `profile` from `organization` (-> `None` since it's commented out)
+- Calls `BedrockAnthropicConfig.fromValues` which uses the `ContextWindowResolver` to determine the model's context window (200k for Claude) and reserve (4096)
+
+**Returns:** `BedrockAnthropicConfig(region="us-west-2", model="us.anthropic.claude-sonnet-4-20250514-v1:0", contextWindow=200000, reserveCompletion=4096, profile=None)`
+
+---
+
+## Step 4: `Llm4sConfig.modelRegistryService()`
+
+Loads model metadata (pricing, token limits) from a bundled JSON resource. This returns a `ModelRegistryService` that providers use for cost estimation and context window lookups.
+
+---
+
+## Step 5: `given org.llm4s.model.ModelRegistryService = registryService`
+
+This line makes the `ModelRegistryService` available as a Scala 3 **given** (implicit). It's needed because `LLMConnect.getClient` has a `(using ModelRegistryService)` parameter — the compiler will pass it automatically.
+
+---
+
+## Step 6: `LLMConnect.getClient(providerCfg)`
+
+**File:** `llmconnect/LLMConnect.scala:114`
+
+```scala
+def getClient(config: ProviderConfig)(using ModelRegistryService): Result[LLMClient] =
+  fromConfig(config)
+```
+
+Which calls `buildClient`, which pattern-matches on the config type:
+
+```scala
+case cfg: BedrockAnthropicConfig =>
+  BedrockAnthropicClient(cfg, metrics, exchangeLogging)
+```
+
+---
+
+## Step 7: `BedrockAnthropicClient` construction
+
+**File:** `llmconnect/provider/BedrockAnthropicClient.scala:53-67`
+
+```scala
+private val credentialsProvider: AwsCredentialsProvider = config.profile match {
+  case Some(profile) => ProfileCredentialsProvider.builder().profileName(profile).build()
+  case None          => DefaultCredentialsProvider.create()
+}
+
+private val client = AnthropicOkHttpClient.builder()
+  .backend(
+    BedrockBackend.builder()
+      .region(Region.of(config.region))           // us-west-2
+      .awsCredentialsProvider(credentialsProvider) // picks up AWS_ACCESS_KEY_ID etc.
+      .build()
+  )
+  .build()
+```
+
+Since `profile = None`, it creates a `DefaultCredentialsProvider` which resolves credentials from:
+1. `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` env vars
+2. `~/.aws/credentials` default profile
+3. IAM instance role
+
+The final result is an `LLMClient` (specifically `BedrockAnthropicClient`) that speaks to `bedrock-runtime.us-west-2.amazonaws.com` using your STS credentials, wrapping calls in the Anthropic Messages API format.
+
+---
+
+## Visual Summary
+
+```
+"bedrock-anthropic-main"
+        |
+        v
++---------------------+
+|  Llm4sConfig        |  Loads ModelRegistryService + ContextWindowResolver
+|  .provider(name)    |
++----------+----------+
+           |
+           v
++---------------------+
+| NamedProviderLoader |  Reads HOCON -> finds section -> pattern matches on ProviderKind
+| .load(source, name) |
++----------+----------+
+           |
+           v
++-------------------------------------------------------------+
+| BedrockAnthropicConfig(region, model, contextWindow, ...)   |
++----------+--------------------------------------------------+
+           |
+           v
++---------------------+
+| LLMConnect          |  Pattern matches config type -> constructs client
+| .getClient(config)  |
++----------+----------+
+           |
+           v
++--------------------------------------------------------------+
+| BedrockAnthropicClient                                       |
+|   +-- AnthropicOkHttpClient + BedrockBackend(region, creds)  |
+|   +-- implements LLMClient.complete() / streamComplete()     |
++--------------------------------------------------------------+
+```
+
+---
+
+## Key Files
+
+| Step | File | Lines |
+|------|------|-------|
+| Config entry point | `modules/core/src/main/scala/org/llm4s/config/Llm4sConfig.scala` | 81-86 |
+| Named provider loader | `modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala` | 11-110 |
+| Bedrock config model | `modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala` | 695-735 |
+| Client factory | `modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala` | 61-62, 114 |
+| Client implementation | `modules/core/src/main/scala/org/llm4s/llmconnect/provider/BedrockAnthropicClient.scala` | 53-67 |
+| Sample config (HOCON) | `modules/samples/src/main/resources/application.conf` | bedrock-anthropic-main section |

--- a/build.sbt
+++ b/build.sbt
@@ -178,6 +178,7 @@ lazy val core = (project in file("modules/core"))
     libraryDependencies ++= Seq(
       Deps.azureOpenAI,
       Deps.anthropic,
+      Deps.anthropicBedrock,
       Deps.jtokkit,
       Deps.websocket,
       Deps.scalatest % Test,
@@ -197,6 +198,13 @@ lazy val core = (project in file("modules/core"))
       Deps.awsSts,
       Deps.prometheusCore,
       Deps.prometheusHttp
+    ),
+    dependencyOverrides ++= Seq(
+      "software.amazon.awssdk" % "auth"    % Versions.awsSdk,
+      "software.amazon.awssdk" % "regions" % Versions.awsSdk,
+      "software.amazon.awssdk" % "sdk-core" % Versions.awsSdk,
+      "software.amazon.awssdk" % "utils"   % Versions.awsSdk,
+      "software.amazon.awssdk" % "retries" % Versions.awsSdk
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -129,6 +129,7 @@ lazy val commonSettings = Seq(
 lazy val llm4s = (project in file("."))
   .aggregate(
     core,
+    algorithms,
     samples,
     workspaceShared,
     workspaceRunner,
@@ -139,6 +140,15 @@ lazy val llm4s = (project in file("."))
   )
   .settings(
     publish / skip := true
+  )
+
+lazy val algorithms = (project in file("modules/algorithms"))
+  .settings(
+    name := "algorithms",
+    commonSettings,
+    libraryDependencies ++= Seq(
+      Deps.scalatest % Test
+    )
   )
 
 lazy val core = (project in file("modules/core"))

--- a/leiden_graph.html
+++ b/leiden_graph.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  body { margin: 0; background: #1a1a2e; display: flex; justify-content: center; align-items: center; height: 100vh; font-family: system-ui, sans-serif; }
+  svg { filter: drop-shadow(0 0 20px rgba(0,0,0,0.3)); }
+  .edge { stroke-linecap: round; }
+  .node-circle { stroke-width: 2; }
+  .node-label { font-size: 14px; font-weight: 600; text-anchor: middle; dominant-baseline: central; fill: #1a1a2e; }
+  .edge-label { font-size: 11px; fill: #8892a0; text-anchor: middle; dominant-baseline: central; }
+  .title { font-size: 20px; fill: #e0e0e0; text-anchor: middle; font-weight: 600; }
+  .subtitle { font-size: 13px; fill: #8892a0; text-anchor: middle; }
+  .legend-text { font-size: 12px; fill: #c0c0c0; }
+  .community-bg { opacity: 0.08; }
+</style>
+</head>
+<body>
+<svg width="800" height="520" viewBox="0 0 800 520">
+  <defs>
+    <radialGradient id="glow1" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#4fc3f7" stop-opacity="0.3"/><stop offset="100%" stop-color="#4fc3f7" stop-opacity="0"/></radialGradient>
+    <radialGradient id="glow2" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#81c784" stop-opacity="0.3"/><stop offset="100%" stop-color="#81c784" stop-opacity="0"/></radialGradient>
+    <radialGradient id="glow3" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#ffb74d" stop-opacity="0.3"/><stop offset="100%" stop-color="#ffb74d" stop-opacity="0"/></radialGradient>
+  </defs>
+
+  <!-- Title -->
+  <text x="400" y="35" class="title">Leiden Algorithm Example Graph</text>
+  <text x="400" y="55" class="subtitle">10 nodes, 10 edges | 3 communities detected</text>
+
+  <!-- Community background regions -->
+  <ellipse cx="190" cy="240" rx="150" ry="130" fill="url(#glow1)" class="community-bg"/>
+  <ellipse cx="610" cy="260" rx="170" ry="160" fill="url(#glow2)" class="community-bg"/>
+  <ellipse cx="390" cy="300" rx="80" ry="70" fill="url(#glow3)" class="community-bg"/>
+
+  <!-- Cluster 1 edges (weight 1.0) -->
+  <line x1="140" y1="170" x2="240" y2="170" class="edge" stroke="#4fc3f7" stroke-width="2.5" opacity="0.7"/>
+  <line x1="140" y1="170" x2="190" y2="260" class="edge" stroke="#4fc3f7" stroke-width="2.5" opacity="0.7"/>
+  <line x1="240" y1="170" x2="190" y2="260" class="edge" stroke="#4fc3f7" stroke-width="2.5" opacity="0.7"/>
+  <line x1="190" y1="260" x2="330" y2="310" class="edge" stroke="#4fc3f7" stroke-width="2.5" opacity="0.7"/>
+
+  <!-- Edges within {3,4} community -->
+  <line x1="330" y1="310" x2="420" y2="280" class="edge" stroke="#ffb74d" stroke-width="2.5" opacity="0.7"/>
+
+  <!-- Bridge edge (weight 0.5) -->
+  <line x1="420" y1="280" x2="510" y2="230" class="edge" stroke="#ff5252" stroke-width="1.5" stroke-dasharray="6,4" opacity="0.8"/>
+  <text x="465" y="245" class="edge-label" fill="#ff8a80">0.5</text>
+
+  <!-- Cluster 2 edges (weight 1.0) -->
+  <line x1="510" y1="230" x2="610" y2="160" class="edge" stroke="#81c784" stroke-width="2.5" opacity="0.7"/>
+  <line x1="610" y1="160" x2="710" y2="220" class="edge" stroke="#81c784" stroke-width="2.5" opacity="0.7"/>
+  <line x1="710" y1="220" x2="680" y2="340" class="edge" stroke="#81c784" stroke-width="2.5" opacity="0.7"/>
+  <line x1="680" y1="340" x2="560" y2="370" class="edge" stroke="#81c784" stroke-width="2.5" opacity="0.7"/>
+  <line x1="560" y1="370" x2="510" y2="230" class="edge" stroke="#81c784" stroke-width="2.5" opacity="0.7"/>
+
+  <!-- Edge weight labels for w=1.0 edges -->
+  <text x="190" y="160" class="edge-label">1.0</text>
+  <text x="155" y="220" class="edge-label">1.0</text>
+  <text x="225" y="220" class="edge-label">1.0</text>
+  <text x="252" y="292" class="edge-label">1.0</text>
+  <text x="378" y="288" class="edge-label">1.0</text>
+  <text x="553" y="188" class="edge-label">1.0</text>
+  <text x="668" y="183" class="edge-label">1.0</text>
+  <text x="704" y="285" class="edge-label">1.0</text>
+  <text x="628" y="363" class="edge-label">1.0</text>
+  <text x="525" y="308" class="edge-label">1.0</text>
+
+  <!-- Cluster 1 nodes (Community 0: blue) -->
+  <circle cx="140" cy="170" r="22" class="node-circle" fill="#4fc3f7" stroke="#29b6f6"/>
+  <text x="140" y="170" class="node-label">0</text>
+
+  <circle cx="240" cy="170" r="22" class="node-circle" fill="#4fc3f7" stroke="#29b6f6"/>
+  <text x="240" y="170" class="node-label">1</text>
+
+  <circle cx="190" cy="260" r="22" class="node-circle" fill="#4fc3f7" stroke="#29b6f6"/>
+  <text x="190" y="260" class="node-label">2</text>
+
+  <!-- Bridge nodes (Community 2: orange) -->
+  <circle cx="330" cy="310" r="22" class="node-circle" fill="#ffb74d" stroke="#ffa726"/>
+  <text x="330" y="310" class="node-label">3</text>
+
+  <circle cx="420" cy="280" r="22" class="node-circle" fill="#ffb74d" stroke="#ffa726"/>
+  <text x="420" y="280" class="node-label">4</text>
+
+  <!-- Cluster 2 nodes (Community 1: green) -->
+  <circle cx="510" cy="230" r="22" class="node-circle" fill="#81c784" stroke="#66bb6a"/>
+  <text x="510" y="230" class="node-label">5</text>
+
+  <circle cx="610" cy="160" r="22" class="node-circle" fill="#81c784" stroke="#66bb6a"/>
+  <text x="610" y="160" class="node-label">6</text>
+
+  <circle cx="710" cy="220" r="22" class="node-circle" fill="#81c784" stroke="#66bb6a"/>
+  <text x="710" y="220" class="node-label">7</text>
+
+  <circle cx="680" cy="340" r="22" class="node-circle" fill="#81c784" stroke="#66bb6a"/>
+  <text x="680" y="340" class="node-label">8</text>
+
+  <circle cx="560" cy="370" r="22" class="node-circle" fill="#81c784" stroke="#66bb6a"/>
+  <text x="560" y="370" class="node-label">9</text>
+
+  <!-- Legend -->
+  <rect x="30" y="420" width="740" height="75" rx="8" fill="#16213e" stroke="#2a2a4a" stroke-width="1"/>
+  <circle cx="70" cy="445" r="8" fill="#4fc3f7"/>
+  <text x="85" y="445" class="legend-text" dominant-baseline="central">Community 0: {0, 1, 2} - triangle cluster</text>
+
+  <circle cx="70" cy="470" r="8" fill="#ffb74d"/>
+  <text x="85" y="470" class="legend-text" dominant-baseline="central">Community 2: {3, 4} - bridge pair (too costly to leave each other)</text>
+
+  <circle cx="530" cy="445" r="8" fill="#81c784"/>
+  <text x="545" y="445" class="legend-text" dominant-baseline="central">Community 1: {5, 6, 7, 8, 9} - ring cluster</text>
+
+  <line x1="530" y1="470" x2="560" y2="470" stroke="#ff5252" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <text x="575" y="470" class="legend-text" dominant-baseline="central">Bridge edge (weight 0.5)</text>
+</svg>
+</body>
+</html>

--- a/modules/algorithms/src/main/scala/org/llm4s/algorithms/LeidenAlgorithm.scala
+++ b/modules/algorithms/src/main/scala/org/llm4s/algorithms/LeidenAlgorithm.scala
@@ -26,7 +26,7 @@ object LeidenAlgorithm:
   // ---------------------------------------------------------
   def runLeiden(graph: Graph, maxIterations: Int): Map[Int, Int] =
     import scala.util.boundary, boundary.break
-    var currentGraph = graph
+    var currentGraph                           = graph
     var nodeToCommunity: mutable.Map[Int, Int] = mutable.Map.from((0 until graph.numNodes).map(i => i -> i))
     // Maps original node -> current macro-node ID
     var originalToMacro: Map[Int, Int] = (0 until graph.numNodes).map(i => i -> i).toMap
@@ -46,7 +46,7 @@ object LeidenAlgorithm:
           orig -> subCommToNewId(refinedPartition(macroId))
         }
 
-        currentGraph = aggregateGraph(currentGraph, refinedPartition)
+        currentGraph = aggregateGraph(currentGraph, refinedPartition, subCommToNewId)
         nodeToCommunity = mutable.Map.from(currentGraph.adjList.keys.map(n => n -> n))
 
       originalToMacro.map { case (orig, macroId) => orig -> nodeToCommunity(macroId) }
@@ -55,8 +55,8 @@ object LeidenAlgorithm:
   // Step 1: Local Move Phase
   // ---------------------------------------------------------
   private def localMove(g: Graph, partition: mutable.Map[Int, Int], maxPasses: Int = 10): Unit =
-    val m    = g.totalWeight
-    var pass = 0
+    val m        = g.totalWeight
+    var pass     = 0
     var improved = true
 
     while improved && pass < maxPasses do
@@ -86,13 +86,23 @@ object LeidenAlgorithm:
     partition: mutable.Map[Int, Int],
     m: Double
   ): Double =
-    val k_i  = g.getDegree(node)
-    val k_in = g.adjList(node).collect { case (nb, w) if partition(nb) == targetComm => w }.sum
-    val sum_tot = g.adjList.keys
+    val currentComm = partition(node)
+    val k_i         = g.getDegree(node)
+
+    val k_in_new = g.adjList(node).collect { case (nb, w) if partition(nb) == targetComm => w }.sum
+    val sum_tot_new = g.adjList.keys
       .filter(n => n != node && partition(n) == targetComm)
       .map(g.getDegree)
       .sum
-    (k_in / m) - (k_i * sum_tot) / (2.0 * m * m)
+
+    val k_in_old = g.adjList(node).collect { case (nb, w) if nb != node && partition(nb) == currentComm => w }.sum
+    val sum_tot_old = g.adjList.keys
+      .filter(n => n != node && partition(n) == currentComm)
+      .map(g.getDegree)
+      .sum
+
+    (k_in_new / m - k_i * sum_tot_new / (2.0 * m * m)) -
+      (k_in_old / m - k_i * sum_tot_old / (2.0 * m * m))
 
   // ---------------------------------------------------------
   // Step 2: Refinement Phase (DSU-based connectivity)
@@ -122,13 +132,11 @@ object LeidenAlgorithm:
   // ---------------------------------------------------------
   // Step 3: Aggregation Phase
   // ---------------------------------------------------------
-  private def aggregateGraph(g: Graph, refinedPartition: Map[Int, Int]): Graph =
-    val subCommToNewId = refinedPartition.values.toSet.zipWithIndex.toMap
-    val macroGraph     = Graph(subCommToNewId.size)
-
+  private def aggregateGraph(g: Graph, refinedPartition: Map[Int, Int], subCommToNewId: Map[Int, Int]): Graph =
+    val macroGraph = Graph(subCommToNewId.size)
     for
-      u            <- g.adjList.keys
-      (v, weight)  <- g.adjList(u)
+      u           <- g.adjList.keys
+      (v, weight) <- g.adjList(u)
       if u <= v
     do
       val macroU = subCommToNewId(refinedPartition(u))
@@ -164,6 +172,4 @@ object LeidenAlgorithm:
     val partition = runLeiden(g, 5)
 
     println("\nFinal Community Assignments:")
-    partition.toSeq.sortBy(_._1).foreach { (node, comm) =>
-      println(s"Node $node -> Community $comm")
-    }
+    partition.toSeq.sortBy(_._1).foreach((node, comm) => println(s"Node $node -> Community $comm"))

--- a/modules/algorithms/src/main/scala/org/llm4s/algorithms/LeidenAlgorithm.scala
+++ b/modules/algorithms/src/main/scala/org/llm4s/algorithms/LeidenAlgorithm.scala
@@ -26,8 +26,10 @@ object LeidenAlgorithm:
   // ---------------------------------------------------------
   def runLeiden(graph: Graph, maxIterations: Int): Map[Int, Int] =
     import scala.util.boundary, boundary.break
-    var currentGraph                           = graph
+    var currentGraph = graph
     var nodeToCommunity: mutable.Map[Int, Int] = mutable.Map.from((0 until graph.numNodes).map(i => i -> i))
+    // Maps original node -> current macro-node ID
+    var originalToMacro: Map[Int, Int] = (0 until graph.numNodes).map(i => i -> i).toMap
 
     boundary:
       for _ <- 0 until maxIterations do
@@ -36,12 +38,18 @@ object LeidenAlgorithm:
         val refinedPartition = refinePartition(currentGraph, nodeToCommunity)
 
         if refinedPartition.values.toSet.size == currentGraph.numNodes then
-          break(nodeToCommunity.toMap)
+          break(originalToMacro.map { case (orig, macroId) => orig -> nodeToCommunity(macroId) })
+
+        val subCommToNewId = refinedPartition.values.toSet.zipWithIndex.toMap
+        // Update original -> macro mapping through this aggregation
+        originalToMacro = originalToMacro.map { case (orig, macroId) =>
+          orig -> subCommToNewId(refinedPartition(macroId))
+        }
 
         currentGraph = aggregateGraph(currentGraph, refinedPartition)
         nodeToCommunity = mutable.Map.from(currentGraph.adjList.keys.map(n => n -> n))
 
-      nodeToCommunity.toMap
+      originalToMacro.map { case (orig, macroId) => orig -> nodeToCommunity(macroId) }
 
   // ---------------------------------------------------------
   // Step 1: Local Move Phase

--- a/modules/algorithms/src/main/scala/org/llm4s/algorithms/LeidenAlgorithm.scala
+++ b/modules/algorithms/src/main/scala/org/llm4s/algorithms/LeidenAlgorithm.scala
@@ -1,0 +1,161 @@
+package org.llm4s.algorithms
+
+import scala.collection.mutable
+import scala.util.Random
+
+object LeidenAlgorithm:
+
+  // ---------------------------------------------------------
+  // 1. Graph Data Structure
+  // ---------------------------------------------------------
+  class Graph(val numNodes: Int):
+    val adjList: mutable.Map[Int, mutable.Map[Int, Double]] =
+      mutable.Map.from((0 until numNodes).map(_ -> mutable.Map.empty[Int, Double]))
+    var totalWeight: Double = 0.0
+
+    def addUndirectedEdge(u: Int, v: Int, weight: Double): Unit =
+      adjList(u)(v) = adjList(u).getOrElse(v, 0.0) + weight
+      adjList(v)(u) = adjList(v).getOrElse(u, 0.0) + weight
+      totalWeight += weight
+
+    def getDegree(node: Int): Double =
+      adjList(node).values.sum
+
+  // ---------------------------------------------------------
+  // 2. Main Leiden Execution Loop
+  // ---------------------------------------------------------
+  def runLeiden(graph: Graph, maxIterations: Int): Map[Int, Int] =
+    import scala.util.boundary, boundary.break
+    var currentGraph                           = graph
+    var nodeToCommunity: mutable.Map[Int, Int] = mutable.Map.from((0 until graph.numNodes).map(i => i -> i))
+
+    boundary:
+      for _ <- 0 until maxIterations do
+        localMove(currentGraph, nodeToCommunity)
+
+        val refinedPartition = refinePartition(currentGraph, nodeToCommunity)
+
+        if refinedPartition.values.toSet.size == currentGraph.numNodes then
+          break(nodeToCommunity.toMap)
+
+        currentGraph = aggregateGraph(currentGraph, refinedPartition)
+        nodeToCommunity = mutable.Map.from(currentGraph.adjList.keys.map(n => n -> n))
+
+      nodeToCommunity.toMap
+
+  // ---------------------------------------------------------
+  // Step 1: Local Move Phase
+  // ---------------------------------------------------------
+  private def localMove(g: Graph, partition: mutable.Map[Int, Int], maxPasses: Int = 10): Unit =
+    val m    = g.totalWeight
+    var pass = 0
+    var improved = true
+
+    while improved && pass < maxPasses do
+      improved = false
+      pass += 1
+      for node <- Random.shuffle(g.adjList.keys.toList) do
+        val currentComm   = partition(node)
+        val neighborComms = g.adjList(node).keys.map(partition(_)).toSet
+
+        var bestComm = currentComm
+        var bestGain = 0.0
+
+        for targetComm <- neighborComms if targetComm != currentComm do
+          val gain = computeModularityGain(g, node, targetComm, partition, m)
+          if gain > bestGain then
+            bestGain = gain
+            bestComm = targetComm
+
+        if bestComm != currentComm then
+          partition(node) = bestComm
+          improved = true
+
+  private def computeModularityGain(
+    g: Graph,
+    node: Int,
+    targetComm: Int,
+    partition: mutable.Map[Int, Int],
+    m: Double
+  ): Double =
+    val k_i  = g.getDegree(node)
+    val k_in = g.adjList(node).collect { case (nb, w) if partition(nb) == targetComm => w }.sum
+    val sum_tot = g.adjList.keys
+      .filter(n => n != node && partition(n) == targetComm)
+      .map(g.getDegree)
+      .sum
+    (k_in / m) - (k_i * sum_tot) / (2.0 * m * m)
+
+  // ---------------------------------------------------------
+  // Step 2: Refinement Phase (DSU-based connectivity)
+  // ---------------------------------------------------------
+  private def refinePartition(g: Graph, partition: mutable.Map[Int, Int]): Map[Int, Int] =
+    val parent = mutable.Map.from(g.adjList.keys.map(n => n -> n))
+
+    for
+      node     <- g.adjList.keys
+      neighbor <- g.adjList(node).keys
+      if partition(neighbor) == partition(node)
+    do union(parent, node, neighbor)
+
+    g.adjList.keys.map(n => n -> find(parent, n)).toMap
+
+  private def find(parent: mutable.Map[Int, Int], i: Int): Int =
+    if parent(i) == i then i
+    else
+      val root = find(parent, parent(i))
+      parent(i) = root
+      root
+
+  private def union(parent: mutable.Map[Int, Int], i: Int, j: Int): Unit =
+    val (ri, rj) = (find(parent, i), find(parent, j))
+    if ri != rj then parent(ri) = rj
+
+  // ---------------------------------------------------------
+  // Step 3: Aggregation Phase
+  // ---------------------------------------------------------
+  private def aggregateGraph(g: Graph, refinedPartition: Map[Int, Int]): Graph =
+    val subCommToNewId = refinedPartition.values.toSet.zipWithIndex.toMap
+    val macroGraph     = Graph(subCommToNewId.size)
+
+    for
+      u            <- g.adjList.keys
+      (v, weight)  <- g.adjList(u)
+      if u <= v
+    do
+      val macroU = subCommToNewId(refinedPartition(u))
+      val macroV = subCommToNewId(refinedPartition(v))
+      macroGraph.addUndirectedEdge(macroU, macroV, weight)
+
+    macroGraph
+
+  // ---------------------------------------------------------
+  // 3. Example Driver (two tightly connected clusters)
+  // ---------------------------------------------------------
+  @main def leidenExample(): Unit =
+    val g = Graph(10)
+
+    // Cluster 1 (Nodes 0-4)
+    g.addUndirectedEdge(0, 1, 1.0)
+    g.addUndirectedEdge(0, 2, 1.0)
+    g.addUndirectedEdge(1, 2, 1.0)
+    g.addUndirectedEdge(2, 3, 1.0)
+    g.addUndirectedEdge(3, 4, 1.0)
+
+    // Bridge between clusters
+    g.addUndirectedEdge(4, 5, 0.5)
+
+    // Cluster 2 (Nodes 5-9)
+    g.addUndirectedEdge(5, 6, 1.0)
+    g.addUndirectedEdge(6, 7, 1.0)
+    g.addUndirectedEdge(7, 8, 1.0)
+    g.addUndirectedEdge(8, 9, 1.0)
+    g.addUndirectedEdge(5, 9, 1.0)
+
+    println("Running Leiden Algorithm on custom graph...")
+    val partition = runLeiden(g, 5)
+
+    println("\nFinal Community Assignments:")
+    partition.toSeq.sortBy(_._1).foreach { (node, comm) =>
+      println(s"Node $node -> Community $comm")
+    }

--- a/modules/algorithms/src/main/scala/org/llm4s/algorithms/LeidenAlgorithm.scala
+++ b/modules/algorithms/src/main/scala/org/llm4s/algorithms/LeidenAlgorithm.scala
@@ -49,7 +49,7 @@ object LeidenAlgorithm:
         currentGraph = aggregateGraph(currentGraph, refinedPartition, subCommToNewId)
         nodeToCommunity = mutable.Map.from(currentGraph.adjList.keys.map(n => n -> n))
 
-      originalToMacro.map { case (orig, macroId) => orig -> nodeToCommunity(macroId) }
+      originalToMacro
 
   // ---------------------------------------------------------
   // Step 1: Local Move Phase

--- a/modules/algorithms/src/main/scala/org/llm4s/algorithms/LeidenAlgorithm.scala
+++ b/modules/algorithms/src/main/scala/org/llm4s/algorithms/LeidenAlgorithm.scala
@@ -137,7 +137,7 @@ object LeidenAlgorithm:
     for
       u           <- g.adjList.keys
       (v, weight) <- g.adjList(u)
-      if u <= v
+      if u <= v // <= not <: self-loops (intra-community weight from prior aggregation) must be preserved
     do
       val macroU = subCommToNewId(refinedPartition(u))
       val macroV = subCommToNewId(refinedPartition(v))

--- a/modules/algorithms/src/main/scala/org/llm4s/algorithms/LeidenAlgorithm.scala
+++ b/modules/algorithms/src/main/scala/org/llm4s/algorithms/LeidenAlgorithm.scala
@@ -168,6 +168,20 @@ object LeidenAlgorithm:
     g.addUndirectedEdge(8, 9, 1.0)
     g.addUndirectedEdge(5, 9, 1.0)
 
+    /*
+      0: (1, 1.0), (2, 1.0)
+      1: (0, 1.0), (2, 1.0)
+      2: (0, 1.0), (1, 1.0), (3, 1.0)
+      3: (2, 1.0), (4, 1.0)
+      4: (3, 1.0), (5, 0.5)
+
+      5: (4, 0.5), (6, 1.0), (9, 1.0)
+      6: (5, 1.0), (7, 1.0)
+      7: (6, 1.0), (8, 1.0)
+      8: (7, 1.0), (9, 1.0)
+      9: (8, 1.0), (5, 1.0)
+     */
+
     println("Running Leiden Algorithm on custom graph...")
     val partition = runLeiden(g, 5)
 

--- a/modules/algorithms/src/main/scala/org/llm4s/algorithms/lancedb/DistanceMetric.scala
+++ b/modules/algorithms/src/main/scala/org/llm4s/algorithms/lancedb/DistanceMetric.scala
@@ -1,0 +1,43 @@
+package org.llm4s.algorithms.lancedb
+
+enum DistanceMetric:
+  case L2, Cosine, Dot
+
+object DistanceMetric:
+
+  def compute(metric: DistanceMetric, a: Array[Float], b: Array[Float]): Float =
+    require(a.length == b.length, s"Dimension mismatch: ${a.length} vs ${b.length}")
+    metric match
+      case DistanceMetric.L2     => l2Squared(a, b)
+      case DistanceMetric.Cosine => cosineDistance(a, b)
+      case DistanceMetric.Dot    => negativeDot(a, b)
+
+  def l2Squared(a: Array[Float], b: Array[Float]): Float =
+    var sum = 0.0f
+    var i = 0
+    while i < a.length do
+      val d = a(i) - b(i)
+      sum += d * d
+      i += 1
+    sum
+
+  def cosineDistance(a: Array[Float], b: Array[Float]): Float =
+    var dot = 0.0f
+    var normA = 0.0f
+    var normB = 0.0f
+    var i = 0
+    while i < a.length do
+      dot += a(i) * b(i)
+      normA += a(i) * a(i)
+      normB += b(i) * b(i)
+      i += 1
+    val denom = math.sqrt(normA.toDouble * normB.toDouble).toFloat
+    if denom == 0.0f then 1.0f else 1.0f - dot / denom
+
+  def negativeDot(a: Array[Float], b: Array[Float]): Float =
+    var dot = 0.0f
+    var i = 0
+    while i < a.length do
+      dot += a(i) * b(i)
+      i += 1
+    -dot

--- a/modules/algorithms/src/main/scala/org/llm4s/algorithms/lancedb/IVFIndex.scala
+++ b/modules/algorithms/src/main/scala/org/llm4s/algorithms/lancedb/IVFIndex.scala
@@ -1,0 +1,154 @@
+package org.llm4s.algorithms.lancedb
+
+import scala.collection.mutable
+import scala.util.Random
+
+case class IVFConfig(
+    nPartitions: Int = 256,
+    nProbes: Int = 20,
+    maxKMeansIterations: Int = 50
+)
+
+class IVFIndex(dimension: Int, metric: DistanceMetric, config: IVFConfig):
+
+  private var centroids: Array[Array[Float]] = Array.empty
+  private var partitions: Array[mutable.ArrayBuffer[Int]] = Array.empty
+  private var _trained: Boolean = false
+
+  def isTrained: Boolean = _trained
+
+  def train(vectors: IndexedSeq[Array[Float]], rng: Random = new Random(42)): Unit =
+    require(vectors.nonEmpty, "Cannot train on empty dataset")
+    val k = math.min(config.nPartitions, vectors.size)
+    centroids = kmeans(vectors, k, config.maxKMeansIterations, rng)
+    partitions = Array.fill(centroids.length)(mutable.ArrayBuffer.empty)
+    vectors.indices.foreach: i =>
+      partitions(nearestCentroid(vectors(i))) += i
+    _trained = true
+
+  def search(
+      query: Array[Float],
+      vectors: IndexedSeq[Array[Float]],
+      k: Int,
+      nProbes: Int = config.nProbes
+  ): IndexedSeq[(Int, Float)] =
+    require(_trained, "Index not trained")
+    val probes = math.min(nProbes, centroids.length)
+    val centroidDists = centroids.indices
+      .map(i => (i, DistanceMetric.compute(metric, query, centroids(i))))
+      .sortBy(_._2)
+      .take(probes)
+
+    val candidates = mutable.ArrayBuffer.empty[(Int, Float)]
+    centroidDists.foreach: (pIdx, _) =>
+      partitions(pIdx).foreach: vecIdx =>
+        candidates += ((vecIdx, DistanceMetric.compute(metric, query, vectors(vecIdx))))
+
+    candidates.sortBy(_._2).take(k).toIndexedSeq
+
+  def addVector(index: Int, vector: Array[Float]): Unit =
+    require(_trained, "Index not trained")
+    partitions(nearestCentroid(vector)) += index
+
+  private def nearestCentroid(v: Array[Float]): Int =
+    var best = 0
+    var bestDist = Float.MaxValue
+    var i = 0
+    while i < centroids.length do
+      val d = DistanceMetric.compute(metric, v, centroids(i))
+      if d < bestDist then
+        bestDist = d
+        best = i
+      i += 1
+    best
+
+  // ---- K-means with k-means++ initialization ----
+
+  private def kmeans(
+      vectors: IndexedSeq[Array[Float]],
+      k: Int,
+      maxIter: Int,
+      rng: Random
+  ): Array[Array[Float]] =
+    import scala.util.boundary, boundary.break
+    val centers = kmeansppInit(vectors, k, rng)
+    val assignments = new Array[Int](vectors.size)
+
+    boundary:
+      for _ <- 0 until maxIter do
+        var changed = false
+        vectors.indices.foreach: i =>
+          val c = nearest(vectors(i), centers)
+          if assignments(i) != c then
+            changed = true
+            assignments(i) = c
+
+        if !changed then break(centers)
+
+        centers.indices.foreach: c =>
+          val members = vectors.indices.filter(assignments(_) == c)
+          if members.nonEmpty then
+            val avg = new Array[Float](dimension)
+            members.foreach: i =>
+              var d = 0
+              while d < dimension do
+                avg(d) += vectors(i)(d)
+                d += 1
+            val n = members.size.toFloat
+            var d = 0
+            while d < dimension do
+              avg(d) /= n
+              d += 1
+            centers(c) = avg
+
+      centers
+
+  private def nearest(v: Array[Float], centers: Array[Array[Float]]): Int =
+    var best = 0
+    var bestDist = Float.MaxValue
+    var i = 0
+    while i < centers.length do
+      val d = DistanceMetric.l2Squared(v, centers(i))
+      if d < bestDist then
+        bestDist = d
+        best = i
+      i += 1
+    best
+
+  private def kmeansppInit(
+      vectors: IndexedSeq[Array[Float]],
+      k: Int,
+      rng: Random
+  ): Array[Array[Float]] =
+    val chosen = mutable.ArrayBuffer(rng.nextInt(vectors.size))
+    val minDist = Array.fill(vectors.size)(Float.MaxValue)
+
+    while chosen.size < k do
+      val last = vectors(chosen.last)
+      var i = 0
+      while i < vectors.size do
+        val d = DistanceMetric.l2Squared(vectors(i), last)
+        if d < minDist(i) then minDist(i) = d
+        i += 1
+
+      val total = minDist.foldLeft(0.0)(_ + _.toDouble)
+      if total <= 0.0 then
+        val remaining = vectors.indices.filterNot(chosen.toSet)
+        chosen ++= remaining.take(k - chosen.size)
+        return chosen.take(k).map(i => vectors(i).clone()).toArray
+
+      val r = rng.nextDouble() * total
+      var cum = 0.0
+      var selected = 0
+      var j = 0
+      var found = false
+      while j < vectors.size && !found do
+        cum += minDist(j)
+        if cum >= r then
+          selected = j
+          found = true
+        j += 1
+
+      chosen += selected
+
+    chosen.map(i => vectors(i).clone()).toArray

--- a/modules/algorithms/src/main/scala/org/llm4s/algorithms/lancedb/Model.scala
+++ b/modules/algorithms/src/main/scala/org/llm4s/algorithms/lancedb/Model.scala
@@ -1,0 +1,50 @@
+package org.llm4s.algorithms.lancedb
+
+enum MetadataValue:
+  case StringVal(value: String)
+  case IntVal(value: Int)
+  case LongVal(value: Long)
+  case FloatVal(value: Float)
+  case DoubleVal(value: Double)
+  case BoolVal(value: Boolean)
+
+case class Schema(
+    dimension: Int,
+    metric: DistanceMetric = DistanceMetric.L2
+)
+
+case class VectorRecord(
+    id: Long,
+    vector: Array[Float],
+    metadata: Map[String, MetadataValue] = Map.empty
+):
+  override def toString: String =
+    s"VectorRecord(id=$id, dim=${vector.length}, metadata=$metadata)"
+
+case class SearchResult(
+    record: VectorRecord,
+    distance: Float
+):
+  override def toString: String =
+    s"SearchResult(id=${record.id}, distance=$distance, metadata=${record.metadata})"
+
+type MetadataFilter = Map[String, MetadataValue] => Boolean
+
+object MetadataFilter:
+  def eq(field: String, value: MetadataValue): MetadataFilter =
+    _.get(field).contains(value)
+
+  def neq(field: String, value: MetadataValue): MetadataFilter =
+    !_.get(field).contains(value)
+
+  def in(field: String, values: Set[MetadataValue]): MetadataFilter =
+    _.get(field).exists(values.contains)
+
+  def and(filters: MetadataFilter*): MetadataFilter =
+    m => filters.forall(_(m))
+
+  def or(filters: MetadataFilter*): MetadataFilter =
+    m => filters.exists(_(m))
+
+  def not(f: MetadataFilter): MetadataFilter =
+    m => !f(m)

--- a/modules/algorithms/src/main/scala/org/llm4s/algorithms/lancedb/SearchQuery.scala
+++ b/modules/algorithms/src/main/scala/org/llm4s/algorithms/lancedb/SearchQuery.scala
@@ -1,0 +1,24 @@
+package org.llm4s.algorithms.lancedb
+
+class SearchQuery private[lancedb] (
+    private[lancedb] val table: VectorTable,
+    private[lancedb] val query: Array[Float],
+    private val distanceMetric: DistanceMetric,
+    private val k: Int = 10,
+    private val probes: Int = 20,
+    private val filter: Option[MetadataFilter] = None
+):
+  def limit(n: Int): SearchQuery =
+    new SearchQuery(table, query, distanceMetric, n, probes, filter)
+
+  def metric(m: DistanceMetric): SearchQuery =
+    new SearchQuery(table, query, m, k, probes, filter)
+
+  def nProbes(n: Int): SearchQuery =
+    new SearchQuery(table, query, distanceMetric, k, n, filter)
+
+  def where(f: MetadataFilter): SearchQuery =
+    new SearchQuery(table, query, distanceMetric, k, probes, Some(f))
+
+  def execute(): Seq[SearchResult] =
+    table.executeSearch(query, k, distanceMetric, probes, filter)

--- a/modules/algorithms/src/main/scala/org/llm4s/algorithms/lancedb/VectorDB.scala
+++ b/modules/algorithms/src/main/scala/org/llm4s/algorithms/lancedb/VectorDB.scala
@@ -1,0 +1,24 @@
+package org.llm4s.algorithms.lancedb
+
+import scala.collection.mutable
+
+class VectorDB private (val name: String):
+  private val tables = mutable.Map.empty[String, VectorTable]
+
+  def createTable(name: String, schema: Schema): VectorTable =
+    require(!tables.contains(name), s"Table '$name' already exists")
+    val table = new VectorTable(name, schema)
+    tables(name) = table
+    table
+
+  def openTable(name: String): Option[VectorTable] =
+    tables.get(name)
+
+  def dropTable(name: String): Boolean =
+    tables.remove(name).isDefined
+
+  def tableNames: Seq[String] =
+    tables.keys.toSeq.sorted
+
+object VectorDB:
+  def open(name: String): VectorDB = new VectorDB(name)

--- a/modules/algorithms/src/main/scala/org/llm4s/algorithms/lancedb/VectorTable.scala
+++ b/modules/algorithms/src/main/scala/org/llm4s/algorithms/lancedb/VectorTable.scala
@@ -1,0 +1,82 @@
+package org.llm4s.algorithms.lancedb
+
+import scala.collection.mutable
+
+class VectorTable(val name: String, val schema: Schema):
+
+  private val records = mutable.ArrayBuffer.empty[VectorRecord]
+  private val vectors = mutable.ArrayBuffer.empty[Array[Float]]
+  private var nextId: Long = 0L
+  private var index: Option[IVFIndex] = None
+
+  def size: Int = records.size
+
+  def add(data: Seq[(Array[Float], Map[String, MetadataValue])]): Seq[Long] =
+    data.map: (vector, metadata) =>
+      require(
+        vector.length == schema.dimension,
+        s"Expected dimension ${schema.dimension}, got ${vector.length}"
+      )
+      val id = nextId
+      nextId += 1
+      records += VectorRecord(id, vector, metadata)
+      vectors += vector
+      index.foreach(_.addVector(records.size - 1, vector))
+      id
+
+  def addVectors(vecs: Seq[Array[Float]]): Seq[Long] =
+    add(vecs.map(v => (v, Map.empty[String, MetadataValue])))
+
+  def get(id: Long): Option[VectorRecord] =
+    records.find(_.id == id)
+
+  def delete(ids: Set[Long]): Int =
+    val before = records.size
+    val keep = records.indices.filterNot(i => ids.contains(records(i).id))
+    val keptRecords = keep.map(records(_))
+    val keptVectors = keep.map(vectors(_))
+    records.clear()
+    vectors.clear()
+    records ++= keptRecords
+    vectors ++= keptVectors
+    index = None
+    before - records.size
+
+  def createIndex(config: IVFConfig = IVFConfig()): Unit =
+    require(records.nonEmpty, "Cannot index empty table")
+    val ivf = new IVFIndex(schema.dimension, schema.metric, config)
+    ivf.train(vectors.toIndexedSeq)
+    index = Some(ivf)
+
+  def hasIndex: Boolean = index.isDefined
+
+  def search(query: Array[Float]): SearchQuery =
+    require(
+      query.length == schema.dimension,
+      s"Query dimension ${query.length} != schema dimension ${schema.dimension}"
+    )
+    new SearchQuery(this, query, schema.metric)
+
+  private[lancedb] def executeSearch(
+      query: Array[Float],
+      k: Int,
+      metric: DistanceMetric,
+      nProbes: Int,
+      filter: Option[MetadataFilter]
+  ): Seq[SearchResult] =
+    if records.isEmpty then return Seq.empty
+
+    val ranked: Seq[(Int, Float)] = index match
+      case Some(ivf) =>
+        val overFetch = if filter.isDefined then k * 4 else k
+        ivf.search(query, vectors.toIndexedSeq, overFetch, nProbes)
+      case None =>
+        records.indices
+          .map(i => (i, DistanceMetric.compute(metric, query, vectors(i))))
+          .sortBy(_._2)
+
+    val filtered = filter match
+      case Some(f) => ranked.filter((idx, _) => f(records(idx).metadata))
+      case None    => ranked
+
+    filtered.take(k).map((idx, dist) => SearchResult(records(idx), dist))

--- a/modules/algorithms/src/test/scala/org/llm4s/algorithms/lancedb/VectorDBSpec.scala
+++ b/modules/algorithms/src/test/scala/org/llm4s/algorithms/lancedb/VectorDBSpec.scala
@@ -1,0 +1,353 @@
+package org.llm4s.algorithms.lancedb
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class VectorDBSpec extends AnyFlatSpec with Matchers:
+
+  private def vec(values: Float*): Array[Float] = values.toArray
+
+  // ---- Distance Metrics ----
+
+  "DistanceMetric.l2Squared" should "compute squared Euclidean distance" in {
+    val a = vec(1.0f, 0.0f, 0.0f)
+    val b = vec(0.0f, 1.0f, 0.0f)
+    DistanceMetric.l2Squared(a, b) shouldBe 2.0f
+  }
+
+  it should "return 0 for identical vectors" in {
+    val a = vec(3.0f, 4.0f)
+    DistanceMetric.l2Squared(a, a) shouldBe 0.0f
+  }
+
+  "DistanceMetric.cosineDistance" should "return 0 for identical directions" in {
+    val a = vec(1.0f, 0.0f)
+    val b = vec(2.0f, 0.0f)
+    DistanceMetric.cosineDistance(a, b) shouldBe (0.0f +- 1e-6f)
+  }
+
+  it should "return 1 for orthogonal vectors" in {
+    val a = vec(1.0f, 0.0f)
+    val b = vec(0.0f, 1.0f)
+    DistanceMetric.cosineDistance(a, b) shouldBe (1.0f +- 1e-6f)
+  }
+
+  it should "return 1 for zero vector" in {
+    val a = vec(0.0f, 0.0f)
+    val b = vec(1.0f, 0.0f)
+    DistanceMetric.cosineDistance(a, b) shouldBe 1.0f
+  }
+
+  "DistanceMetric.negativeDot" should "return negated dot product" in {
+    val a = vec(1.0f, 2.0f, 3.0f)
+    val b = vec(4.0f, 5.0f, 6.0f)
+    DistanceMetric.negativeDot(a, b) shouldBe -32.0f
+  }
+
+  "DistanceMetric.compute" should "dispatch to the correct metric" in {
+    val a = vec(1.0f, 0.0f)
+    val b = vec(0.0f, 1.0f)
+    DistanceMetric.compute(DistanceMetric.L2, a, b) shouldBe 2.0f
+    DistanceMetric.compute(DistanceMetric.Cosine, a, b) shouldBe (1.0f +- 1e-6f)
+    DistanceMetric.compute(DistanceMetric.Dot, a, b) shouldBe 0.0f
+  }
+
+  it should "reject dimension mismatches" in {
+    an[IllegalArgumentException] should be thrownBy {
+      DistanceMetric.compute(DistanceMetric.L2, vec(1.0f), vec(1.0f, 2.0f))
+    }
+  }
+
+  // ---- VectorDB ----
+
+  "VectorDB" should "create and open tables" in {
+    val db = VectorDB.open("test")
+    val table = db.createTable("vectors", Schema(4))
+    db.tableNames should contain("vectors")
+    db.openTable("vectors") shouldBe Some(table)
+    db.openTable("nonexistent") shouldBe None
+  }
+
+  it should "reject duplicate table names" in {
+    val db = VectorDB.open("test")
+    db.createTable("t1", Schema(4))
+    an[IllegalArgumentException] should be thrownBy {
+      db.createTable("t1", Schema(4))
+    }
+  }
+
+  it should "drop tables" in {
+    val db = VectorDB.open("test")
+    db.createTable("t1", Schema(4))
+    db.dropTable("t1") shouldBe true
+    db.dropTable("t1") shouldBe false
+    db.tableNames shouldBe empty
+  }
+
+  // ---- VectorTable CRUD ----
+
+  "VectorTable" should "add and retrieve records" in {
+    val table = new VectorTable("test", Schema(3))
+    val ids = table.add(Seq(
+      (vec(1, 0, 0), Map("label" -> MetadataValue.StringVal("a"))),
+      (vec(0, 1, 0), Map("label" -> MetadataValue.StringVal("b")))
+    ))
+    ids shouldBe Seq(0L, 1L)
+    table.size shouldBe 2
+    table.get(0L).map(_.metadata("label")) shouldBe Some(MetadataValue.StringVal("a"))
+    table.get(1L).map(_.metadata("label")) shouldBe Some(MetadataValue.StringVal("b"))
+  }
+
+  it should "add vectors without metadata" in {
+    val table = new VectorTable("test", Schema(3))
+    val ids = table.addVectors(Seq(vec(1, 0, 0), vec(0, 1, 0)))
+    ids shouldBe Seq(0L, 1L)
+    table.get(0L).map(_.metadata) shouldBe Some(Map.empty)
+  }
+
+  it should "reject wrong dimension" in {
+    val table = new VectorTable("test", Schema(3))
+    an[IllegalArgumentException] should be thrownBy {
+      table.add(Seq((vec(1, 0, 0, 0), Map.empty)))
+    }
+  }
+
+  it should "delete records by id" in {
+    val table = new VectorTable("test", Schema(3))
+    table.addVectors(Seq(vec(1, 0, 0), vec(0, 1, 0), vec(0, 0, 1)))
+    table.delete(Set(1L)) shouldBe 1
+    table.size shouldBe 2
+    table.get(1L) shouldBe None
+    table.get(0L) shouldBe defined
+    table.get(2L) shouldBe defined
+  }
+
+  // ---- Brute-force Search ----
+
+  "Brute-force search" should "return nearest neighbors in L2" in {
+    val table = new VectorTable("test", Schema(4))
+    table.addVectors(Seq(
+      vec(1, 0, 0, 0),
+      vec(0, 1, 0, 0),
+      vec(0, 0, 1, 0),
+      vec(0.9f, 0.1f, 0, 0)
+    ))
+    val results = table.search(vec(1, 0, 0, 0)).limit(2).execute()
+    results.size shouldBe 2
+    results.head.record.id shouldBe 0L
+    results.head.distance shouldBe 0.0f
+    results(1).record.id shouldBe 3L
+  }
+
+  it should "return all results when limit exceeds table size" in {
+    val table = new VectorTable("test", Schema(2))
+    table.addVectors(Seq(vec(1, 0), vec(0, 1)))
+    val results = table.search(vec(1, 0)).limit(100).execute()
+    results.size shouldBe 2
+  }
+
+  it should "return empty for empty table" in {
+    val table = new VectorTable("test", Schema(2))
+    val results = table.search(vec(1, 0)).limit(10).execute()
+    results shouldBe empty
+  }
+
+  it should "reject query with wrong dimension" in {
+    val table = new VectorTable("test", Schema(3))
+    an[IllegalArgumentException] should be thrownBy {
+      table.search(vec(1, 0))
+    }
+  }
+
+  // ---- Metadata Filtering ----
+
+  "Metadata filtering" should "filter by equality" in {
+    val table = new VectorTable("test", Schema(3))
+    table.add(Seq(
+      (vec(1, 0, 0), Map("cat" -> MetadataValue.StringVal("A"))),
+      (vec(0.9f, 0.1f, 0), Map("cat" -> MetadataValue.StringVal("B"))),
+      (vec(0.8f, 0.2f, 0), Map("cat" -> MetadataValue.StringVal("A")))
+    ))
+    val results = table.search(vec(1, 0, 0))
+      .where(MetadataFilter.eq("cat", MetadataValue.StringVal("A")))
+      .limit(10)
+      .execute()
+    results.size shouldBe 2
+    results.foreach(_.record.metadata("cat") shouldBe MetadataValue.StringVal("A"))
+  }
+
+  it should "filter with compound predicates" in {
+    val table = new VectorTable("test", Schema(2))
+    table.add(Seq(
+      (vec(1, 0), Map("x" -> MetadataValue.IntVal(1), "y" -> MetadataValue.StringVal("a"))),
+      (vec(0, 1), Map("x" -> MetadataValue.IntVal(2), "y" -> MetadataValue.StringVal("a"))),
+      (vec(1, 1), Map("x" -> MetadataValue.IntVal(1), "y" -> MetadataValue.StringVal("b")))
+    ))
+    val results = table.search(vec(1, 0))
+      .where(MetadataFilter.and(
+        MetadataFilter.eq("x", MetadataValue.IntVal(1)),
+        MetadataFilter.eq("y", MetadataValue.StringVal("a"))
+      ))
+      .limit(10)
+      .execute()
+    results.size shouldBe 1
+    results.head.record.id shouldBe 0L
+  }
+
+  it should "support negation" in {
+    val table = new VectorTable("test", Schema(2))
+    table.add(Seq(
+      (vec(1, 0), Map("cat" -> MetadataValue.StringVal("A"))),
+      (vec(0, 1), Map("cat" -> MetadataValue.StringVal("B")))
+    ))
+    val results = table.search(vec(1, 0))
+      .where(MetadataFilter.not(MetadataFilter.eq("cat", MetadataValue.StringVal("A"))))
+      .limit(10)
+      .execute()
+    results.size shouldBe 1
+    results.head.record.metadata("cat") shouldBe MetadataValue.StringVal("B")
+  }
+
+  // ---- Cosine & Dot Metrics ----
+
+  "Cosine search" should "rank by cosine similarity" in {
+    val table = new VectorTable("test", Schema(3, DistanceMetric.Cosine))
+    table.addVectors(Seq(
+      vec(1, 0, 0),
+      vec(0, 1, 0),
+      vec(0.7f, 0.7f, 0)
+    ))
+    val results = table.search(vec(1, 0, 0)).limit(3).execute()
+    results.head.record.id shouldBe 0L
+    results.head.distance shouldBe (0.0f +- 1e-5f)
+  }
+
+  "Dot product search" should "rank by dot product" in {
+    val table = new VectorTable("test", Schema(3, DistanceMetric.Dot))
+    table.addVectors(Seq(
+      vec(1, 0, 0),
+      vec(10, 0, 0),
+      vec(0, 1, 0)
+    ))
+    val results = table.search(vec(1, 0, 0)).limit(3).execute()
+    results.head.record.id shouldBe 1L
+    results.head.distance shouldBe -10.0f
+  }
+
+  // ---- IVF Index ----
+
+  "IVF index" should "return approximate nearest neighbors" in {
+    val rng = new scala.util.Random(42)
+    val d = 16
+    val table = new VectorTable("test", Schema(d))
+
+    val clusterCenters = Array(
+      Array.fill(d)(0.0f),
+      Array.tabulate(d)(i => if i == 0 then 10.0f else 0.0f),
+      Array.tabulate(d)(i => if i == 1 then 10.0f else 0.0f),
+      Array.tabulate(d)(i => if i == 2 then 10.0f else 0.0f)
+    )
+
+    val vecs = (0 until 1000).map: i =>
+      val center = clusterCenters(i % 4)
+      Array.tabulate(d)(j => center(j) + rng.nextGaussian().toFloat * 0.5f)
+    table.addVectors(vecs)
+
+    table.createIndex(IVFConfig(nPartitions = 8, nProbes = 2))
+    table.hasIndex shouldBe true
+
+    val query = Array.fill(d)(0.0f)
+    val results = table.search(query).limit(10).execute()
+    results.size shouldBe 10
+    results.foreach(_.distance should be < 20.0f)
+  }
+
+  it should "find the exact nearest neighbor with enough probes" in {
+    val table = new VectorTable("test", Schema(4))
+    table.addVectors(Seq(
+      vec(1, 0, 0, 0),
+      vec(0, 1, 0, 0),
+      vec(0, 0, 1, 0),
+      vec(0, 0, 0, 1),
+      vec(0.5f, 0.5f, 0, 0),
+      vec(0.9f, 0.1f, 0, 0)
+    ))
+    table.createIndex(IVFConfig(nPartitions = 2, nProbes = 2))
+
+    val results = table.search(vec(1, 0, 0, 0)).limit(1).execute()
+    results.head.record.id shouldBe 0L
+    results.head.distance shouldBe 0.0f
+  }
+
+  it should "work with metadata filtering post-index" in {
+    val rng = new scala.util.Random(123)
+    val d = 8
+    val table = new VectorTable("test", Schema(d))
+
+    val vecs = (0 until 200).map: i =>
+      val v = Array.tabulate(d)(_ => rng.nextGaussian().toFloat)
+      (v, Map("parity" -> MetadataValue.StringVal(if i % 2 == 0 then "even" else "odd")))
+    table.add(vecs)
+    table.createIndex(IVFConfig(nPartitions = 4, nProbes = 4))
+
+    val query = Array.fill(d)(0.0f)
+    val results = table.search(query)
+      .where(MetadataFilter.eq("parity", MetadataValue.StringVal("even")))
+      .limit(5)
+      .execute()
+    results.size shouldBe 5
+    results.foreach(_.record.metadata("parity") shouldBe MetadataValue.StringVal("even"))
+  }
+
+  // ---- End-to-end ----
+
+  "End-to-end workflow" should "support create, add, index, search, delete" in {
+    val db = VectorDB.open("e2e-test")
+    val table = db.createTable("embeddings", Schema(dimension = 4, metric = DistanceMetric.Cosine))
+
+    val ids = table.add(Seq(
+      (vec(1, 0, 0, 0), Map("text" -> MetadataValue.StringVal("north"))),
+      (vec(0, 1, 0, 0), Map("text" -> MetadataValue.StringVal("east"))),
+      (vec(-1, 0, 0, 0), Map("text" -> MetadataValue.StringVal("south"))),
+      (vec(0, -1, 0, 0), Map("text" -> MetadataValue.StringVal("west"))),
+      (vec(0.7f, 0.7f, 0, 0), Map("text" -> MetadataValue.StringVal("northeast")))
+    ))
+    ids.size shouldBe 5
+
+    val results = table.search(vec(1, 0, 0, 0)).limit(2).execute()
+    results.head.record.metadata("text") shouldBe MetadataValue.StringVal("north")
+    results(1).record.metadata("text") shouldBe MetadataValue.StringVal("northeast")
+
+    table.delete(Set(ids.head))
+    table.size shouldBe 4
+    table.get(ids.head) shouldBe None
+
+    val afterDelete = table.search(vec(1, 0, 0, 0)).limit(1).execute()
+    afterDelete.head.record.metadata("text") shouldBe MetadataValue.StringVal("northeast")
+  }
+
+  // ---- MetadataFilter combinators ----
+
+  "MetadataFilter" should "support in-set filter" in {
+    val filter = MetadataFilter.in("x", Set(MetadataValue.IntVal(1), MetadataValue.IntVal(2)))
+    filter(Map("x" -> MetadataValue.IntVal(1))) shouldBe true
+    filter(Map("x" -> MetadataValue.IntVal(3))) shouldBe false
+    filter(Map.empty) shouldBe false
+  }
+
+  it should "support or combinator" in {
+    val filter = MetadataFilter.or(
+      MetadataFilter.eq("a", MetadataValue.IntVal(1)),
+      MetadataFilter.eq("b", MetadataValue.IntVal(2))
+    )
+    filter(Map("a" -> MetadataValue.IntVal(1))) shouldBe true
+    filter(Map("b" -> MetadataValue.IntVal(2))) shouldBe true
+    filter(Map("a" -> MetadataValue.IntVal(99))) shouldBe false
+  }
+
+  it should "support neq filter" in {
+    val filter = MetadataFilter.neq("x", MetadataValue.IntVal(1))
+    filter(Map("x" -> MetadataValue.IntVal(1))) shouldBe false
+    filter(Map("x" -> MetadataValue.IntVal(2))) shouldBe true
+    filter(Map.empty) shouldBe true
+  }

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -83,6 +83,13 @@ llm4s {
     #   model = "llama3.2"
     #   baseUrl = ${?OLLAMA_LOCAL_BASE_URL}
     # }
+
+    # bedrock-anthropic-main {
+    #   provider = "bedrock-anthropic"
+    #   model = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+    #   baseUrl = ${?AWS_REGION}           # region, defaults to us-east-1
+    #   organization = ${?AWS_PROFILE}     # optional: AWS profile name for credentials
+    # }
   }
 
   # Tracing: Langfuse (app/runners may use these)

--- a/modules/core/src/main/scala/org/llm4s/config/DefaultConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/DefaultConfig.scala
@@ -17,4 +17,5 @@ object DefaultConfig {
   val DEFAULT_LANGFUSE_RELEASE          = "1.0.0"
   val DEFAULT_LANGFUSE_VERSION          = "1.0.0"
   val DEFAULT_AZURE_V2025_01_01_PREVIEW = "V2025_01_01_PREVIEW"
+  val DEFAULT_BEDROCK_ANTHROPIC_REGION  = "us-east-1"
 }

--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
@@ -104,3 +104,6 @@ private[config] object NamedProviderLoader:
         requiredApiKey("llm4s.providers.<name>.apiKey").map: apiKey =>
           val baseUrl = section.baseUrl.map(_.asUrl).getOrElse(MistralConfig.DEFAULT_BASE_URL)
           MistralConfig.fromValues(section.model.asString, apiKey, baseUrl)
+      case ProviderKind.BedrockAnthropic =>
+        val region = section.baseUrl.map(_.asUrl).getOrElse(DefaultConfig.DEFAULT_BEDROCK_ANTHROPIC_REGION)
+        Right(BedrockAnthropicConfig.fromValues(section.model.asString, region))

--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
@@ -105,5 +105,6 @@ private[config] object NamedProviderLoader:
           val baseUrl = section.baseUrl.map(_.asUrl).getOrElse(MistralConfig.DEFAULT_BASE_URL)
           MistralConfig.fromValues(section.model.asString, apiKey, baseUrl)
       case ProviderKind.BedrockAnthropic =>
-        val region = section.baseUrl.map(_.asUrl).getOrElse(DefaultConfig.DEFAULT_BEDROCK_ANTHROPIC_REGION)
-        Right(BedrockAnthropicConfig.fromValues(section.model.asString, region))
+        val region  = section.baseUrl.map(_.asUrl).getOrElse(DefaultConfig.DEFAULT_BEDROCK_ANTHROPIC_REGION)
+        val profile = section.organization
+        Right(BedrockAnthropicConfig.fromValues(section.model.asString, region, profile))

--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderValidator.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderValidator.scala
@@ -133,6 +133,19 @@ private[llm4s] object NamedProviderValidators:
         requireApiKey = true,
       )
 
+  object BedrockAnthropic extends NamedProviderValidator:
+    def validate(
+      providerName: ProviderName,
+      section: RawNamedProviderSection
+    ): Result[NamedProviderConfig] =
+      validateNamedProviderConfig(
+        providerName = providerName,
+        providerKind = ProviderKind.BedrockAnthropic,
+        section = section,
+        requireApiKey = false,
+        requireBaseUrl = true,
+      )
+
   private def validateNamedProviderConfig(
     providerName: ProviderName,
     providerKind: ProviderKind,

--- a/modules/core/src/main/scala/org/llm4s/config/ProviderCapabilities.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/ProviderCapabilities.scala
@@ -42,3 +42,6 @@ private[llm4s] object ProviderCapabilities:
   object Mistral extends ProviderCapabilities:
     val validator: NamedProviderValidator                 = NamedProviderValidators.Mistral
     override val modelLister: Option[ProviderModelLister] = Some(ProviderModelListers.Mistral)
+
+  object BedrockAnthropic extends ProviderCapabilities:
+    val validator: NamedProviderValidator = NamedProviderValidators.BedrockAnthropic

--- a/modules/core/src/main/scala/org/llm4s/config/ProviderCapabilitiesRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/ProviderCapabilitiesRegistry.scala
@@ -21,5 +21,6 @@ private[llm4s] object ProviderCapabilitiesRegistry:
     ProviderKind.Gemini     -> ProviderCapabilities.Gemini,
     ProviderKind.DeepSeek   -> ProviderCapabilities.DeepSeek,
     ProviderKind.Cohere     -> ProviderCapabilities.Cohere,
-    ProviderKind.Mistral    -> ProviderCapabilities.Mistral,
+    ProviderKind.Mistral           -> ProviderCapabilities.Mistral,
+    ProviderKind.BedrockAnthropic  -> ProviderCapabilities.BedrockAnthropic,
   )

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -58,6 +58,8 @@ object LLMConnect {
         CohereClient(cfg, metrics, exchangeLogging)
       case cfg: MistralConfig =>
         MistralClient(cfg, metrics, exchangeLogging)
+      case cfg: BedrockAnthropicConfig =>
+        BedrockAnthropicClient(cfg, metrics, exchangeLogging)
     }
 
   def fromConfig(
@@ -167,7 +169,8 @@ object LLMConnect {
       case (ProviderKind.Gemini, cfg: GeminiConfig)       => GeminiClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.DeepSeek, cfg: DeepSeekConfig)   => DeepSeekClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Cohere, cfg: CohereConfig)       => CohereClient(cfg, metrics, exchangeLogging)
-      case (ProviderKind.Mistral, cfg: MistralConfig)     => MistralClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.Mistral, cfg: MistralConfig)                     => MistralClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.BedrockAnthropic, cfg: BedrockAnthropicConfig) => BedrockAnthropicClient(cfg, metrics, exchangeLogging)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -696,12 +696,13 @@ case class BedrockAnthropicConfig(
   region: String,
   model: String,
   contextWindow: Int,
-  reserveCompletion: Int
+  reserveCompletion: Int,
+  profile: Option[String] = None
 ) extends ProviderConfig:
   override val provider: ProviderKind = ProviderKind.BedrockAnthropic
   override def toString: String =
-    s"BedrockAnthropicConfig(region=$region, model=$model, contextWindow=$contextWindow, " +
-      s"reserveCompletion=$reserveCompletion)"
+    s"BedrockAnthropicConfig(region=$region, model=$model, profile=${profile.getOrElse("default-chain")}, " +
+      s"contextWindow=$contextWindow, reserveCompletion=$reserveCompletion)"
 
 object BedrockAnthropicConfig:
   private val standardReserve = 4096
@@ -714,7 +715,8 @@ object BedrockAnthropicConfig:
 
   def fromValues(
     modelName: String,
-    region: String
+    region: String,
+    profile: Option[String] = None
   )(using resolver: ContextWindowResolver): BedrockAnthropicConfig =
     require(region.trim.nonEmpty, "Bedrock Anthropic region must be non-empty")
     val (cw, rc) = resolver.resolve(
@@ -728,5 +730,6 @@ object BedrockAnthropicConfig:
       region = region,
       model = modelName,
       contextWindow = cw,
-      reserveCompletion = rc
+      reserveCompletion = rc,
+      profile = profile
     )

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -677,3 +677,56 @@ object MistralConfig:
       contextWindow = cw,
       reserveCompletion = rc
     )
+
+/**
+ * Configuration for Anthropic Claude models accessed via AWS Bedrock.
+ *
+ * Authentication uses the AWS Default Credential Provider Chain (environment
+ * variables, `~/.aws/credentials`, IAM roles, etc.) — no explicit API key is
+ * required. Prefer [[BedrockAnthropicConfig.fromValues]] over the primary
+ * constructor; it resolves `contextWindow` and `reserveCompletion` from the
+ * model name automatically.
+ *
+ * @param region           AWS region hosting the Bedrock endpoint, e.g. `"us-east-1"`.
+ * @param model            Bedrock model identifier, e.g. `"anthropic.claude-3-5-sonnet-20241022-v2:0"`.
+ * @param contextWindow    Model's total token capacity (prompt + completion combined).
+ * @param reserveCompletion Tokens held back from prompt history for the completion.
+ */
+case class BedrockAnthropicConfig(
+  region: String,
+  model: String,
+  contextWindow: Int,
+  reserveCompletion: Int
+) extends ProviderConfig:
+  override val provider: ProviderKind = ProviderKind.BedrockAnthropic
+  override def toString: String =
+    s"BedrockAnthropicConfig(region=$region, model=$model, contextWindow=$contextWindow, " +
+      s"reserveCompletion=$reserveCompletion)"
+
+object BedrockAnthropicConfig:
+  private val standardReserve = 4096
+
+  private def bedrockAnthropicFallback(modelName: String): (Int, Int) =
+    modelName match
+      case name if name.contains("claude-3")       => (200000, standardReserve)
+      case name if name.contains("claude-instant") => (100000, standardReserve)
+      case _                                       => (200000, standardReserve)
+
+  def fromValues(
+    modelName: String,
+    region: String
+  )(using resolver: ContextWindowResolver): BedrockAnthropicConfig =
+    require(region.trim.nonEmpty, "Bedrock Anthropic region must be non-empty")
+    val (cw, rc) = resolver.resolve(
+      lookupProviders = Seq("bedrock", "anthropic"),
+      modelName = modelName,
+      defaultContextWindow = 200000,
+      defaultReserve = standardReserve,
+      fallbackResolver = bedrockAnthropicFallback
+    )
+    BedrockAnthropicConfig(
+      region = region,
+      model = modelName,
+      contextWindow = cw,
+      reserveCompletion = rc
+    )

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicMessageSupport.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicMessageSupport.scala
@@ -1,0 +1,181 @@
+package org.llm4s.llmconnect.provider
+
+import com.anthropic.core.ObjectMappers
+import com.anthropic.models.messages.{
+  Message,
+  MessageCreateParams,
+  RawMessageStreamEvent,
+  Tool
+}
+
+import org.llm4s.llmconnect.model.*
+import org.llm4s.model.ModelRegistryService
+import org.llm4s.toolapi.{ ObjectSchema, ToolFunction }
+
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Shared protocol logic for Anthropic-compatible clients (direct API and Bedrock).
+ *
+ * Encapsulates message format conversion, tool schema sanitization, response
+ * parsing, and serialization helpers that are identical regardless of transport.
+ */
+private[provider] trait AnthropicMessageSupport:
+
+  protected def registryService: ModelRegistryService
+  private given ModelRegistryService = registryService
+
+  private[provider] def addMessagesToParams(
+    conversation: Conversation,
+    paramsBuilder: MessageCreateParams.Builder
+  ): Unit =
+    var hasSystemMessage = false
+
+    conversation.messages.foreach {
+      case SystemMessage(content) =>
+        paramsBuilder.system(content)
+        hasSystemMessage = true
+
+      case UserMessage(content) =>
+        paramsBuilder.addUserMessage(content)
+
+      case AssistantMessage(contentOpt, toolCalls) =>
+        if (toolCalls.isEmpty) {
+          paramsBuilder.addAssistantMessage(contentOpt.getOrElse(""))
+        }
+
+      case ToolMessage(content, toolCallId) =>
+        paramsBuilder.addUserMessage(s"[Tool result for $toolCallId]: $content")
+    }
+
+    if (!hasSystemMessage) {
+      paramsBuilder.system("You are Claude, a helpful AI assistant.")
+    }
+
+  private[provider] def convertToolToAnthropicTool(toolFunction: ToolFunction[_, _]): Tool =
+    val objectSchema = toolFunction.schema.asInstanceOf[ObjectSchema[_]]
+    val jsonSchemaStr = objectSchema.toJsonSchema(false).render()
+
+    val jsonNode = ujson.read(jsonSchemaStr)
+
+    jsonNode.obj.remove("strict")
+    jsonNode.obj.remove("additionalProperties")
+
+    stripAdditionalProperties(jsonNode)
+
+    val sanitizedSchemaStr = jsonNode.render()
+    val jsonSchema: com.anthropic.core.JsonObject =
+      ObjectMappers.jsonMapper().readValue(sanitizedSchemaStr, classOf[com.anthropic.core.JsonObject])
+    val jsonSchemaMap = jsonSchema.values()
+
+    val inputSchemaBuilder = Tool.InputSchema.builder()
+    val propertiesValue    = jsonSchemaMap.get("properties")
+    if (propertiesValue != null) {
+      val propertiesObj = ObjectMappers
+        .jsonMapper()
+        .readValue(
+          ObjectMappers.jsonMapper().writeValueAsString(propertiesValue),
+          classOf[Tool.InputSchema.Properties]
+        )
+      inputSchemaBuilder.properties(propertiesObj)
+    }
+
+    Tool
+      .builder()
+      .name(toolFunction.name)
+      .description(toolFunction.description)
+      .inputSchema(inputSchemaBuilder.build().validate())
+      .build()
+
+  private[provider] def stripAdditionalProperties(json: ujson.Value): Unit =
+    json match {
+      case obj: ujson.Obj =>
+        obj.value.remove("additionalProperties")
+        obj.value.get("properties").foreach(props => props.obj.values.foreach(stripAdditionalProperties))
+        obj.value.get("items").foreach(stripAdditionalProperties)
+        Seq("anyOf", "oneOf", "allOf").foreach { key =>
+          obj.value.get(key).foreach(arr => arr.arr.foreach(stripAdditionalProperties))
+        }
+      case _ =>
+    }
+
+  private[provider] def convertFromAnthropicResponse(response: Message, modelName: String): Completion =
+    val contentBlocks = response.content().asScala.toList
+
+    val textContent: Option[String] =
+      val texts = contentBlocks.filter(_.isText).map(_.asText().text())
+      if (texts.nonEmpty) Some(texts.mkString) else None
+
+    val thinkingContent: Option[String] =
+      val thinkingTexts = contentBlocks.filter(_.isThinking).map(_.asThinking().thinking())
+      if (thinkingTexts.nonEmpty) Some(thinkingTexts.mkString) else None
+
+    val toolCalls = extractToolCalls(response)
+    val message   = AssistantMessage(contentOpt = textContent, toolCalls = toolCalls)
+
+    val usage = response.usage()
+
+    val cachedTokens: Option[Int] =
+      Option(usage.cacheReadInputTokens())
+        .filter(_.isPresent)
+        .map(_.get().toInt)
+
+    val cacheCreationTokens: Option[Int] =
+      Option(usage.cacheCreationInputTokens())
+        .filter(_.isPresent)
+        .map(_.get().toInt)
+
+    val tokenUsage = TokenUsage(
+      promptTokens = usage.inputTokens().toInt,
+      completionTokens = usage.outputTokens().toInt,
+      totalTokens = (usage.inputTokens() + usage.outputTokens()).toInt,
+      cachedTokens = cachedTokens,
+      cacheCreationTokens = cacheCreationTokens
+    )
+
+    val cost = CostEstimator.estimate(modelName, tokenUsage)
+
+    Completion(
+      id = response.id(),
+      content = message.content,
+      model = response.model().asString(),
+      toolCalls = toolCalls.toList,
+      created = System.currentTimeMillis() / 1000,
+      message = message,
+      usage = Some(tokenUsage),
+      thinking = thinkingContent,
+      estimatedCost = cost
+    )
+
+  private[provider] def extractToolCalls(response: Message): Seq[ToolCall] =
+    response.content().asScala.toList.filter(_.isToolUse).map { cb =>
+      val toolUse   = cb.asToolUse()
+      val toolId    = toolUse.id()
+      val toolName  = toolUse.name()
+      val rawParams = toolUse._input()
+      val arguments = ujson.read(ObjectMappers.jsonMapper().writeValueAsString(rawParams))
+
+      ToolCall(
+        id = toolId,
+        name = toolName,
+        arguments = arguments
+      )
+    }
+
+  private[provider] def clampBudgetTokens(budgetTokens: Int, maxTokens: Int): Int =
+    math.max(1024, math.min(budgetTokens, maxTokens - 1))
+
+  private[provider] def applySamplingParameters(
+    builder: MessageCreateParams.Builder,
+    options: CompletionOptions
+  ): Unit =
+    builder.temperature(options.temperature.floatValue())
+
+  private[provider] def serializeRequestBody(params: MessageCreateParams): String =
+    ObjectMappers.jsonMapper().writeValueAsString(params._body())
+
+  private[provider] def serializeResponseBody(message: Message): String =
+    ObjectMappers.jsonMapper().writeValueAsString(message)
+
+  private[provider] def serializeStreamEvent(event: RawMessageStreamEvent): String =
+    ObjectMappers.jsonMapper().writeValueAsString(event)

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/BedrockAnthropicClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/BedrockAnthropicClient.scala
@@ -7,6 +7,7 @@ import com.anthropic.models.messages.{
   RawMessageStreamEvent,
   ThinkingConfigEnabled
 }
+import software.amazon.awssdk.auth.credentials.{ AwsCredentialsProvider, DefaultCredentialsProvider, ProfileCredentialsProvider }
 import software.amazon.awssdk.regions.Region
 
 import scala.collection.mutable
@@ -50,12 +51,22 @@ class BedrockAnthropicClient(
 
   private val providerConfig: ProviderConfig = config
 
+  private val credentialsProvider: AwsCredentialsProvider = config.profile match {
+    case Some(profile) =>
+      ProfileCredentialsProvider.builder()
+        .profileName(profile)
+        .build()
+    case None =>
+      DefaultCredentialsProvider.create()
+  }
+
   private val client = AnthropicOkHttpClient
     .builder()
     .backend(
       BedrockBackend
         .builder()
         .region(Region.of(config.region))
+        .awsCredentialsProvider(credentialsProvider)
         .build()
     )
     .build()

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/BedrockAnthropicClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/BedrockAnthropicClient.scala
@@ -1,15 +1,18 @@
 package org.llm4s.llmconnect.provider
+
+import com.anthropic.bedrock.backends.BedrockBackend
 import com.anthropic.client.okhttp.AnthropicOkHttpClient
 import com.anthropic.models.messages.{
   MessageCreateParams,
   RawMessageStreamEvent,
   ThinkingConfigEnabled
 }
+import software.amazon.awssdk.regions.Region
 
 import scala.collection.mutable
 import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.ProviderExchangeLogging
-import org.llm4s.llmconnect.config.{ AnthropicConfig, ProviderConfig }
+import org.llm4s.llmconnect.config.{ BedrockAnthropicConfig, ProviderConfig }
 import org.llm4s.llmconnect.model.*
 import org.llm4s.llmconnect.provider.ProviderResultOps.*
 import org.llm4s.llmconnect.streaming.*
@@ -22,70 +25,43 @@ import java.time.Instant
 import scala.util.Try
 
 /**
- * [[LLMClient]] implementation for Anthropic Claude models.
+ * [[org.llm4s.llmconnect.LLMClient]] implementation for Anthropic Claude
+ * models accessed through AWS Bedrock.
  *
- * Uses the official Anthropic Java SDK (`AnthropicOkHttpClient`) for all
- * API calls. SDK exceptions are mapped to the appropriate [[org.llm4s.error.LLMError]]
- * subtypes before being returned.
+ * Uses the Anthropic Java SDK's Bedrock transport (`AnthropicBedrockOkHttpClient`)
+ * which authenticates via the AWS Default Credential Provider Chain. No explicit
+ * API key is required — credentials are resolved from environment variables,
+ * `~/.aws/credentials`, IAM roles, etc.
  *
- * == Message format adaptations ==
+ * Message format adaptations and streaming event handling are identical to
+ * [[AnthropicClient]]; both mix in [[AnthropicMessageSupport]] for shared logic.
  *
- * The Anthropic Messages API differs from the OpenAI convention in several
- * ways that this client handles transparently:
- *
- *  - **Default system prompt**: if the conversation contains no
- *    `SystemMessage`, the client injects `"You are Claude, a helpful AI
- *    assistant."` automatically. Supply an explicit `SystemMessage` to
- *    override this.
- *
- *  - **Tool results as user messages**: the Anthropic API does not accept
- *    native tool-result messages in the same turn structure as OpenAI.
- *    `ToolMessage` values are therefore forwarded as user messages with
- *    the prefix `"[Tool result for <toolCallId>]: "`.
- *
- *  - **Assistant messages with tool calls are skipped**: when an
- *    `AssistantMessage` carries pending tool calls, it is not forwarded —
- *    Anthropic infers the assistant turn from the subsequent tool-result
- *    user messages.
- *
- *  - **Schema sanitisation**: OpenAI-specific fields (`strict`,
- *    `additionalProperties`) are stripped from tool schemas before sending,
- *    because Anthropic's API rejects them.
- *
- * == Extended thinking ==
- *
- * When `CompletionOptions.reasoning` is set, a `thinking` block is added
- * to the request. The token budget is clamped to `[1024, maxTokens - 1]`
- * to satisfy the Anthropic API constraint; the effective budget may
- * therefore differ from what was requested.
- *
- * `maxTokens` defaults to 2048 when not set in `CompletionOptions` because
- * the Anthropic API requires the field.
- *
- * @param config  `AnthropicConfig` carrying the API key, model name, and base URL.
+ * @param config  `BedrockAnthropicConfig` carrying the region and model name.
  * @param metrics Receives per-call latency and token-usage events.
  *                Defaults to `MetricsCollector.noop`.
  */
-class AnthropicClient(
-  config: AnthropicConfig,
+class BedrockAnthropicClient(
+  config: BedrockAnthropicConfig,
   protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop,
   exchangeLogging: ProviderExchangeLogging = ProviderExchangeLogging.Disabled
 )(using val registryService: ModelRegistryService)
     extends BaseLifecycleLLMClient
     with AnthropicMessageSupport {
 
-  // Store config for budget calculations
   private val providerConfig: ProviderConfig = config
 
-  // Initialize Anthropic client
   private val client = AnthropicOkHttpClient
     .builder()
-    .apiKey(config.apiKey)
-    .baseUrl(config.baseUrl)
+    .backend(
+      BedrockBackend
+        .builder()
+        .region(Region.of(config.region))
+        .build()
+    )
     .build()
 
-  protected def clientDescription: String = s"Anthropic client for model ${config.model}"
-  protected def providerName: String      = "anthropic"
+  protected def clientDescription: String = s"Bedrock Anthropic client for model ${config.model}"
+  protected def providerName: String      = "bedrock-anthropic"
   protected def modelName: String         = config.model
 
   override def complete(
@@ -93,7 +69,6 @@ class AnthropicClient(
     options: CompletionOptions
   ): Result[Completion] = completeWithMetrics {
     val startedAt = Instant.now()
-    // Transform options and messages for model-specific constraints
     TransformationResult
       .transform(
         config.model,
@@ -105,19 +80,14 @@ class AnthropicClient(
       .flatMap { transformed =>
         val transformedConversation = conversation.copy(messages = transformed.messages)
 
-        // Create message parameters builder
         val paramsBuilder = MessageCreateParams
           .builder()
           .model(config.model)
         applySamplingParameters(paramsBuilder, transformed.options)
 
-        // Add max tokens if specified
-        // max tokens is required by the api
         val maxTokens = transformed.options.maxTokens.getOrElse(2048)
         paramsBuilder.maxTokens(maxTokens)
 
-        // Add extended thinking configuration if requested
-        // Minimum budget is 1024 tokens, must be less than max_tokens
         transformed.options.effectiveBudgetTokens.foreach { budgetTokens =>
           val effectiveBudget = clampBudgetTokens(budgetTokens, maxTokens)
           paramsBuilder.thinking(
@@ -125,23 +95,19 @@ class AnthropicClient(
           )
         }
 
-        // Add tools if specified
         if (transformed.options.tools.nonEmpty) {
           transformed.options.tools.foreach(tool => paramsBuilder.addTool(convertToolToAnthropicTool(tool)))
         }
 
-        // Add messages from conversation
         addMessagesToParams(transformedConversation, paramsBuilder)
 
-        // Build the parameters
         val messageParams = paramsBuilder.build()
         val requestBody   = serializeRequestBody(messageParams)
 
         val messageService = client.messages()
-        // Make API call
         val attempt = Try(messageService.create(messageParams)).toEither.left.map {
-          case e: com.anthropic.errors.UnauthorizedException         => AuthenticationError("anthropic", e.getMessage)
-          case _: com.anthropic.errors.RateLimitException            => RateLimitError("anthropic")
+          case e: com.anthropic.errors.UnauthorizedException         => AuthenticationError("bedrock-anthropic", e.getMessage)
+          case _: com.anthropic.errors.RateLimitException            => RateLimitError("bedrock-anthropic")
           case e: com.anthropic.errors.AnthropicInvalidDataException => ValidationError("input", e.getMessage)
           case e: Exception                                          => e.toLLMError
         }
@@ -156,37 +122,12 @@ class AnthropicClient(
       }
   }
 
-  /*
-curl https://api.anthropic.com/v1/messages \
-     --header "x-api-key: $ANTHROPIC_API_KEY" \
-     --header "anthropic-version: 2023-06-01" \
-     --header "content-type: application/json" \
-     --data \
-'{
-    "model": "claude-3-7-sonnet-20250219",
-    "max_tokens": 1024,
-    "tools": [{
-        "name": "get_weather",
-        "description": "Get the current weather in a given location",
-        "input_schema": {
-          "type":"object",
-          "properties":{
-            "location":{"type":"string","description":"City and country e.g. Bogotá, Colombia"},
-            "units":{"type":"string","description":"Units the temperature will be returned in.","enum":["celsius","fahrenheit"]}
-          },
-          "additionalProperties": {}
-        }
-    }],
-    "messages": [{"role": "user", "content": "What is the weather like in San Francisco?"}]
-}'
-   */
   override def streamComplete(
     conversation: Conversation,
     options: CompletionOptions = CompletionOptions(),
     onChunk: StreamedChunk => Unit
   ): Result[Completion] = completeWithMetrics {
     val startedAt = Instant.now()
-    // Transform options and messages for model-specific constraints
     TransformationResult
       .transform(
         config.model,
@@ -198,17 +139,14 @@ curl https://api.anthropic.com/v1/messages \
       .flatMap { transformed =>
         val transformedConversation = conversation.copy(messages = transformed.messages)
 
-        // Build parameters
         val paramsBuilder = MessageCreateParams
           .builder()
           .model(config.model)
         applySamplingParameters(paramsBuilder, transformed.options)
 
-        // Add max tokens if specified (required by the API)
         val maxTokens = transformed.options.maxTokens.getOrElse(2048)
         paramsBuilder.maxTokens(maxTokens)
 
-        // Add extended thinking configuration if requested
         transformed.options.effectiveBudgetTokens.foreach { budgetTokens =>
           val effectiveBudget = clampBudgetTokens(budgetTokens, maxTokens)
           paramsBuilder.thinking(
@@ -216,22 +154,19 @@ curl https://api.anthropic.com/v1/messages \
           )
         }
 
-        // Add tools if specified
         if (transformed.options.tools.nonEmpty)
           transformed.options.tools.foreach(t => paramsBuilder.addTool(convertToolToAnthropicTool(t)))
-        // Add messages from conversation
+
         addMessagesToParams(transformedConversation, paramsBuilder)
-        // Build the parameters
+
         val messageParams = paramsBuilder.build()
         val requestBody   = serializeRequestBody(messageParams)
 
-        // Create accumulator for building the final completion
         val accumulator                      = StreamingAccumulator.create()
         var currentMessageId: Option[String] = None
         val blockIndexToToolId               = mutable.Map.empty[Long, String]
         val rawStream                        = StringBuilder()
 
-        // Process the stream
         val attempt = Try {
           val messageService = client.messages()
           val streamResponse = messageService.createStreaming(messageParams)
@@ -241,21 +176,18 @@ curl https://api.anthropic.com/v1/messages \
           val loopTry = Try {
             stream.foreach { event =>
               rawStream.append(serializeStreamEvent(event)).append('\n')
-              // Process different event types using the event's accessor methods
-              // Check for message start event
+
               val messageStartOpt = event.messageStart()
               if (messageStartOpt != null && messageStartOpt.isPresent) {
                 val msgStart = messageStartOpt.get()
                 currentMessageId = Some(msgStart.message().id())
               }
 
-              // Check for content block delta event
               val contentDeltaOpt = event.contentBlockDelta()
               if (contentDeltaOpt != null && contentDeltaOpt.isPresent) {
                 val contentDelta = contentDeltaOpt.get()
                 val delta        = contentDelta.delta()
 
-                // Handle text content delta
                 Try(delta.text()).foreach { textOpt =>
                   if (textOpt != null && textOpt.isPresent) {
                     val textDelta = textOpt.get()
@@ -273,7 +205,6 @@ curl https://api.anthropic.com/v1/messages \
                   }
                 }
 
-                // Handle thinking content delta
                 Try(delta.thinking()).foreach { thinkingOpt =>
                   if (thinkingOpt != null && thinkingOpt.isPresent) {
                     val thinkingDelta = thinkingOpt.get()
@@ -292,7 +223,6 @@ curl https://api.anthropic.com/v1/messages \
                   }
                 }
 
-                // Handle input_json_delta for tool call arguments
                 Try(delta.inputJson()).foreach { inputJsonOpt =>
                   if (inputJsonOpt != null && inputJsonOpt.isPresent) {
                     val fragment   = inputJsonOpt.get().partialJson()
@@ -364,13 +294,12 @@ curl https://api.anthropic.com/v1/messages \
           loopTry.get
         }.toEither.left
           .map {
-            case e: com.anthropic.errors.UnauthorizedException         => AuthenticationError("anthropic", e.getMessage)
-            case _: com.anthropic.errors.RateLimitException            => RateLimitError("anthropic")
+            case e: com.anthropic.errors.UnauthorizedException         => AuthenticationError("bedrock-anthropic", e.getMessage)
+            case _: com.anthropic.errors.RateLimitException            => RateLimitError("bedrock-anthropic")
             case e: com.anthropic.errors.AnthropicInvalidDataException => ValidationError("input", e.getMessage)
             case e: Exception                                          => e.toLLMError
           }
 
-        // Return the accumulated completion
         attempt
           .flatMap(_ =>
             accumulator.toCompletion.map { c =>
@@ -390,10 +319,8 @@ curl https://api.anthropic.com/v1/messages \
 
   override def getReserveCompletion(): Int = providerConfig.reserveCompletion
 
-
   override protected def releaseResources(): Unit =
     client.close()
-
 
   private def recordExchange(
     startedAt: Instant,
@@ -412,29 +339,19 @@ curl https://api.anthropic.com/v1/messages \
     )
 }
 
-object AnthropicClient {
+object BedrockAnthropicClient {
   import org.llm4s.types.TryOps
 
-  /**
-   * Constructs an [[AnthropicClient]], wrapping any construction-time
-   * exception in a `Left`.
-   *
-   * @param config  `AnthropicConfig` with API key, model, and base URL.
-   * @param metrics Receives per-call latency and token-usage events.
-   *                Defaults to `MetricsCollector.noop`.
-   * @return `Right(client)` on success; `Left(LLMError)` if the underlying
-   *         SDK client cannot be initialised.
-   */
   def apply(
-    config: AnthropicConfig,
+    config: BedrockAnthropicConfig,
     metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop
-  )(using ModelRegistryService): Result[AnthropicClient] =
-    Try(new AnthropicClient(config, metrics)).toResult
+  )(using ModelRegistryService): Result[BedrockAnthropicClient] =
+    Try(new BedrockAnthropicClient(config, metrics)).toResult
 
   def apply(
-    config: AnthropicConfig,
+    config: BedrockAnthropicConfig,
     metrics: org.llm4s.metrics.MetricsCollector,
     exchangeLogging: ProviderExchangeLogging
-  )(using ModelRegistryService): Result[AnthropicClient] =
-    Try(new AnthropicClient(config, metrics, exchangeLogging)).toResult
+  )(using ModelRegistryService): Result[BedrockAnthropicClient] =
+    Try(new BedrockAnthropicClient(config, metrics, exchangeLogging)).toResult
 }

--- a/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
+++ b/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
@@ -35,6 +35,7 @@ object ProviderModelTypes:
     case DeepSeek
     case Cohere
     case Mistral
+    case BedrockAnthropic
 
   object ProviderKind:
     val all: Seq[ProviderKind] = Seq(
@@ -47,7 +48,8 @@ object ProviderModelTypes:
       ProviderKind.Gemini,
       ProviderKind.DeepSeek,
       ProviderKind.Cohere,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.BedrockAnthropic
     )
 
     def fromString(value: String): Option[ProviderKind] =
@@ -62,8 +64,9 @@ object ProviderModelTypes:
         case "google"     => Some(ProviderKind.Gemini)
         case "deepseek"   => Some(ProviderKind.DeepSeek)
         case "cohere"     => Some(ProviderKind.Cohere)
-        case "mistral"    => Some(ProviderKind.Mistral)
-        case _            => None
+        case "mistral"            => Some(ProviderKind.Mistral)
+        case "bedrock-anthropic"  => Some(ProviderKind.BedrockAnthropic)
+        case _                    => None
 
     def fromName(value: String): Option[ProviderKind] =
       fromString(value)
@@ -80,4 +83,5 @@ object ProviderModelTypes:
         case ProviderKind.Gemini     => "gemini"
         case ProviderKind.DeepSeek   => "deepseek"
         case ProviderKind.Cohere     => "cohere"
-        case ProviderKind.Mistral    => "mistral"
+        case ProviderKind.Mistral           => "mistral"
+        case ProviderKind.BedrockAnthropic => "bedrock-anthropic"

--- a/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 class ProviderKindSpec extends AnyFlatSpec with Matchers:
 
   "ProviderKind" should "expose all expected provider instances" in {
-    ProviderKind.all should have size 10
+    ProviderKind.all should have size 11
     (ProviderKind.all should contain).allOf(
       ProviderKind.OpenAI,
       ProviderKind.Azure,
@@ -18,7 +18,8 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       ProviderKind.Gemini,
       ProviderKind.Cohere,
       ProviderKind.DeepSeek,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.BedrockAnthropic
     )
   }
 
@@ -70,8 +71,9 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       case ProviderKind.Zai        => "cloud-zai"
       case ProviderKind.Gemini     => "cloud-gemini"
       case ProviderKind.DeepSeek   => "cloud-deepseek"
-      case ProviderKind.Cohere     => "cloud-cohere"
-      case ProviderKind.Mistral    => "cloud-mistral"
+      case ProviderKind.Cohere           => "cloud-cohere"
+      case ProviderKind.Mistral          => "cloud-mistral"
+      case ProviderKind.BedrockAnthropic => "cloud-bedrock-anthropic"
 
     describe(ProviderKind.OpenAI) shouldBe "cloud-openai"
     describe(ProviderKind.Ollama) shouldBe "local"

--- a/modules/samples/src/main/resources/application.conf
+++ b/modules/samples/src/main/resources/application.conf
@@ -13,6 +13,23 @@ llm4s {
       baseUrl = "http://localhost:11434"
       baseUrl = ${?OLLAMA_BASE_URL}
     }
+
+    # AWS Bedrock Anthropic provider.
+    # Uses AWS credential profile or Default Credential Provider Chain.
+    # Activate with: export LLM4S_PROVIDER=bedrock-anthropic-main
+    bedrock-anthropic-main {
+      provider = "bedrock-anthropic"
+      model = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+      model = ${?BEDROCK_MODEL}
+
+      # AWS region; baseUrl is reused as the region field for this provider.
+      baseUrl = "us-west-2"
+      baseUrl = ${?AWS_REGION}
+
+      # AWS profile name from ~/.aws/credentials; organization field carries this value.
+      # If omitted, falls back to DefaultCredentialsProvider chain (env vars, instance role, etc).
+      # organization = ${?AWS_PROFILE}
+    }
   }
 
   exchangeLogging {

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/BedrockAnthropicExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/BedrockAnthropicExample.scala
@@ -40,7 +40,7 @@ object BedrockAnthropicExample {
     )
 
     val result = for {
-      providerCfg     <- Llm4sConfig.defaultProvider()
+      providerCfg     <- Llm4sConfig.provider("bedrock-anthropic-main")
       registryService <- Llm4sConfig.modelRegistryService()
       given org.llm4s.model.ModelRegistryService = registryService
       client     <- LLMConnect.getClient(providerCfg)

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/BedrockAnthropicExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/BedrockAnthropicExample.scala
@@ -1,0 +1,74 @@
+package org.llm4s.samples.basic
+
+import org.llm4s.config.Llm4sConfig
+import org.llm4s.llmconnect.LLMConnect
+import org.llm4s.llmconnect.model._
+import org.slf4j.LoggerFactory
+
+/**
+ * Demonstrates using Anthropic Claude models via AWS Bedrock.
+ *
+ * Authentication uses the AWS Default Credential Provider Chain — no explicit
+ * API key is needed. Credentials are resolved from (in order):
+ *  1. Environment variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN
+ *  2. ~/.aws/credentials profile
+ *  3. IAM instance role (EC2/ECS/Lambda)
+ *
+ * To run this example:
+ * {{{
+ * # Ensure AWS credentials are available, then:
+ * export LLM4S_PROVIDER=bedrock-anthropic-main
+ *
+ * # Optionally override the model (default: anthropic.claude-3-5-sonnet-20241022-v2:0)
+ * export BEDROCK_MODEL=anthropic.claude-3-5-sonnet-20241022-v2:0
+ *
+ * # Optionally override the region (default: us-east-1)
+ * export AWS_REGION=us-west-2
+ *
+ * sbt "samples/runMain org.llm4s.samples.basic.BedrockAnthropicExample"
+ * }}}
+ */
+object BedrockAnthropicExample {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  def main(args: Array[String]): Unit = {
+    val conversation = Conversation(
+      Seq(
+        SystemMessage("You are a concise assistant."),
+        UserMessage("Explain the difference between val and var in Scala in two sentences.")
+      )
+    )
+
+    val result = for {
+      providerCfg     <- Llm4sConfig.defaultProvider()
+      registryService <- Llm4sConfig.modelRegistryService()
+      given org.llm4s.model.ModelRegistryService = registryService
+      client     <- LLMConnect.getClient(providerCfg)
+      completion <- client.complete(conversation, CompletionOptions())
+      _ = {
+        logger.info("Provider: Bedrock Anthropic")
+        logger.info("Model: {}", completion.model)
+        logger.info("--- Response ---")
+        logger.info("{}", completion.message.content)
+        logger.info("--- End Response ---")
+        completion.usage.foreach { usage =>
+          logger.info(
+            "Tokens used: {} ({} prompt + {} completion)",
+            usage.totalTokens,
+            usage.promptTokens,
+            usage.completionTokens
+          )
+        }
+      }
+    } yield ()
+
+    result.fold(
+      err => {
+        logger.error("Error: {}", err.formatted)
+        logger.info("Tip: Ensure AWS credentials are configured (env vars, ~/.aws/credentials, or IAM role)")
+        logger.info("Tip: Set LLM4S_PROVIDER=bedrock-anthropic-main in your environment")
+      },
+      identity
+    )
+  }
+}

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/StreamingExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/StreamingExample.scala
@@ -3,120 +3,152 @@ package org.llm4s.samples.basic
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
 import org.llm4s.llmconnect.model._
+import org.llm4s.toolapi._
+import org.llm4s.toolapi.tools.WeatherTool
 import org.slf4j.LoggerFactory
+import upickle.default._
 
 /**
- * Demonstrates streaming responses from LLMs using the streamComplete method.
- * Shows how to process chunks as they arrive and compare with non-streaming calls.
+ * Demonstrates tool calling and streaming responses via AWS Bedrock.
+ *
+ * This example shows the full tool-calling flow:
+ * 1. Send a query with tools defined — the LLM responds with tool calls
+ * 2. Execute the tools locally and collect results
+ * 3. Send the results back and stream the LLM's final answer
  *
  * To run this example:
- * ```bash
- * # Set up environment variables (choose one provider)
- * export LLM_MODEL=openai/gpt-4o           # For OpenAI
- * export OPENAI_API_KEY=sk-...             # Your OpenAI API key
+ * {{{
+ * # Export AWS credentials
+ * export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile twdc-bedrock-central)
+ * export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile twdc-bedrock-central)
+ * export AWS_SESSION_TOKEN=$(aws configure get aws_session_token --profile twdc-bedrock-central)
  *
- * # OR for Anthropic:
- * export LLM_MODEL=anthropic/claude-3-5-sonnet-latest
- * export ANTHROPIC_API_KEY=sk-ant-...      # Your Anthropic API key
- *
- * # Run the example
  * sbt "samples/runMain org.llm4s.samples.basic.StreamingExample"
- * ```
+ * }}}
  */
 object StreamingExample {
   private val logger = LoggerFactory.getLogger(getClass)
 
-  def main(args: Array[String]): Unit = {
-    // Create a conversation
-    val conversation = Conversation(
-      Seq(
-        SystemMessage("You are a helpful assistant who explains things clearly and concisely."),
-        UserMessage("Explain the concept of recursion in programming with a simple example.")
-      )
-    )
+  case class CalcResult(expression: String, result: Double)
+  implicit val calcResultRW: ReadWriter[CalcResult] = macroRW
 
-    var fullContent = ""
-    var chunkCount  = 0
-    val startTime   = System.currentTimeMillis()
+  def main(args: Array[String]): Unit = {
     val result = for {
-      providerCfg     <- Llm4sConfig.defaultProvider()
+      providerCfg     <- Llm4sConfig.provider("bedrock-anthropic-main")
       registryService <- Llm4sConfig.modelRegistryService()
       given org.llm4s.model.ModelRegistryService = registryService
       client <- LLMConnect.getClient(providerCfg)
-      _ = {
-        logger.info("=== Streaming Response ===")
-        logger.info("Receiving chunks as they arrive:")
-        logger.info("-" * 40)
-      }
-      completion <-
-        client.streamComplete(
-          conversation,
-          CompletionOptions(),
-          onChunk = { chunk =>
-            chunkCount += 1
 
-            // Process content chunks
-            chunk.content.foreach { content =>
-              print(content) // Print each chunk as it arrives (Keep print for Streaming UI)
-              fullContent += content
-            }
-
-            // Handle tool calls if present
-            chunk.toolCall.foreach(toolCall => logger.info("[Tool Call: {}]", toolCall.name))
-
-            // Check if streaming is finished
-            chunk.finishReason.foreach { reason =>
-              // Ensure we break the line after streaming finishes
-              println()
-              logger.info("[Stream finished: {}]", reason)
-            }
+      // Define a calculator tool
+      calcTool <- ToolBuilder[Map[String, Any], CalcResult](
+        "calculate",
+        "Evaluates a simple arithmetic expression with two numbers. Supports +, -, *, /.",
+        Schema
+          .`object`[Map[String, Any]]("Calculator parameters")
+          .withProperty(Schema.property("a", Schema.number("First number")))
+          .withProperty(Schema.property("b", Schema.number("Second number")))
+          .withProperty(
+            Schema.property("operator", Schema.string("Operator: +, -, *, /").withEnum(Seq("+", "-", "*", "/")))
+          )
+      ).withHandler { params =>
+        for {
+          a  <- params.getDouble("a")
+          b  <- params.getDouble("b")
+          op <- params.getString("operator")
+        } yield {
+          val res = op match {
+            case "+" => a + b
+            case "-" => a - b
+            case "*" => a * b
+            case "/" => if (b != 0) a / b else Double.NaN
+            case _   => Double.NaN
           }
-        )
+          CalcResult(s"$a $op $b", res)
+        }
+      }.buildSafe()
+
+      // Build the weather tool
+      weatherTool <- WeatherTool.toolSafe
+
+      toolRegistry = new ToolRegistry(Seq(calcTool, weatherTool))
+
+      query = "What's the weather in Tokyo? Also, what is 15 * 7?"
+
       _ = {
-        val endTime  = System.currentTimeMillis()
-        val duration = endTime - startTime
+        logger.info("=== Tool Calling + Streaming (Bedrock Anthropic) ===")
+        logger.info("Query: {}", query)
+        logger.info("")
+      }
 
-        logger.info("-" * 40)
-        logger.info("=== Streaming Complete ===")
-        logger.info("Total chunks received: {}", chunkCount)
-        logger.info("Total time: {}ms", duration)
-        logger.info("Completion ID: {}", completion.id)
+      // Step 1: Send query with tools — LLM will respond with tool calls
+      conversation1 = Conversation(Seq(
+        SystemMessage("You are a helpful assistant. Use tools when needed."),
+        UserMessage(query)
+      ))
+      options = CompletionOptions(tools = toolRegistry.tools)
 
-        // Print token usage if available
-        completion.usage.foreach { usage =>
+      _ = logger.info("--- Step 1: LLM decides which tools to call ---")
+      completion1 <- client.complete(conversation1, options)
+
+      _ = {
+        if (completion1.toolCalls.nonEmpty) {
+          completion1.toolCalls.foreach { tc =>
+            logger.info("  Tool call: {}({})", tc.name, tc.arguments.render())
+          }
+        } else {
+          logger.info("  No tool calls (LLM responded directly)")
+        }
+      }
+
+      // Step 2: Execute tools locally
+      _ = logger.info("")
+      _ = logger.info("--- Step 2: Execute tools locally ---")
+      toolResults = completion1.toolCalls.map { tc =>
+        val toolResult = toolRegistry.tools
+          .find(_.name == tc.name)
+          .map(_.execute(tc.arguments))
+          .getOrElse(Left(ToolCallError.HandlerError(tc.name, "Tool not found")))
+
+        val resultStr = toolResult match {
+          case Right(json) => json.render()
+          case Left(err)   => s"""{"error": "${err.toString}"}"""
+        }
+        logger.info("  {} -> {}", tc.name, resultStr)
+        ToolMessage(resultStr, tc.id)
+      }
+
+      // Step 3: Send tool results back and stream the final answer
+      _ = logger.info("")
+      _ = logger.info("--- Step 3: Stream final response with tool results ---")
+      conversation2 = Conversation(
+        conversation1.messages
+          ++ Seq(completion1.message)
+          ++ toolResults
+      )
+
+      streamCompletion <- client.streamComplete(
+        conversation2,
+        CompletionOptions(),
+        onChunk = { chunk =>
+          chunk.content.foreach(print)
+          chunk.finishReason.foreach(_ => println())
+        }
+      )
+
+      _ = {
+        logger.info("")
+        logger.info("=== Complete ===")
+        streamCompletion.usage.foreach { usage =>
           logger.info(
-            "Tokens used: {} ({} prompt, {} completion)",
+            "Tokens used: {} ({} prompt + {} completion)",
             usage.totalTokens,
             usage.promptTokens,
             usage.completionTokens
           )
         }
-
-        // Verify the full content matches the completion message
-        if (completion.message.content == fullContent) {
-          logger.info("Streamed content matches final completion")
-        } else {
-          logger.warn("Warning: Streamed content differs from final completion")
-        }
-        logger.info("=== Comparison with Non-Streaming ===")
-        logger.info("Now calling the same request without streaming...")
-      }
-      nonStreamStartTime = System.currentTimeMillis()
-      noStreamCompletion <- client.complete(conversation)
-      _ = {
-        val nonStreamEndTime  = System.currentTimeMillis()
-        val nonStreamDuration = nonStreamEndTime - nonStreamStartTime
-
-        logger.info("Non-streaming time: {}ms", nonStreamDuration)
-        logger.info("Response length: {} characters", noStreamCompletion.message.content.length)
-
-        // The non-streaming response should be similar
-        logger.info("Non-streaming response (first 200 chars):")
-        logger.info("{}...", noStreamCompletion.message.content.take(200))
       }
     } yield ()
 
     result.fold(err => logger.error("Error: {}", err.formatted), identity)
-
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
@@ -372,6 +372,11 @@ private[providersetup] object ProviderSetupRuntime:
           apiKey = input.flatMap(_.apiKey).getOrElse(cfg.apiKey),
           baseUrl = input.flatMap(_.baseUrl).getOrElse(cfg.baseUrl)
         )
+      case cfg: BedrockAnthropicConfig =>
+        cfg.copy(
+          model = input.flatMap(_.model).getOrElse(cfg.model),
+          region = input.flatMap(_.baseUrl).getOrElse(cfg.region)
+        )
 
   def demoCompletionCmd(
     providerConfig: ProviderConfig,
@@ -579,4 +584,5 @@ private[providersetup] object ProviderSetupRuntime:
       case cfg: DeepSeekConfig  => cfg.copy(model = modelName)
       case cfg: CohereConfig    => cfg.copy(model = modelName)
       case cfg: MistralConfig   => cfg.copy(model = modelName)
-      case cfg: ZaiConfig       => cfg.copy(model = modelName)
+      case cfg: ZaiConfig               => cfg.copy(model = modelName)
+      case cfg: BedrockAnthropicConfig  => cfg.copy(model = modelName)

--- a/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
@@ -131,15 +131,16 @@ object PrometheusMetricsExample {
 
             case Right(config) =>
               val providerName = config match {
-                case _: org.llm4s.llmconnect.config.OpenAIConfig    => "openai"
-                case _: org.llm4s.llmconnect.config.AnthropicConfig => "anthropic"
-                case _: org.llm4s.llmconnect.config.OllamaConfig    => "ollama"
-                case _: org.llm4s.llmconnect.config.AzureConfig     => "azure"
-                case _: org.llm4s.llmconnect.config.ZaiConfig       => "zai"
-                case _: org.llm4s.llmconnect.config.GeminiConfig    => "gemini"
-                case _: org.llm4s.llmconnect.config.DeepSeekConfig  => "deepseek"
-                case _: org.llm4s.llmconnect.config.CohereConfig    => "cohere"
-                case _: org.llm4s.llmconnect.config.MistralConfig   => "mistral"
+                case _: org.llm4s.llmconnect.config.OpenAIConfig            => "openai"
+                case _: org.llm4s.llmconnect.config.AnthropicConfig         => "anthropic"
+                case _: org.llm4s.llmconnect.config.OllamaConfig            => "ollama"
+                case _: org.llm4s.llmconnect.config.AzureConfig             => "azure"
+                case _: org.llm4s.llmconnect.config.ZaiConfig               => "zai"
+                case _: org.llm4s.llmconnect.config.GeminiConfig            => "gemini"
+                case _: org.llm4s.llmconnect.config.DeepSeekConfig          => "deepseek"
+                case _: org.llm4s.llmconnect.config.CohereConfig            => "cohere"
+                case _: org.llm4s.llmconnect.config.MistralConfig           => "mistral"
+                case _: org.llm4s.llmconnect.config.BedrockAnthropicConfig  => "bedrock-anthropic"
               }
 
               println(s"Using model: ${config.model}")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,7 +69,8 @@ object Deps {
 
 
   val azureOpenAI = "com.azure"     % "azure-ai-openai" % Versions.azureOpenAI
-  val anthropic   = "com.anthropic" % "anthropic-java"  % Versions.anthropic
+  val anthropic        = "com.anthropic" % "anthropic-java"         % Versions.anthropic
+  val anthropicBedrock = "com.anthropic" % "anthropic-java-bedrock" % Versions.anthropic
   val jtokkit     = "com.knuddels"  % "jtokkit"         % Versions.jtokkit
   val websocket   = "org.java-websocket" % "Java-WebSocket" % Versions.websocket
   val ujson       = "com.lihaoyi"  %% "ujson"           % Versions.ujson


### PR DESCRIPTION
Enable calling Claude models through AWS Bedrock using the Default Credential Provider Chain (env vars, ~/.aws/credentials, IAM roles). Extracts shared Anthropic message logic into AnthropicMessageSupport trait for reuse between direct API and Bedrock transports.

## What does this PR do?
<!-- Brief description of the change and WHY it's needed -->

## Related issue
<!-- Link the issue this addresses: Fixes #XXX or Relates to #XXX -->

## How was this tested?
<!-- Describe what you tested and how. Include relevant commands or test names. -->

## Checklist

- [ ] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [ ] PR is small and focused — one change, one reason
- [ ] `sbt scalafmtAll` — code is formatted
- [ ] `sbt test` — tests pass on Scala 3
- [ ] New code includes tests
- [ ] No unrelated changes included (branched from `main`, not from another PR)
- [ ] Commit messages explain the "why"
