### PR TITLE
Fix funding.json schema validation for FLOSS/fund

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -59,7 +59,7 @@
         "guid": "maintainer-sustainability",
         "status": "active",
         "name": "Maintainer sustainability for LLM4S",
-        "description": "LLM4S is requesting USD 25,000 in one-time support to sustain development of critical Scala and JVM AI infrastructure. The funding will support maintainer and contributor time, contributor onboarding, documentation, tutorials, examples, release engineering, CI, testing, security hardening, community Dev Hours, and production-readiness work. This support will help the project move from a volunteer-led effort to a more sustainable open-source project serving Scala, JVM, AI, functional programming, and enterprise developer communities. It will also support the project's transition toward stronger governance and legal registration for long-term stewardship.",
+        "description": "One-time support for LLM4S maintainer time, contributor onboarding, documentation, examples, release engineering, CI, testing, security hardening, community Dev Hours, production readiness, and transition toward stronger governance and legal registration.",
         "amount": 25000,
         "currency": "USD",
         "frequency": "one-time",


### PR DESCRIPTION
## What does this PR do?

This PR fixes the remaining `funding.json` schema validation issue before submitting the LLM4S FLOSS/fund application.

The main funding request remains unchanged:

**USD 25,000 one-time support for maintainer sustainability for LLM4S.**

## Why this is needed

The FLOSS/fund validator previously reported:

```text
plans[maintainer-sustainability].description should be of length 0 - 500
```

The previous funding plan description was too long for the `funding.json` schema.

This PR shortens the plan description while keeping the funding request, project positioning, funding channels, and legal-status wording intact.

## Screenshot of validation issue

<img width="1360" height="914" alt="FLOSS/fund validator showing funding plan description length issue" src="https://github.com/user-attachments/assets/5efacd19-52a6-4525-a1a3-cf52c0d08ad3" />

The screenshot above shows the FLOSS/fund validator reporting that `plans[maintainer-sustainability].description` must be between 0 and 500 characters.

## Screenshot after fix

<img width="1360" height="914" alt="image" src="https://github.com/user-attachments/assets/d1400786-bd2d-484a-949a-fa18aac3df8a" />


The screenshot above shows that the updated manifest is now valid after shortening the funding plan description and keeping the project tags within the allowed limit.

## Changes made

This PR updates `funding.json` by:

- Shortening the `maintainer-sustainability` plan description to fit the schema limit
- Keeping the funding ask unchanged at USD 25,000 one-time
- Keeping the selected 10 project tags
- Keeping Open Collective as the preferred public funding channel
- Keeping `entity.type` as `group`
- Keeping LLM4S Foundation’s current legal status transparent
- Keeping the Google Summer of Code 2025 credibility note


## Funding ask remains unchanged

```json
{
  "name": "Maintainer sustainability for LLM4S",
  "amount": 25000,
  "currency": "USD",
  "frequency": "one-time"
}
```

## What the funding supports

The USD 25,000 one-time funding request supports:

- Maintainer and contributor time
- Contributor onboarding
- Documentation and examples
- Release engineering and CI
- Testing and security hardening
- Community Dev Hours
- Production-readiness work
- Transition toward stronger governance and legal registration

## Why this matters

LLM4S is a Scala-native open-source framework for building production-grade LLM applications.

Most LLM tooling today is Python-first, while many production systems in finance, telecom, enterprise software, data platforms, and distributed systems are built on Scala and the JVM. LLM4S helps close this ecosystem gap by giving Scala developers open infrastructure for building AI-powered applications without abandoning their existing production stack.

The project has already received external ecosystem validation through Google Summer of Code 2025 under the Scala Center umbrella, where four funded interns from the United States, Switzerland, and India worked on the project during summer 2025.

FLOSS/fund support would help LLM4S move from a purely volunteer-led effort toward a more sustainable open-source project serving the Scala, JVM, AI, functional programming, and enterprise developer communities.

## Testing

- [x] Funding plan description is now under 500 characters
- [x] Project tag count remains 10
- [x] Funding ask remains USD 25,000 one-time
- [x] FLOSS/fund validator shows: `Manifest is valid`
- [x] No source code changes

## Notes for reviewers

Please review:

- Whether the shortened funding plan description is clear enough
- Whether the legal status is described transparently
- Whether the selected tags are still the best 10 tags
- Whether this manifest is ready for FLOSS/fund submission after merge

## Collaboration note

This PR was prepared in collaboration with @AnshumanAI. Thanks to Anshuman for pairing on the final validation pass and helping make the `funding.json` manifest ready for FLOSS/fund submission.