### PR TITLE
fix: implement SSE streaming for Cohere and Mistral providers

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/CohereClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/CohereClient.scala
@@ -122,8 +122,9 @@ class CohereClient(
         .flatMap { response =>
           Try {
             val sseParser = SSEParser.createStreamingParser()
-            val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
-            try {
+            scala.util.Using.resource(
+              new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
+            ) { reader =>
               var line: String = null
               while ({ line = reader.readLine(); line != null }) {
                 rawStream.append(line).append('\n')
@@ -135,9 +136,6 @@ class CohereClient(
                     }
                   }
               }
-            } finally {
-              Try(reader.close())
-              Try(response.body().close())
             }
           }.toEither.left.map { e =>
             val err = e.toLLMError

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/CohereClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/CohereClient.scala
@@ -1,14 +1,17 @@
 package org.llm4s.llmconnect.provider
 
-import org.llm4s.error.{ ConfigurationError, ValidationError }
+import org.llm4s.error.ValidationError
 import org.llm4s.error.ThrowableOps._
 import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.ProviderExchangeLogging
 import org.llm4s.llmconnect.config.CohereConfig
 import org.llm4s.llmconnect.model._
+import org.llm4s.llmconnect.provider.ProviderResultOps.*
+import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator }
 import org.llm4s.model.ModelRegistryService
-import org.llm4s.types.Result
+import org.llm4s.types.{ Result, TryOps }
 
+import java.io.{ BufferedReader, InputStreamReader }
 import java.net.URI
 import java.net.http.{ HttpClient, HttpRequest, HttpResponse }
 import java.nio.charset.StandardCharsets
@@ -17,13 +20,13 @@ import java.time.Instant
 import scala.util.Try
 
 /**
- * Minimal Cohere provider client (v2 scope).
+ * Cohere provider client (v2 API).
  *
  * Supported:
  * - Non-streaming chat completion via Cohere v2 `/chat` API.
+ * - Streaming via SSE using the Cohere v2 streaming event format.
  *
- * Intentionally not supported in v2:
- * - Streaming
+ * Intentionally not supported:
  * - Tool calling
  * - Embeddings
  * - Multimodal inputs
@@ -80,15 +83,124 @@ class CohereClient(
     conversation: Conversation,
     options: CompletionOptions = CompletionOptions(),
     onChunk: StreamedChunk => Unit
-  ): Result[Completion] =
-    // TODO: When Cohere streaming is implemented here, add raw streaming
-    // exchange capture using the same completed-or-partial logging contract
-    // used by the other streaming-capable providers.
-    Left(
-      ConfigurationError(
-        "Cohere streaming is not supported in this minimal v2 provider implementation"
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt = Instant.now()
+    buildChatRequest(conversation, options).flatMap { requestBody =>
+      requestBody("stream") = true
+      val requestText       = requestBody.render()
+      val streamAccumulator = StreamingAccumulator.create()
+      val rawStream         = StringBuilder()
+
+      val responseOrError = Try {
+        val request = HttpRequest
+          .newBuilder()
+          .uri(URI.create(s"${config.baseUrl}/v2/chat"))
+          .header("Content-Type", "application/json")
+          .header("Authorization", s"Bearer ${config.apiKey}")
+          .timeout(Duration.ofMinutes(5))
+          .POST(HttpRequest.BodyPublishers.ofString(requestText, StandardCharsets.UTF_8))
+          .build()
+        httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
+      }.toResult.tapLeft(error =>
+        recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(error))
       )
-    )
+
+      val streamOrError = responseOrError.flatMap { response =>
+        if (response.statusCode() == 200) {
+          Right(response)
+        } else {
+          val errorBody = Try(new String(response.body().readAllBytes(), StandardCharsets.UTF_8))
+            .getOrElse("<error body unreadable>")
+          val errorResult = HttpErrorMapper.mapHttpError(response.statusCode(), errorBody, providerName)
+          recordExchange(startedAt, requestText, Some(errorBody), errorResult)
+          errorResult
+        }
+      }
+
+      val attempt = streamOrError.flatMap { response =>
+        Try {
+          val sseParser = SSEParser.createStreamingParser()
+          val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
+          try {
+            var line: String = null
+            while ({ line = reader.readLine(); line != null }) {
+              rawStream.append(line).append('\n')
+              sseParser.addChunk(line + "\n")
+              while (sseParser.hasEvents)
+                sseParser.nextEvent().foreach { event =>
+                  event.data.foreach { data =>
+                    parseCohereStreamingChunk(data, streamAccumulator).foreach(c => onChunk(c))
+                  }
+                }
+            }
+          } finally {
+            Try(reader.close())
+            Try(response.body().close())
+          }
+        }.toEither.left.map(_.toLLMError)
+      }
+
+      attempt
+        .flatMap(_ =>
+          streamAccumulator.toCompletion.map { c =>
+            val cost       = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
+            val completion = c.copy(model = config.model, estimatedCost = cost)
+            recordExchange(startedAt, requestText, Some(rawStream.result()), Right(completion))
+            completion
+          }
+        )
+        .tapLeft(error =>
+          recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(error))
+        )
+    }
+  }
+
+  private def parseCohereStreamingChunk(data: String, accumulator: StreamingAccumulator): Option[StreamedChunk] =
+    Try(ujson.read(data)).toOption.flatMap { json =>
+      json.obj.get("type").flatMap(_.strOpt) match {
+        case Some("message-start") =>
+          val id    = json.obj.get("id").flatMap(_.strOpt).getOrElse("")
+          val chunk = StreamedChunk(id = id, content = None, toolCall = None, finishReason = None)
+          accumulator.addChunk(chunk)
+          None
+
+        case Some("content-delta") =>
+          val textOpt = json.obj
+            .get("delta")
+            .flatMap(_.obj.get("message"))
+            .flatMap(_.obj.get("content"))
+            .flatMap(_.obj.get("text"))
+            .flatMap(_.strOpt)
+          textOpt.map { text =>
+            val chunk = StreamedChunk(id = "", content = Some(text), toolCall = None, finishReason = None)
+            accumulator.addChunk(chunk)
+            chunk
+          }
+
+        case Some("message-end") =>
+          val finishReason = json.obj
+            .get("delta")
+            .flatMap(_.obj.get("finish_reason"))
+            .flatMap(_.strOpt)
+          json.obj
+            .get("delta")
+            .flatMap(_.obj.get("usage"))
+            .flatMap(_.obj.get("tokens"))
+            .foreach { tokens =>
+              val input  = tokens.obj.get("input_tokens").flatMap(_.numOpt).map(_.toInt)
+              val output = tokens.obj.get("output_tokens").flatMap(_.numOpt).map(_.toInt)
+              (input, output) match {
+                case (Some(in), Some(out)) => accumulator.updateTokens(in, out)
+                case _                     => ()
+              }
+            }
+          val chunk = StreamedChunk(id = "", content = None, toolCall = None, finishReason = finishReason)
+          accumulator.addChunk(chunk)
+          None
+
+        case _ => None
+      }
+    }
 
   override def getContextWindow(): Int = config.contextWindow
 

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/CohereClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/CohereClient.scala
@@ -91,6 +91,7 @@ class CohereClient(
       val streamAccumulator = StreamingAccumulator.create()
       val rawStream         = StringBuilder()
 
+      // Network-level failure: record immediately and propagate.
       val responseOrError = Try {
         val request = HttpRequest
           .newBuilder()
@@ -101,10 +102,9 @@ class CohereClient(
           .POST(HttpRequest.BodyPublishers.ofString(requestText, StandardCharsets.UTF_8))
           .build()
         httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
-      }.toResult.tapLeft(error =>
-        recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(error))
-      )
+      }.toResult.tapLeft(error => recordExchange(startedAt, requestText, None, Left(error)))
 
+      // HTTP error: record with response body and propagate.
       val streamOrError = responseOrError.flatMap { response =>
         if (response.statusCode() == 200) {
           Right(response)
@@ -117,30 +117,34 @@ class CohereClient(
         }
       }
 
-      val attempt = streamOrError.flatMap { response =>
-        Try {
-          val sseParser = SSEParser.createStreamingParser()
-          val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
-          try {
-            var line: String = null
-            while ({ line = reader.readLine(); line != null }) {
-              rawStream.append(line).append('\n')
-              sseParser.addChunk(line + "\n")
-              while (sseParser.hasEvents)
-                sseParser.nextEvent().foreach { event =>
-                  event.data.foreach { data =>
-                    parseCohereStreamingChunk(data, streamAccumulator).foreach(c => onChunk(c))
+      // SSE parsing: record on I/O or parse failure.
+      streamOrError
+        .flatMap { response =>
+          Try {
+            val sseParser = SSEParser.createStreamingParser()
+            val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
+            try {
+              var line: String = null
+              while ({ line = reader.readLine(); line != null }) {
+                rawStream.append(line).append('\n')
+                sseParser.addChunk(line + "\n")
+                while (sseParser.hasEvents)
+                  sseParser.nextEvent().foreach { event =>
+                    event.data.foreach { data =>
+                      parseCohereStreamingChunk(data, streamAccumulator).foreach(c => onChunk(c))
+                    }
                   }
-                }
+              }
+            } finally {
+              Try(reader.close())
+              Try(response.body().close())
             }
-          } finally {
-            Try(reader.close())
-            Try(response.body().close())
+          }.toEither.left.map { e =>
+            val err = e.toLLMError
+            recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(err))
+            err
           }
-        }.toEither.left.map(_.toLLMError)
-      }
-
-      attempt
+        }
         .flatMap(_ =>
           streamAccumulator.toCompletion.map { c =>
             val cost       = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
@@ -148,9 +152,6 @@ class CohereClient(
             recordExchange(startedAt, requestText, Some(rawStream.result()), Right(completion))
             completion
           }
-        )
-        .tapLeft(error =>
-          recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(error))
         )
     }
   }

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
@@ -97,6 +97,7 @@ class MistralClient(
       val streamAccumulator = StreamingAccumulator.create()
       val rawStream         = StringBuilder()
 
+      // Network-level failure: record immediately and propagate.
       val responseOrError = Try {
         val request = HttpRequest
           .newBuilder()
@@ -107,10 +108,9 @@ class MistralClient(
           .POST(HttpRequest.BodyPublishers.ofString(requestText, StandardCharsets.UTF_8))
           .build()
         httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
-      }.toResult.tapLeft(error =>
-        recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(error))
-      )
+      }.toResult.tapLeft(error => recordExchange(startedAt, requestText, None, Left(error)))
 
+      // HTTP error: record with response body and propagate.
       val streamOrError = responseOrError.flatMap { response =>
         if (response.statusCode() == 200) {
           Right(response)
@@ -123,37 +123,42 @@ class MistralClient(
         }
       }
 
-      val attempt = streamOrError.flatMap { response =>
-        Try {
-          val sseParser = SSEParser.createStreamingParser()
-          val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
-          try {
-            var line: String = null
-            while ({ line = reader.readLine(); line != null }) {
-              rawStream.append(line).append('\n')
-              sseParser.addChunk(line + "\n")
-              while (sseParser.hasEvents)
-                sseParser.nextEvent().foreach { event =>
-                  event.data.foreach { data =>
-                    if (data != "[DONE]") {
-                      val json   = ujson.read(data)
-                      val chunks = parseMistralStreamingChunks(json)
-                      chunks.foreach { c =>
-                        streamAccumulator.addChunk(c)
-                        onChunk(c)
+      // SSE parsing: record on I/O or parse failure.
+      streamOrError
+        .flatMap { response =>
+          Try {
+            val sseParser = SSEParser.createStreamingParser()
+            val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
+            try {
+              var line: String = null
+              while ({ line = reader.readLine(); line != null }) {
+                rawStream.append(line).append('\n')
+                sseParser.addChunk(line + "\n")
+                while (sseParser.hasEvents)
+                  sseParser.nextEvent().foreach { event =>
+                    event.data.foreach { data =>
+                      if (data != "[DONE]") {
+                        val json            = ujson.read(data)
+                        val (chunks, usage) = parseMistralStreamingChunk(json)
+                        usage.foreach { case (in, out) => streamAccumulator.updateTokens(in, out) }
+                        chunks.foreach { c =>
+                          streamAccumulator.addChunk(c)
+                          onChunk(c)
+                        }
                       }
                     }
                   }
-                }
+              }
+            } finally {
+              Try(reader.close())
+              Try(response.body().close())
             }
-          } finally {
-            Try(reader.close())
-            Try(response.body().close())
+          }.toEither.left.map { e =>
+            val err = e.toLLMError
+            recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(err))
+            err
           }
-        }.toEither.left.map(_.toLLMError)
-      }
-
-      attempt
+        }
         .flatMap(_ =>
           streamAccumulator.toCompletion.map { c =>
             val cost       = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
@@ -162,15 +167,14 @@ class MistralClient(
             completion
           }
         )
-        .tapLeft(error =>
-          recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(error))
-        )
     }
   }
 
-  private def parseMistralStreamingChunks(json: ujson.Value): Seq[StreamedChunk] = {
+  // Returns (chunks, Option[(promptTokens, completionTokens)]).
+  // Usage is present only in the last chunk of a Mistral streaming response.
+  private def parseMistralStreamingChunk(json: ujson.Value): (Seq[StreamedChunk], Option[(Int, Int)]) = {
     val choices = json("choices").arr
-    if (choices.nonEmpty) {
+    val chunks = if (choices.nonEmpty) {
       val choice       = choices(0)
       val delta        = choice("delta")
       val content      = delta.obj.get("content").flatMap(_.strOpt)
@@ -189,14 +193,29 @@ class MistralClient(
       if (toolCalls.isEmpty) {
         Seq(StreamedChunk(id = chunkId, content = content, toolCall = None, finishReason = finishReason))
       } else {
-        val first =
-          StreamedChunk(id = chunkId, content = content, toolCall = Some(toolCalls.head), finishReason = finishReason)
+        val first = StreamedChunk(
+          id = chunkId,
+          content = content,
+          toolCall = Some(toolCalls.head),
+          finishReason = finishReason
+        )
         val rest = toolCalls
           .drop(1)
           .map(tc => StreamedChunk(id = chunkId, content = None, toolCall = Some(tc), finishReason = None))
         Seq(first) ++ rest
       }
     } else Seq.empty
+
+    val usage = json.obj.get("usage").flatMap { u =>
+      val in  = u.obj.get("prompt_tokens").flatMap(_.numOpt).map(_.toInt)
+      val out = u.obj.get("completion_tokens").flatMap(_.numOpt).map(_.toInt)
+      (in, out) match {
+        case (Some(i), Some(o)) => Some((i, o))
+        case _                  => None
+      }
+    }
+
+    (chunks, usage)
   }
 
   override def getContextWindow(): Int = config.contextWindow

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
@@ -7,7 +7,7 @@ import org.llm4s.llmconnect.ProviderExchangeLogging
 import org.llm4s.llmconnect.config.MistralConfig
 import org.llm4s.llmconnect.model._
 import org.llm4s.llmconnect.provider.ProviderResultOps.*
-import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator, StreamingToolArgumentParser }
+import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator }
 import org.llm4s.model.ModelRegistryService
 import org.llm4s.types.{ Result, TryOps }
 
@@ -177,31 +177,8 @@ class MistralClient(
       val delta        = choice("delta")
       val content      = delta.obj.get("content").flatMap(_.strOpt)
       val finishReason = choice.obj.get("finish_reason").flatMap(_.strOpt).filter(r => r != "null" && r.nonEmpty)
-      val toolCalls = delta.obj.get("tool_calls").map(_.arr).getOrElse(Seq.empty).collect {
-        case call if call.obj.contains("function") =>
-          val function = call("function")
-          val rawArgs  = function.obj.get("arguments").flatMap(_.strOpt).getOrElse("")
-          ToolCall(
-            id = call.obj.get("id").flatMap(_.strOpt).getOrElse(""),
-            name = function.obj.get("name").flatMap(_.strOpt).getOrElse(""),
-            arguments = StreamingToolArgumentParser.parse(rawArgs)
-          )
-      }
-      val chunkId = json.obj.get("id").flatMap(_.strOpt).getOrElse("")
-      if (toolCalls.isEmpty) {
-        Seq(StreamedChunk(id = chunkId, content = content, toolCall = None, finishReason = finishReason))
-      } else {
-        val first = StreamedChunk(
-          id = chunkId,
-          content = content,
-          toolCall = Some(toolCalls.head),
-          finishReason = finishReason
-        )
-        val rest = toolCalls
-          .drop(1)
-          .map(tc => StreamedChunk(id = chunkId, content = None, toolCall = Some(tc), finishReason = None))
-        Seq(first) ++ rest
-      }
+      val chunkId      = json.obj.get("id").flatMap(_.strOpt).getOrElse("")
+      Seq(StreamedChunk(id = chunkId, content = content, toolCall = None, finishReason = finishReason))
     } else Seq.empty
 
     val usage = json.obj.get("usage").flatMap { u =>

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
@@ -1,14 +1,17 @@
 package org.llm4s.llmconnect.provider
 
-import org.llm4s.error.{ ConfigurationError, ValidationError }
+import org.llm4s.error.ValidationError
 import org.llm4s.error.ThrowableOps._
 import org.llm4s.llmconnect.BaseLifecycleLLMClient
 import org.llm4s.llmconnect.ProviderExchangeLogging
 import org.llm4s.llmconnect.config.MistralConfig
 import org.llm4s.llmconnect.model._
+import org.llm4s.llmconnect.provider.ProviderResultOps.*
+import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator, StreamingToolArgumentParser }
 import org.llm4s.model.ModelRegistryService
-import org.llm4s.types.Result
+import org.llm4s.types.{ Result, TryOps }
 
+import java.io.{ BufferedReader, InputStreamReader }
 import java.net.URI
 import java.net.http.{ HttpClient, HttpRequest, HttpResponse }
 import java.nio.charset.StandardCharsets
@@ -21,9 +24,9 @@ import scala.util.Try
  *
  * Supported:
  * - Non-streaming chat completion via Mistral `/v1/chat/completions` API.
+ * - Streaming via SSE using the OpenAI-compatible streaming format.
  *
- * Intentionally not supported in v1:
- * - Streaming
+ * Intentionally not supported:
  * - Tool calling
  * - Embeddings
  * - Multimodal inputs
@@ -86,15 +89,115 @@ class MistralClient(
     conversation: Conversation,
     options: CompletionOptions = CompletionOptions(),
     onChunk: StreamedChunk => Unit
-  ): Result[Completion] =
-    // TODO: When Mistral streaming is implemented here, add raw streaming
-    // exchange capture using the same completed-or-partial logging contract
-    // used by the other streaming-capable providers.
-    Left(
-      ConfigurationError(
-        "Mistral streaming is not supported in this minimal v1 provider implementation"
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt = Instant.now()
+    buildChatRequest(conversation, options).flatMap { requestBody =>
+      requestBody("stream") = true
+      val requestText       = requestBody.render()
+      val streamAccumulator = StreamingAccumulator.create()
+      val rawStream         = StringBuilder()
+
+      val responseOrError = Try {
+        val request = HttpRequest
+          .newBuilder()
+          .uri(URI.create(s"${config.baseUrl}/v1/chat/completions"))
+          .header("Content-Type", "application/json")
+          .header("Authorization", s"Bearer ${config.apiKey}")
+          .timeout(Duration.ofMinutes(5))
+          .POST(HttpRequest.BodyPublishers.ofString(requestText, StandardCharsets.UTF_8))
+          .build()
+        httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
+      }.toResult.tapLeft(error =>
+        recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(error))
       )
-    )
+
+      val streamOrError = responseOrError.flatMap { response =>
+        if (response.statusCode() == 200) {
+          Right(response)
+        } else {
+          val errorBody = Try(new String(response.body().readAllBytes(), StandardCharsets.UTF_8))
+            .getOrElse("<error body unreadable>")
+          val errorResult = HttpErrorMapper.mapHttpError(response.statusCode(), errorBody, providerName)
+          recordExchange(startedAt, requestText, Some(errorBody), errorResult)
+          errorResult
+        }
+      }
+
+      val attempt = streamOrError.flatMap { response =>
+        Try {
+          val sseParser = SSEParser.createStreamingParser()
+          val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
+          try {
+            var line: String = null
+            while ({ line = reader.readLine(); line != null }) {
+              rawStream.append(line).append('\n')
+              sseParser.addChunk(line + "\n")
+              while (sseParser.hasEvents)
+                sseParser.nextEvent().foreach { event =>
+                  event.data.foreach { data =>
+                    if (data != "[DONE]") {
+                      val json   = ujson.read(data)
+                      val chunks = parseMistralStreamingChunks(json)
+                      chunks.foreach { c =>
+                        streamAccumulator.addChunk(c)
+                        onChunk(c)
+                      }
+                    }
+                  }
+                }
+            }
+          } finally {
+            Try(reader.close())
+            Try(response.body().close())
+          }
+        }.toEither.left.map(_.toLLMError)
+      }
+
+      attempt
+        .flatMap(_ =>
+          streamAccumulator.toCompletion.map { c =>
+            val cost       = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
+            val completion = c.copy(model = config.model, estimatedCost = cost)
+            recordExchange(startedAt, requestText, Some(rawStream.result()), Right(completion))
+            completion
+          }
+        )
+        .tapLeft(error =>
+          recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(error))
+        )
+    }
+  }
+
+  private def parseMistralStreamingChunks(json: ujson.Value): Seq[StreamedChunk] = {
+    val choices = json("choices").arr
+    if (choices.nonEmpty) {
+      val choice       = choices(0)
+      val delta        = choice("delta")
+      val content      = delta.obj.get("content").flatMap(_.strOpt)
+      val finishReason = choice.obj.get("finish_reason").flatMap(_.strOpt).filter(r => r != "null" && r.nonEmpty)
+      val toolCalls = delta.obj.get("tool_calls").map(_.arr).getOrElse(Seq.empty).collect {
+        case call if call.obj.contains("function") =>
+          val function = call("function")
+          val rawArgs  = function.obj.get("arguments").flatMap(_.strOpt).getOrElse("")
+          ToolCall(
+            id = call.obj.get("id").flatMap(_.strOpt).getOrElse(""),
+            name = function.obj.get("name").flatMap(_.strOpt).getOrElse(""),
+            arguments = StreamingToolArgumentParser.parse(rawArgs)
+          )
+      }
+      val chunkId = json.obj.get("id").flatMap(_.strOpt).getOrElse("")
+      if (toolCalls.isEmpty) {
+        Seq(StreamedChunk(id = chunkId, content = content, toolCall = None, finishReason = finishReason))
+      } else {
+        val first =
+          StreamedChunk(id = chunkId, content = content, toolCall = Some(toolCalls.head), finishReason = finishReason)
+        val rest = toolCalls
+          .drop(1)
+          .map(tc => StreamedChunk(id = chunkId, content = None, toolCall = Some(tc), finishReason = None))
+        Seq(first) ++ rest
+      }
+    } else Seq.empty
+  }
 
   override def getContextWindow(): Int = config.contextWindow
 

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/MistralClient.scala
@@ -128,8 +128,9 @@ class MistralClient(
         .flatMap { response =>
           Try {
             val sseParser = SSEParser.createStreamingParser()
-            val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
-            try {
+            scala.util.Using.resource(
+              new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
+            ) { reader =>
               var line: String = null
               while ({ line = reader.readLine(); line != null }) {
                 rawStream.append(line).append('\n')
@@ -149,9 +150,6 @@ class MistralClient(
                     }
                   }
               }
-            } finally {
-              Try(reader.close())
-              Try(response.body().close())
             }
           }.toEither.left.map { e =>
             val err = e.toLLMError

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/CohereClientClosedStateTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/CohereClientClosedStateTest.scala
@@ -42,9 +42,11 @@ class CohereClientClosedStateTest extends AnyFlatSpec with Matchers {
     result.left.toOption.get.message should include("command-r")
   }
 
-  it should "return ConfigurationError when streamComplete() is called (streaming not supported)" in {
+  it should "return ConfigurationError when streamComplete() is called after close()" in {
     val client         = new CohereClient(createTestConfig)
     var chunksReceived = 0
+
+    client.close()
 
     val result = client.streamComplete(
       createTestConversation,
@@ -54,7 +56,7 @@ class CohereClientClosedStateTest extends AnyFlatSpec with Matchers {
 
     result.isLeft shouldBe true
     result.left.toOption.get shouldBe a[ConfigurationError]
-    result.left.toOption.get.message.toLowerCase should include("stream")
+    result.left.toOption.get.message should include("already closed")
     chunksReceived shouldBe 0
   }
 

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/CohereClientStreamingSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/CohereClientStreamingSpec.scala
@@ -142,6 +142,22 @@ class CohereClientStreamingSpec extends AnyFlatSpec with Matchers {
       result.toOption.get.content shouldBe ""
     }
 
+  it should "handle message-end with missing or incomplete token counts gracefully" in
+    withServer("/v2/chat") { exchange =>
+      val missingTokens =
+        "data: {\"type\":\"message-start\",\"id\":\"x\"}\n\n" +
+          "data: {\"type\":\"content-delta\",\"index\":0,\"delta\":{\"message\":{\"content\":{\"text\":\"hi\"}}}}\n\n" +
+          "data: {\"type\":\"message-end\",\"delta\":{\"finish_reason\":\"COMPLETE\",\"usage\":{\"tokens\":{}}}}\n\n"
+      sendSseResponse(exchange, missingTokens)
+    } { baseUrl =>
+      val client = new CohereClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isRight shouldBe true
+      result.toOption.get.content shouldBe "hi"
+      result.toOption.get.usage shouldBe None
+    }
+
   it should "set stream:true in the outgoing request body" in
     withServer("/v2/chat") { exchange =>
       val body = new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/CohereClientStreamingSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/CohereClientStreamingSpec.scala
@@ -1,0 +1,283 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.{ AuthenticationError, RateLimitError, ServiceError }
+import org.llm4s.llmconnect.{ ProviderExchange, ProviderExchangeLogging, ProviderExchangeSink }
+import org.llm4s.llmconnect.config.CohereConfig
+import org.llm4s.llmconnect.model._
+import org.llm4s.testutil.LocalProviderTestServer._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues._
+
+import java.nio.charset.StandardCharsets
+import scala.collection.mutable.ListBuffer
+import org.llm4s.model.ModelRegistryService
+
+/**
+ * HTTP-level tests for CohereClient.streamComplete() (PR #925).
+ *
+ * Verifies that the new SSE streaming implementation correctly handles
+ * the Cohere v2 streaming event format (message-start / content-delta /
+ * message-end).  All tests run against a local in-process HTTP server —
+ * no API keys or external services are required.
+ */
+class CohereClientStreamingSpec extends AnyFlatSpec with Matchers {
+
+  private given ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+
+  private def localConfig(baseUrl: String): CohereConfig =
+    CohereConfig(
+      apiKey = "test-key",
+      model = "command-r",
+      baseUrl = baseUrl,
+      contextWindow = 128000,
+      reserveCompletion = 4096
+    )
+
+  private def conversation: Conversation = Conversation(Seq(UserMessage("hello")))
+
+  /**
+   * Builds a Cohere v2 SSE body from a sequence of text chunks.
+   * Format: message-start → content-start → content-delta* → content-end → message-end
+   */
+  private def cohereSseBody(
+    chunks: Seq[String],
+    id: String = "msg-cohere-test",
+    inputTokens: Int = 10,
+    outputTokens: Int = 5
+  ): String = {
+    val messageStart =
+      s"""data: {"type":"message-start","id":"$id","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}"""
+
+    val contentStart =
+      """data: {"type":"content-start","index":0,"delta":{"message":{"content":{"type":"text","text":""}}}}"""
+
+    val contentDeltas = chunks.map { text =>
+      s"""data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":${ujson
+          .Str(text)
+          .render()}}}}}"""
+    }
+
+    val contentEnd = """data: {"type":"content-end","index":0}"""
+
+    val messageEnd =
+      s"""data: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"billed_units":{"input_tokens":$inputTokens,"output_tokens":$outputTokens},"tokens":{"input_tokens":$inputTokens,"output_tokens":$outputTokens}}}}"""
+
+    (Seq(messageStart, contentStart) ++ contentDeltas ++ Seq(contentEnd, messageEnd))
+      .mkString("\n\n") + "\n\n"
+  }
+
+  // ===========================================================================
+  // streamComplete() — happy path
+  // ===========================================================================
+
+  "CohereClient.streamComplete" should "parse Cohere v2 SSE events and accumulate content" in
+    withServer("/v2/chat")(exchange => sendSseResponse(exchange, cohereSseBody(Seq("Hello", " world")))) { baseUrl =>
+      val client = new CohereClient(localConfig(baseUrl))
+      val chunks = ListBuffer.empty[StreamedChunk]
+      val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+      result.isRight shouldBe true
+      val completion = result.toOption.get
+      completion.content shouldBe "Hello world"
+      completion.model shouldBe "command-r"
+      chunks should not be empty
+    }
+
+  it should "deliver each content-delta to the onChunk callback" in
+    withServer("/v2/chat")(exchange => sendSseResponse(exchange, cohereSseBody(Seq("A", "B", "C")))) { baseUrl =>
+      val client = new CohereClient(localConfig(baseUrl))
+      val chunks = ListBuffer.empty[StreamedChunk]
+      val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+      result.isRight shouldBe true
+      chunks.flatMap(_.content).mkString shouldBe "ABC"
+      chunks.size shouldBe 3
+    }
+
+  it should "accumulate token usage from the message-end event" in
+    withServer("/v2/chat") { exchange =>
+      sendSseResponse(exchange, cohereSseBody(Seq("Hi"), inputTokens = 12, outputTokens = 7))
+    } { baseUrl =>
+      val client = new CohereClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isRight shouldBe true
+      val usage = result.toOption.get.usage
+      usage shouldBe defined
+      usage.get.promptTokens shouldBe 12
+      usage.get.completionTokens shouldBe 7
+    }
+
+  it should "capture the message ID from the message-start event" in
+    withServer("/v2/chat")(exchange => sendSseResponse(exchange, cohereSseBody(Seq("Hi"), id = "cohere-id-42"))) {
+      baseUrl =>
+        val client = new CohereClient(localConfig(baseUrl))
+        val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+        result.isRight shouldBe true
+        result.toOption.get.id shouldBe "cohere-id-42"
+    }
+
+  it should "handle a single-word streaming response" in
+    withServer("/v2/chat")(exchange => sendSseResponse(exchange, cohereSseBody(Seq("Bonjour")))) { baseUrl =>
+      val client = new CohereClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isRight shouldBe true
+      result.toOption.get.content shouldBe "Bonjour"
+    }
+
+  it should "return an empty completion when no content-delta events are present" in
+    withServer("/v2/chat") { exchange =>
+      val noContent =
+        "data: {\"type\":\"message-start\",\"id\":\"x\"}\n\n" +
+          "data: {\"type\":\"message-end\",\"delta\":{\"finish_reason\":\"COMPLETE\",\"usage\":{\"tokens\":{\"input_tokens\":1,\"output_tokens\":0}}}}\n\n"
+      sendSseResponse(exchange, noContent)
+    } { baseUrl =>
+      val client = new CohereClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isRight shouldBe true
+      result.toOption.get.content shouldBe ""
+    }
+
+  it should "set stream:true in the outgoing request body" in
+    withServer("/v2/chat") { exchange =>
+      val body = new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
+      val json = ujson.read(body)
+      json("stream").bool shouldBe true
+      sendSseResponse(exchange, cohereSseBody(Seq("ok")))
+    } { baseUrl =>
+      val client = new CohereClient(localConfig(baseUrl))
+      client.streamComplete(conversation, CompletionOptions(), _ => ())
+    }
+
+  it should "include the model in the streaming request body" in
+    withServer("/v2/chat") { exchange =>
+      val body = new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
+      val json = ujson.read(body)
+      json("model").str shouldBe "command-r"
+      sendSseResponse(exchange, cohereSseBody(Seq("ok")))
+    } { baseUrl =>
+      val client = new CohereClient(localConfig(baseUrl))
+      client.streamComplete(conversation, CompletionOptions(), _ => ())
+    }
+
+  it should "pass maxTokens option in the streaming request" in
+    withServer("/v2/chat") { exchange =>
+      val body = new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
+      val json = ujson.read(body)
+      json("max_tokens").num.toInt shouldBe 512
+      sendSseResponse(exchange, cohereSseBody(Seq("ok")))
+    } { baseUrl =>
+      val client = new CohereClient(localConfig(baseUrl))
+      client.streamComplete(conversation, CompletionOptions(maxTokens = Some(512)), _ => ())
+    }
+
+  // ===========================================================================
+  // streamComplete() — error handling
+  // ===========================================================================
+
+  it should "map HTTP 401 to AuthenticationError" in
+    withServer("/v2/chat")(exchange => sendJsonResponse(exchange, 401, """{"message":"Unauthorized"}""")) {
+      baseUrl =>
+        val client = new CohereClient(localConfig(baseUrl))
+        val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+        result.isLeft shouldBe true
+        result.swap.toOption.get shouldBe an[AuthenticationError]
+    }
+
+  it should "map HTTP 429 to RateLimitError" in
+    withServer("/v2/chat")(exchange => sendJsonResponse(exchange, 429, """{"message":"Rate limit exceeded"}""")) {
+      baseUrl =>
+        val client = new CohereClient(localConfig(baseUrl))
+        val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+        result.isLeft shouldBe true
+        result.swap.toOption.get shouldBe a[RateLimitError]
+    }
+
+  it should "map HTTP 500 to ServiceError" in
+    withServer("/v2/chat")(exchange => sendJsonResponse(exchange, 500, """{"message":"Internal error"}""")) {
+      baseUrl =>
+        val client = new CohereClient(localConfig(baseUrl))
+        val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+        result.isLeft shouldBe true
+        result.swap.toOption.get shouldBe a[ServiceError]
+    }
+
+  it should "not invoke onChunk when the server returns an error status" in
+    withServer("/v2/chat")(exchange => sendJsonResponse(exchange, 429, """{"message":"Too many requests"}""")) {
+      baseUrl =>
+        val client       = new CohereClient(localConfig(baseUrl))
+        var chunksCalled = 0
+        val result       = client.streamComplete(conversation, CompletionOptions(), _ => chunksCalled += 1)
+
+        result.isLeft shouldBe true
+        chunksCalled shouldBe 0
+    }
+
+  // ===========================================================================
+  // streamComplete() — exchange logging
+  // ===========================================================================
+
+  it should "record a provider exchange with streaming request and SSE response body" in
+    withServer("/v2/chat")(exchange => sendSseResponse(exchange, cohereSseBody(Seq("Hello", " Cohere")))) {
+      baseUrl =>
+        val exchanges = ListBuffer.empty[ProviderExchange]
+        val sink = new ProviderExchangeSink:
+          override def record(e: ProviderExchange): Unit = exchanges += e
+
+        val client = new CohereClient(
+          localConfig(baseUrl),
+          exchangeLogging = ProviderExchangeLogging.enabled(sink)
+        )
+        val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+        result.isRight shouldBe true
+        exchanges should have size 1
+        val ex = exchanges.head
+        ex.provider shouldBe "cohere"
+        ex.model shouldBe Some("command-r")
+        ex.requestBody should include("\"stream\":true")
+        ex.requestBody should include("hello")
+        ex.responseBody.value should include("data:")
+        ex.responseBody.value should include("content-delta")
+        ex.errorMessage shouldBe empty
+    }
+
+  it should "record a provider exchange with errorMessage when streaming returns an error" in
+    withServer("/v2/chat")(exchange => sendJsonResponse(exchange, 401, """{"message":"Unauthorized"}""")) {
+      baseUrl =>
+        val exchanges = ListBuffer.empty[ProviderExchange]
+        val sink = new ProviderExchangeSink:
+          override def record(e: ProviderExchange): Unit = exchanges += e
+
+        val client = new CohereClient(
+          localConfig(baseUrl),
+          exchangeLogging = ProviderExchangeLogging.enabled(sink)
+        )
+        client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+        exchanges should have size 1
+        exchanges.head.errorMessage shouldBe defined
+    }
+
+  // ===========================================================================
+  // closed-state — streamComplete after close
+  // ===========================================================================
+
+  it should "return ConfigurationError when called after close()" in {
+    val client = new CohereClient(
+      CohereConfig("k", "command-r", "https://example.invalid", 128000, 4096)
+    )
+    client.close()
+    val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get.message should include("already closed")
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/CohereClientStreamingSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/CohereClientStreamingSpec.scala
@@ -180,13 +180,12 @@ class CohereClientStreamingSpec extends AnyFlatSpec with Matchers {
   // ===========================================================================
 
   it should "map HTTP 401 to AuthenticationError" in
-    withServer("/v2/chat")(exchange => sendJsonResponse(exchange, 401, """{"message":"Unauthorized"}""")) {
-      baseUrl =>
-        val client = new CohereClient(localConfig(baseUrl))
-        val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+    withServer("/v2/chat")(exchange => sendJsonResponse(exchange, 401, """{"message":"Unauthorized"}""")) { baseUrl =>
+      val client = new CohereClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
 
-        result.isLeft shouldBe true
-        result.swap.toOption.get shouldBe an[AuthenticationError]
+      result.isLeft shouldBe true
+      result.swap.toOption.get shouldBe an[AuthenticationError]
     }
 
   it should "map HTTP 429 to RateLimitError" in
@@ -200,13 +199,12 @@ class CohereClientStreamingSpec extends AnyFlatSpec with Matchers {
     }
 
   it should "map HTTP 500 to ServiceError" in
-    withServer("/v2/chat")(exchange => sendJsonResponse(exchange, 500, """{"message":"Internal error"}""")) {
-      baseUrl =>
-        val client = new CohereClient(localConfig(baseUrl))
-        val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+    withServer("/v2/chat")(exchange => sendJsonResponse(exchange, 500, """{"message":"Internal error"}""")) { baseUrl =>
+      val client = new CohereClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
 
-        result.isLeft shouldBe true
-        result.swap.toOption.get shouldBe a[ServiceError]
+      result.isLeft shouldBe true
+      result.swap.toOption.get shouldBe a[ServiceError]
     }
 
   it should "not invoke onChunk when the server returns an error status" in
@@ -225,45 +223,43 @@ class CohereClientStreamingSpec extends AnyFlatSpec with Matchers {
   // ===========================================================================
 
   it should "record a provider exchange with streaming request and SSE response body" in
-    withServer("/v2/chat")(exchange => sendSseResponse(exchange, cohereSseBody(Seq("Hello", " Cohere")))) {
-      baseUrl =>
-        val exchanges = ListBuffer.empty[ProviderExchange]
-        val sink = new ProviderExchangeSink:
-          override def record(e: ProviderExchange): Unit = exchanges += e
+    withServer("/v2/chat")(exchange => sendSseResponse(exchange, cohereSseBody(Seq("Hello", " Cohere")))) { baseUrl =>
+      val exchanges = ListBuffer.empty[ProviderExchange]
+      val sink = new ProviderExchangeSink:
+        override def record(e: ProviderExchange): Unit = exchanges += e
 
-        val client = new CohereClient(
-          localConfig(baseUrl),
-          exchangeLogging = ProviderExchangeLogging.enabled(sink)
-        )
-        val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+      val client = new CohereClient(
+        localConfig(baseUrl),
+        exchangeLogging = ProviderExchangeLogging.enabled(sink)
+      )
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
 
-        result.isRight shouldBe true
-        exchanges should have size 1
-        val ex = exchanges.head
-        ex.provider shouldBe "cohere"
-        ex.model shouldBe Some("command-r")
-        ex.requestBody should include("\"stream\":true")
-        ex.requestBody should include("hello")
-        ex.responseBody.value should include("data:")
-        ex.responseBody.value should include("content-delta")
-        ex.errorMessage shouldBe empty
+      result.isRight shouldBe true
+      exchanges should have size 1
+      val ex = exchanges.head
+      ex.provider shouldBe "cohere"
+      ex.model shouldBe Some("command-r")
+      ex.requestBody should include("\"stream\":true")
+      ex.requestBody should include("hello")
+      ex.responseBody.value should include("data:")
+      ex.responseBody.value should include("content-delta")
+      ex.errorMessage shouldBe empty
     }
 
   it should "record a provider exchange with errorMessage when streaming returns an error" in
-    withServer("/v2/chat")(exchange => sendJsonResponse(exchange, 401, """{"message":"Unauthorized"}""")) {
-      baseUrl =>
-        val exchanges = ListBuffer.empty[ProviderExchange]
-        val sink = new ProviderExchangeSink:
-          override def record(e: ProviderExchange): Unit = exchanges += e
+    withServer("/v2/chat")(exchange => sendJsonResponse(exchange, 401, """{"message":"Unauthorized"}""")) { baseUrl =>
+      val exchanges = ListBuffer.empty[ProviderExchange]
+      val sink = new ProviderExchangeSink:
+        override def record(e: ProviderExchange): Unit = exchanges += e
 
-        val client = new CohereClient(
-          localConfig(baseUrl),
-          exchangeLogging = ProviderExchangeLogging.enabled(sink)
-        )
-        client.streamComplete(conversation, CompletionOptions(), _ => ())
+      val client = new CohereClient(
+        localConfig(baseUrl),
+        exchangeLogging = ProviderExchangeLogging.enabled(sink)
+      )
+      client.streamComplete(conversation, CompletionOptions(), _ => ())
 
-        exchanges should have size 1
-        exchanges.head.errorMessage shouldBe defined
+      exchanges should have size 1
+      exchanges.head.errorMessage shouldBe defined
     }
 
   // ===========================================================================

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/MistralClientClosedStateTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/MistralClientClosedStateTest.scala
@@ -46,9 +46,11 @@ class MistralClientClosedStateTest extends AnyFlatSpec with Matchers {
     )
   }
 
-  it should "return ConfigurationError when streamComplete() is called (streaming not supported)" in {
+  it should "return ConfigurationError when streamComplete() is called after close()" in {
     val client         = new MistralClient(createTestConfig)
     var chunksReceived = 0
+
+    client.close()
 
     val result = client.streamComplete(
       createTestConversation,
@@ -59,7 +61,7 @@ class MistralClientClosedStateTest extends AnyFlatSpec with Matchers {
     result.fold(
       err => {
         err shouldBe a[ConfigurationError]
-        err.message.toLowerCase should include("stream")
+        err.message should include("already closed")
       },
       _ => fail("Expected Left(ConfigurationError)")
     )

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/MistralClientStreamingSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/MistralClientStreamingSpec.scala
@@ -1,0 +1,250 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.{ AuthenticationError, RateLimitError, ServiceError }
+import org.llm4s.llmconnect.{ ProviderExchange, ProviderExchangeLogging, ProviderExchangeSink }
+import org.llm4s.llmconnect.config.MistralConfig
+import org.llm4s.llmconnect.model._
+import org.llm4s.testutil.LocalProviderTestServer._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues._
+
+import java.nio.charset.StandardCharsets
+import scala.collection.mutable.ListBuffer
+import org.llm4s.model.ModelRegistryService
+
+/**
+ * HTTP-level tests for MistralClient.streamComplete() (PR #925).
+ *
+ * Verifies that the new SSE streaming implementation correctly handles
+ * the OpenAI-compatible streaming format used by Mistral's v1/chat/completions
+ * endpoint.  All tests run against a local in-process HTTP server — no API
+ * keys or external services are required.
+ */
+class MistralClientStreamingSpec extends AnyFlatSpec with Matchers {
+
+  private given ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+
+  private def localConfig(baseUrl: String): MistralConfig =
+    MistralConfig(
+      apiKey = "test-key",
+      model = "mistral-small-latest",
+      baseUrl = baseUrl,
+      contextWindow = 128000,
+      reserveCompletion = 4096
+    )
+
+  private def conversation: Conversation = Conversation(Seq(UserMessage("hello")))
+
+  // ===========================================================================
+  // streamComplete() — happy path
+  // ===========================================================================
+
+  "MistralClient.streamComplete" should "parse SSE events and accumulate content" in
+    withServer("/v1/chat/completions") { exchange =>
+      sendSseResponse(exchange, openAISseBody(Seq("Hello", " world"), "mistral-small-latest"))
+    } { baseUrl =>
+      val client = new MistralClient(localConfig(baseUrl))
+      val chunks = ListBuffer.empty[StreamedChunk]
+      val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+      result.isRight shouldBe true
+      val completion = result.toOption.get
+      completion.content shouldBe "Hello world"
+      completion.model shouldBe "mistral-small-latest"
+      chunks should not be empty
+    }
+
+  it should "deliver each SSE chunk to the onChunk callback" in
+    withServer("/v1/chat/completions") { exchange =>
+      sendSseResponse(exchange, openAISseBody(Seq("A", "B", "C"), "mistral-small-latest"))
+    } { baseUrl =>
+      val client = new MistralClient(localConfig(baseUrl))
+      val chunks = ListBuffer.empty[StreamedChunk]
+      val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+      result.isRight shouldBe true
+      chunks.flatMap(_.content).mkString shouldBe "ABC"
+      chunks.size shouldBe 3
+    }
+
+  it should "accumulate token usage from the final SSE chunk" in
+    withServer("/v1/chat/completions") { exchange =>
+      sendSseResponse(exchange, openAISseBody(Seq("Hi"), "mistral-small-latest"))
+    } { baseUrl =>
+      val client = new MistralClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isRight shouldBe true
+      val usage = result.toOption.get.usage
+      usage shouldBe defined
+      usage.get.promptTokens shouldBe 10
+      usage.get.completionTokens shouldBe 5
+    }
+
+  it should "return a completion even when the SSE stream has no content chunks (only [DONE])" in
+    withServer("/v1/chat/completions") { exchange =>
+      val onlyDone = "data: [DONE]\n\n"
+      sendSseResponse(exchange, onlyDone)
+    } { baseUrl =>
+      val client = new MistralClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isRight shouldBe true
+      result.toOption.get.content shouldBe ""
+    }
+
+  it should "populate the returned completion id from SSE chunk ids" in
+    withServer("/v1/chat/completions") { exchange =>
+      sendSseResponse(exchange, openAISseBody(Seq("Hi"), "mistral-small-latest"))
+    } { baseUrl =>
+      val client = new MistralClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isRight shouldBe true
+      result.toOption.get.id shouldBe "chatcmpl-test"
+    }
+
+  it should "set stream:true in the outgoing request body" in
+    withServer("/v1/chat/completions") { exchange =>
+      val body = new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
+      val json = ujson.read(body)
+      json("stream").bool shouldBe true
+      sendSseResponse(exchange, openAISseBody(Seq("ok"), "mistral-small-latest"))
+    } { baseUrl =>
+      val client = new MistralClient(localConfig(baseUrl))
+      client.streamComplete(conversation, CompletionOptions(), _ => ())
+    }
+
+  it should "include the model in the request body" in
+    withServer("/v1/chat/completions") { exchange =>
+      val body = new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
+      val json = ujson.read(body)
+      json("model").str shouldBe "mistral-small-latest"
+      sendSseResponse(exchange, openAISseBody(Seq("ok"), "mistral-small-latest"))
+    } { baseUrl =>
+      val client = new MistralClient(localConfig(baseUrl))
+      client.streamComplete(conversation, CompletionOptions(), _ => ())
+    }
+
+  it should "pass maxTokens option in the streaming request" in
+    withServer("/v1/chat/completions") { exchange =>
+      val body = new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
+      val json = ujson.read(body)
+      json("max_tokens").num.toInt shouldBe 256
+      sendSseResponse(exchange, openAISseBody(Seq("ok"), "mistral-small-latest"))
+    } { baseUrl =>
+      val client = new MistralClient(localConfig(baseUrl))
+      client.streamComplete(conversation, CompletionOptions(maxTokens = Some(256)), _ => ())
+    }
+
+  // ===========================================================================
+  // streamComplete() — error handling
+  // ===========================================================================
+
+  it should "map HTTP 401 to AuthenticationError" in
+    withServer("/v1/chat/completions")(exchange => sendJsonResponse(exchange, 401, """{"error":"Unauthorized"}""")) {
+      baseUrl =>
+        val client = new MistralClient(localConfig(baseUrl))
+        val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+        result.isLeft shouldBe true
+        result.swap.toOption.get shouldBe an[AuthenticationError]
+    }
+
+  it should "map HTTP 429 to RateLimitError" in
+    withServer("/v1/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 429, """{"error":"Rate limit exceeded"}""")
+    } { baseUrl =>
+      val client = new MistralClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isLeft shouldBe true
+      result.swap.toOption.get shouldBe a[RateLimitError]
+    }
+
+  it should "map HTTP 500 to ServiceError" in
+    withServer("/v1/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 500, """{"error":"Internal server error"}""")
+    } { baseUrl =>
+      val client = new MistralClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isLeft shouldBe true
+      result.swap.toOption.get shouldBe a[ServiceError]
+    }
+
+  it should "not invoke onChunk when the server returns an error status" in
+    withServer("/v1/chat/completions")(exchange => sendJsonResponse(exchange, 429, """{"error":"Rate limited"}""")) {
+      baseUrl =>
+        val client       = new MistralClient(localConfig(baseUrl))
+        var chunksCalled = 0
+        val result       = client.streamComplete(conversation, CompletionOptions(), _ => chunksCalled += 1)
+
+        result.isLeft shouldBe true
+        chunksCalled shouldBe 0
+    }
+
+  // ===========================================================================
+  // streamComplete() — exchange logging
+  // ===========================================================================
+
+  it should "record a provider exchange with streaming request and SSE response body" in
+    withServer("/v1/chat/completions") { exchange =>
+      sendSseResponse(exchange, openAISseBody(Seq("Hello", " Mistral"), "mistral-small-latest"))
+    } { baseUrl =>
+      val exchanges = ListBuffer.empty[ProviderExchange]
+      val sink = new ProviderExchangeSink:
+        override def record(e: ProviderExchange): Unit = exchanges += e
+
+      val client = new MistralClient(
+        localConfig(baseUrl),
+        exchangeLogging = ProviderExchangeLogging.enabled(sink)
+      )
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isRight shouldBe true
+      exchanges should have size 1
+      val ex = exchanges.head
+      ex.provider shouldBe "mistral"
+      ex.model shouldBe Some("mistral-small-latest")
+      ex.requestBody should include("\"stream\":true")
+      ex.requestBody should include("hello")
+      ex.responseBody.value should include("data:")
+      ex.responseBody.value should include("Hello")
+      ex.responseBody.value should include("[DONE]")
+      ex.errorMessage shouldBe empty
+    }
+
+  it should "record a provider exchange with errorMessage when streaming returns an error" in
+    withServer("/v1/chat/completions")(exchange => sendJsonResponse(exchange, 401, """{"error":"Unauthorized"}""")) {
+      baseUrl =>
+        val exchanges = ListBuffer.empty[ProviderExchange]
+        val sink = new ProviderExchangeSink:
+          override def record(e: ProviderExchange): Unit = exchanges += e
+
+        val client = new MistralClient(
+          localConfig(baseUrl),
+          exchangeLogging = ProviderExchangeLogging.enabled(sink)
+        )
+        client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+        exchanges should have size 1
+        exchanges.head.errorMessage shouldBe defined
+    }
+
+  // ===========================================================================
+  // closed-state — streamComplete after close
+  // ===========================================================================
+
+  it should "return ConfigurationError when called after close()" in {
+    val client = new MistralClient(
+      MistralConfig("k", "mistral-small-latest", "https://example.invalid", 128000, 4096)
+    )
+    client.close()
+    val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get.message should include("already closed")
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/MistralClientStreamingSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/MistralClientStreamingSpec.scala
@@ -94,6 +94,36 @@ class MistralClientStreamingSpec extends AnyFlatSpec with Matchers {
       result.toOption.get.content shouldBe ""
     }
 
+  it should "handle a chunk with an empty choices array (usage-only chunk)" in
+    withServer("/v1/chat/completions") { exchange =>
+      val emptyChoices =
+        """data: {"id":"chatcmpl-test","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}"""
+      sendSseResponse(exchange, s"$emptyChoices\n\ndata: [DONE]\n\n")
+    } { baseUrl =>
+      val client = new MistralClient(localConfig(baseUrl))
+      val chunks = ListBuffer.empty[StreamedChunk]
+      val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+      result.isRight shouldBe true
+      chunks shouldBe empty
+      result.toOption.get.content shouldBe ""
+      result.toOption.get.usage.get.promptTokens shouldBe 3
+    }
+
+  it should "tolerate a chunk whose usage field has no recognised token counts" in
+    withServer("/v1/chat/completions") { exchange =>
+      val noTokens =
+        """data: {"id":"chatcmpl-test","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}],"usage":{}}"""
+      sendSseResponse(exchange, s"$noTokens\n\ndata: [DONE]\n\n")
+    } { baseUrl =>
+      val client = new MistralClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isRight shouldBe true
+      result.toOption.get.content shouldBe "hi"
+      result.toOption.get.usage shouldBe None
+    }
+
   it should "populate the returned completion id from SSE chunk ids" in
     withServer("/v1/chat/completions") { exchange =>
       sendSseResponse(exchange, openAISseBody(Seq("Hi"), "mistral-small-latest"))


### PR DESCRIPTION
## Summary

Fixes #925

Both `CohereClient` and `MistralClient` previously returned `Left(ConfigurationError("... streaming is not supported"))` from `streamComplete`, silently breaking any user who switched from OpenAI expecting feature parity.

- **MistralClient**: implements SSE streaming via the OpenAI-compatible format (`"stream": true`, `data: [DONE]` terminator) — reuses the same `SSEParser` + `StreamingAccumulator` pattern as `OpenRouterClient`
- **CohereClient**: implements SSE streaming for the Cohere v2 event format, handling `message-start` (captures ID), `content-delta` (emits text chunks), and `message-end` (extracts token usage and finish reason)

Both providers now follow the same exchange-logging contract as the other streaming-capable providers (request body, raw SSE stream, and `tapLeft` on errors).

Updated `CohereClientClosedStateTest` and `MistralClientClosedStateTest`: the "streaming not supported" test cases are replaced with closed-state tests for `streamComplete()`, consistent with the existing `complete()` closed-state tests.

## Test plan

- [x] `sbt "core/compile"` — clean compile
- [x] `sbt "core/test"` — all 6731 tests pass (0 failures)
- [x] `sbt "core/scalafmtAll"` — code formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)