### PR TITLE
docs(imagegeneration): clarify intentional dual cost recording

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/imagegeneration/InstrumentedImageGenerationClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/imagegeneration/InstrumentedImageGenerationClient.scala
@@ -161,6 +161,10 @@ class InstrumentedImageGenerationClient(
         size.flatMap { s =>
           val cost = ImagePricingRegistry.estimateCost(model, quality, s, imageCount)
           cost.foreach { c =>
+            // Record to both the image-specific cost counter (for a per-provider/model image
+            // breakdown) and the unified cost counter (so total spend across all operations,
+            // LLM and image, stays correct). This dual recording is intentional, not double
+            // counting within a single series.
             metrics.recordImageGenerationCost(providerName, model, c, imageCount)
             metrics.recordCost(providerName, model, c)
           }


### PR DESCRIPTION
## What

Follow-up to #818 (image generation cost tracking & metrics, now merged). Adds a clarifying code comment in `InstrumentedImageGenerationClient` documenting that recording each cost to **both** counters is intentional:

- `recordImageGenerationCost` → `llm4s_image_generation_cost_usd_total` (per-provider/model image breakdown)
- `recordCost` → `llm4s_cost_usd_total` (unified total spend across LLM + image operations)

This was raised as a question during the #818 follow-up review ("is the dual recording intended?"). It is — the comment makes that explicit so future readers don't mistake it for double counting within a single series.

## Why

Documentation-only clarification. No behavior change.

## Notes on the other review nit

The second follow-up nit — release-noting the `llm4s_errors_total` label-value change (`ratelimit` → `rate_limit`, etc.) from #818 — has no action: the repo has no CHANGELOG, and the observability docs don't reference the specific label values.

## Testing

- `sbt core/compile` passes (Scala 3.7.1, `-Werror`)
- `sbt scalafmtAll` clean
- Pre-commit hooks (full `core/test`) passed