### PR TITLE
feat(vertexai): add Vertex AI provider with OAuth2 ADC authentication (fixes #930)

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/config/DefaultConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/DefaultConfig.scala
@@ -17,4 +17,5 @@ object DefaultConfig {
   val DEFAULT_LANGFUSE_RELEASE          = "1.0.0"
   val DEFAULT_LANGFUSE_VERSION          = "1.0.0"
   val DEFAULT_AZURE_V2025_01_01_PREVIEW = "V2025_01_01_PREVIEW"
+  val DEFAULT_VERTEXAI_LOCATION        = "us-central1"
 }

--- a/modules/core/src/main/scala/org/llm4s/config/DefaultConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/DefaultConfig.scala
@@ -17,5 +17,5 @@ object DefaultConfig {
   val DEFAULT_LANGFUSE_RELEASE          = "1.0.0"
   val DEFAULT_LANGFUSE_VERSION          = "1.0.0"
   val DEFAULT_AZURE_V2025_01_01_PREVIEW = "V2025_01_01_PREVIEW"
-  val DEFAULT_VERTEXAI_LOCATION        = "us-central1"
+  val DEFAULT_VERTEXAI_LOCATION         = "us-central1"
 }

--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
@@ -104,3 +104,10 @@ private[config] object NamedProviderLoader:
         requiredApiKey("llm4s.providers.<name>.apiKey").map: apiKey =>
           val baseUrl = section.baseUrl.map(_.asUrl).getOrElse(MistralConfig.DEFAULT_BASE_URL)
           MistralConfig.fromValues(section.model.asString, apiKey, baseUrl)
+      case ProviderKind.VertexAI =>
+        for
+          projectId <- required("endpoint (GCP project ID)", section.endpoint, "llm4s.providers.<name>.endpoint")
+        yield
+          val location          = section.organization.getOrElse(DefaultConfig.DEFAULT_VERTEXAI_LOCATION)
+          val credentialFilePath = section.apiKey.map(_.asKey)
+          VertexAIConfig.fromValues(section.model.asString, projectId, location, credentialFilePath)

--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
@@ -105,9 +105,8 @@ private[config] object NamedProviderLoader:
           val baseUrl = section.baseUrl.map(_.asUrl).getOrElse(MistralConfig.DEFAULT_BASE_URL)
           MistralConfig.fromValues(section.model.asString, apiKey, baseUrl)
       case ProviderKind.VertexAI =>
-        for
-          projectId <- required("endpoint (GCP project ID)", section.endpoint, "llm4s.providers.<name>.endpoint")
+        for projectId <- required("endpoint (GCP project ID)", section.endpoint, "llm4s.providers.<name>.endpoint")
         yield
-          val location          = section.organization.getOrElse(DefaultConfig.DEFAULT_VERTEXAI_LOCATION)
+          val location           = section.organization.getOrElse(DefaultConfig.DEFAULT_VERTEXAI_LOCATION)
           val credentialFilePath = section.apiKey.map(_.asKey)
           VertexAIConfig.fromValues(section.model.asString, projectId, location, credentialFilePath)

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -170,7 +170,7 @@ object LLMConnect {
       case (ProviderKind.DeepSeek, cfg: DeepSeekConfig)   => DeepSeekClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Cohere, cfg: CohereConfig)       => CohereClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Mistral, cfg: MistralConfig)     => MistralClient(cfg, metrics, exchangeLogging)
-      case (ProviderKind.VertexAI, cfg: VertexAIConfig)    => VertexAIClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.VertexAI, cfg: VertexAIConfig)   => VertexAIClient(cfg, metrics, exchangeLogging)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -58,6 +58,8 @@ object LLMConnect {
         CohereClient(cfg, metrics, exchangeLogging)
       case cfg: MistralConfig =>
         MistralClient(cfg, metrics, exchangeLogging)
+      case cfg: VertexAIConfig =>
+        VertexAIClient(cfg, metrics, exchangeLogging)
     }
 
   def fromConfig(
@@ -168,6 +170,7 @@ object LLMConnect {
       case (ProviderKind.DeepSeek, cfg: DeepSeekConfig)   => DeepSeekClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Cohere, cfg: CohereConfig)       => CohereClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Mistral, cfg: MistralConfig)     => MistralClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.VertexAI, cfg: VertexAIConfig)    => VertexAIClient(cfg, metrics, exchangeLogging)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -677,3 +677,79 @@ object MistralConfig:
       contextWindow = cw,
       reserveCompletion = rc
     )
+
+/**
+ * Configuration for Google Cloud Vertex AI.
+ *
+ * Uses the Gemini-compatible REST format (`aiplatform.googleapis.com`) with
+ * OAuth2 bearer-token authentication via Application Default Credentials (ADC).
+ *
+ * @param projectId          GCP project ID that owns the Vertex AI resources.
+ * @param location           GCP region, e.g. `"us-central1"`.
+ * @param model              Model identifier, e.g. `"gemini-2.0-flash"`.
+ * @param credentialFilePath Optional path to a Google JSON credential file.
+ *                           Falls back to `GOOGLE_APPLICATION_CREDENTIALS` env,
+ *                           then `~/.config/gcloud/application_default_credentials.json`,
+ *                           then the GCE metadata server.
+ * @param contextWindow      Maximum token capacity for prompt + completion combined.
+ * @param reserveCompletion  Tokens reserved for the completion response.
+ */
+case class VertexAIConfig(
+  projectId: String,
+  location: String,
+  model: String,
+  credentialFilePath: Option[String],
+  contextWindow: Int,
+  reserveCompletion: Int
+) extends ProviderConfig:
+  override val provider: ProviderKind = ProviderKind.VertexAI
+
+  /** Base URL derived from the location, e.g. `"https://us-central1-aiplatform.googleapis.com/v1"`. */
+  def computedBaseUrl: String = s"https://$location-aiplatform.googleapis.com/v1"
+
+  override def toString: String =
+    s"VertexAIConfig(projectId=$projectId, location=$location, model=$model, " +
+      s"credentialFilePath=${credentialFilePath.map(_ => "<redacted>").getOrElse("none")}, " +
+      s"contextWindow=$contextWindow, reserveCompletion=$reserveCompletion)"
+
+object VertexAIConfig:
+  val DEFAULT_LOCATION = "us-central1"
+
+  private val DefaultContextWindow     = 1048576
+  private val DefaultReserveCompletion = 8192
+
+  private val vertexAiFallback: String => (Int, Int) =
+    _ => (DefaultContextWindow, DefaultReserveCompletion)
+
+  /**
+   * Constructs a [[VertexAIConfig]], resolving `contextWindow` and
+   * `reserveCompletion` from the model registry if available.
+   *
+   * @param modelName          Model identifier, e.g. `"gemini-2.0-flash"`.
+   * @param projectId          GCP project ID.
+   * @param location           GCP region (defaults to `"us-central1"`).
+   * @param credentialFilePath Optional path to a Google JSON credential file.
+   */
+  def fromValues(
+    modelName: String,
+    projectId: String,
+    location: String = DEFAULT_LOCATION,
+    credentialFilePath: Option[String] = None
+  )(using resolver: ContextWindowResolver): VertexAIConfig =
+    require(projectId.trim.nonEmpty, "Vertex AI projectId must be non-empty")
+    require(location.trim.nonEmpty, "Vertex AI location must be non-empty")
+    val (cw, rc) = resolver.resolve(
+      lookupProviders = Seq("gemini", "vertexai"),
+      modelName = modelName,
+      defaultContextWindow = DefaultContextWindow,
+      defaultReserve = DefaultReserveCompletion,
+      fallbackResolver = vertexAiFallback
+    )
+    VertexAIConfig(
+      projectId = projectId,
+      location = location,
+      model = modelName,
+      credentialFilePath = credentialFilePath,
+      contextWindow = cw,
+      reserveCompletion = rc
+    )

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VertexAIAuthProvider.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VertexAIAuthProvider.scala
@@ -136,8 +136,8 @@ class VertexAIAuthProvider(
 
     for {
       privateKey <- parsePrivateKey(privateKeyPem)
-      jwt         = createJwt(clientEmail, privateKey, tokenUri)
-      token      <- exchangeJwtForToken(jwt, tokenUri)
+      jwt = createJwt(clientEmail, privateKey, tokenUri)
+      token <- exchangeJwtForToken(jwt, tokenUri)
     } yield token
   }
 
@@ -149,9 +149,7 @@ class VertexAIAuthProvider(
         .replaceAll("\\s", "")
       val keyBytes = Base64.getDecoder.decode(cleaned)
       KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(keyBytes))
-    }.toEither.left.map(e =>
-      AuthenticationError("vertexai", s"Failed to parse private key: ${e.getMessage}")
-    )
+    }.toEither.left.map(e => AuthenticationError("vertexai", s"Failed to parse private key: ${e.getMessage}"))
 
   private def createJwt(serviceAccountEmail: String, privateKey: java.security.PrivateKey, tokenUri: String): String = {
     val now     = System.currentTimeMillis() / 1000
@@ -175,7 +173,7 @@ class VertexAIAuthProvider(
   }
 
   private def exchangeJwtForToken(jwt: String, tokenUri: String): Result[CachedToken] = {
-    val body     = s"grant_type=${enc("urn:ietf:params:oauth:grant-type:jwt-bearer")}&assertion=${enc(jwt)}"
+    val body = s"grant_type=${enc("urn:ietf:params:oauth:grant-type:jwt-bearer")}&assertion=${enc(jwt)}"
     val response = httpClient.post(
       tokenUri,
       Map("Content-Type" -> "application/x-www-form-urlencoded"),
@@ -231,7 +229,7 @@ class VertexAIAuthProvider(
 }
 
 object VertexAIAuthProvider {
-  private[provider] val TOKEN_ENDPOINT     = "https://oauth2.googleapis.com/token"
+  private[provider] val TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
   private[provider] val METADATA_TOKEN_URL =
     "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
 

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VertexAIAuthProvider.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VertexAIAuthProvider.scala
@@ -1,0 +1,241 @@
+// scalafix:off DisableSyntax.NoKeywordTry, DisableSyntax.NoSystemGetenv
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.AuthenticationError
+import org.llm4s.error.ThrowableOps._
+import org.llm4s.http.Llm4sHttpClient
+import org.llm4s.types.Result
+import org.slf4j.LoggerFactory
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Paths }
+import java.security.KeyFactory
+import java.security.Signature
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
+import scala.util.Try
+
+/**
+ * Provides Google Cloud OAuth2 access tokens for Vertex AI via ADC.
+ *
+ * Token resolution order:
+ *  1. `GOOGLE_ACCESS_TOKEN` environment variable — direct token; useful for CI and testing.
+ *  2. JSON credential file resolved from [[credentialFilePath]], then
+ *     `GOOGLE_APPLICATION_CREDENTIALS`, then
+ *     `~/.config/gcloud/application_default_credentials.json`.
+ *     Supports both `authorized_user` (refresh-token flow) and `service_account`
+ *     (RS256 JWT assertion flow, no extra dependencies).
+ *  3. GCE / GKE metadata server — Workload Identity path for production deployments.
+ *
+ * Tokens are cached until one minute before expiry to minimise round-trips.
+ *
+ * @param credentialFilePath Optional explicit path to a Google JSON credential file.
+ * @param httpClient         HTTP client for token-endpoint calls.
+ * @param envReader          Environment variable reader; injectable for testing.
+ * @param fileReader         File reader; injectable for testing.
+ */
+class VertexAIAuthProvider(
+  credentialFilePath: Option[String],
+  httpClient: Llm4sHttpClient,
+  envReader: String => Option[String] = key => Option(System.getenv(key)),
+  fileReader: String => Result[String] = path =>
+    Try(new String(Files.readAllBytes(Paths.get(path)), StandardCharsets.UTF_8)).toEither.left.map(_.toLLMError)
+) {
+  import VertexAIAuthProvider._
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  @volatile private var cachedToken: Option[CachedToken] = None
+
+  /** Returns a valid OAuth2 access token, fetching or refreshing as needed. */
+  def getAccessToken(): Result[String] =
+    cachedToken match {
+      case Some(t) if !t.isExpired => Right(t.token)
+      case _                       => fetchAndCacheToken()
+    }
+
+  private def fetchAndCacheToken(): Result[String] =
+    fetchToken().map { t =>
+      cachedToken = Some(t)
+      t.token
+    }
+
+  private def fetchToken(): Result[CachedToken] = {
+    envReader("GOOGLE_ACCESS_TOKEN") match {
+      case Some(tok) if tok.nonEmpty =>
+        logger.debug("[VertexAI] Using GOOGLE_ACCESS_TOKEN from environment")
+        return Right(CachedToken(tok, Long.MaxValue))
+      case _ => ()
+    }
+
+    resolveCredentialFilePath() match {
+      case Some(path) =>
+        fileReader(path).flatMap(fetchTokenFromCredentialFile)
+      case None =>
+        fetchTokenFromMetadataServer()
+    }
+  }
+
+  private def resolveCredentialFilePath(): Option[String] =
+    credentialFilePath
+      .orElse(envReader("GOOGLE_APPLICATION_CREDENTIALS"))
+      .orElse {
+        val defaultPath =
+          s"${System.getProperty("user.home")}/.config/gcloud/application_default_credentials.json"
+        if (new java.io.File(defaultPath).exists()) Some(defaultPath) else None
+      }
+
+  private def fetchTokenFromCredentialFile(content: String): Result[CachedToken] =
+    Try(ujson.read(content)).toEither.left.map(_.toLLMError).flatMap { json =>
+      Try(json("type").str).toOption match {
+        case Some("authorized_user") => refreshTokenFlow(json)
+        case Some("service_account") => serviceAccountFlow(json)
+        case Some(other)             => Left(AuthenticationError("vertexai", s"Unsupported credential type: $other"))
+        case None                    => Left(AuthenticationError("vertexai", "Credential file missing 'type' field"))
+      }
+    }
+
+  private def refreshTokenFlow(json: ujson.Value): Result[CachedToken] = {
+    val clientId     = json("client_id").str
+    val clientSecret = json("client_secret").str
+    val refreshToken = json("refresh_token").str
+
+    val body =
+      s"client_id=${enc(clientId)}&client_secret=${enc(clientSecret)}" +
+        s"&grant_type=refresh_token&refresh_token=${enc(refreshToken)}"
+
+    val response = httpClient.post(
+      TOKEN_ENDPOINT,
+      Map("Content-Type" -> "application/x-www-form-urlencoded"),
+      body
+    )
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      Try {
+        val respJson  = ujson.read(response.body)
+        val token     = respJson("access_token").str
+        val expiresIn = Try(respJson("expires_in").num.toInt).getOrElse(3600)
+        val expiresAt = System.currentTimeMillis() + (expiresIn.toLong - 60) * 1000
+        CachedToken(token, expiresAt)
+      }.toEither.left.map(_.toLLMError)
+    } else {
+      Left(
+        AuthenticationError(
+          "vertexai",
+          s"Token refresh failed (HTTP ${response.statusCode}): ${response.body}"
+        )
+      )
+    }
+  }
+
+  private def serviceAccountFlow(json: ujson.Value): Result[CachedToken] = {
+    val clientEmail   = json("client_email").str
+    val privateKeyPem = json("private_key").str
+    val tokenUri      = Try(json("token_uri").str).getOrElse(TOKEN_ENDPOINT)
+
+    for {
+      privateKey <- parsePrivateKey(privateKeyPem)
+      jwt         = createJwt(clientEmail, privateKey, tokenUri)
+      token      <- exchangeJwtForToken(jwt, tokenUri)
+    } yield token
+  }
+
+  private def parsePrivateKey(pem: String): Result[java.security.PrivateKey] =
+    Try {
+      val cleaned = pem
+        .replace("-----BEGIN PRIVATE KEY-----", "")
+        .replace("-----END PRIVATE KEY-----", "")
+        .replaceAll("\\s", "")
+      val keyBytes = Base64.getDecoder.decode(cleaned)
+      KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(keyBytes))
+    }.toEither.left.map(e =>
+      AuthenticationError("vertexai", s"Failed to parse private key: ${e.getMessage}")
+    )
+
+  private def createJwt(serviceAccountEmail: String, privateKey: java.security.PrivateKey, tokenUri: String): String = {
+    val now     = System.currentTimeMillis() / 1000
+    val encoder = Base64.getUrlEncoder.withoutPadding()
+
+    val header = encoder.encodeToString(
+      """{"alg":"RS256","typ":"JWT"}""".getBytes(StandardCharsets.UTF_8)
+    )
+    val payload = encoder.encodeToString(
+      s"""{"iss":"$serviceAccountEmail","scope":"https://www.googleapis.com/auth/cloud-platform","aud":"$tokenUri","exp":${now + 3600},"iat":$now}"""
+        .getBytes(StandardCharsets.UTF_8)
+    )
+
+    val signingInput = s"$header.$payload"
+    val signer       = Signature.getInstance("SHA256withRSA")
+    signer.initSign(privateKey)
+    signer.update(signingInput.getBytes(StandardCharsets.UTF_8))
+    val sig = encoder.encodeToString(signer.sign())
+
+    s"$signingInput.$sig"
+  }
+
+  private def exchangeJwtForToken(jwt: String, tokenUri: String): Result[CachedToken] = {
+    val body     = s"grant_type=${enc("urn:ietf:params:oauth:grant-type:jwt-bearer")}&assertion=${enc(jwt)}"
+    val response = httpClient.post(
+      tokenUri,
+      Map("Content-Type" -> "application/x-www-form-urlencoded"),
+      body
+    )
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      Try {
+        val respJson  = ujson.read(response.body)
+        val token     = respJson("access_token").str
+        val expiresIn = Try(respJson("expires_in").num.toInt).getOrElse(3600)
+        val expiresAt = System.currentTimeMillis() + (expiresIn.toLong - 60) * 1000
+        CachedToken(token, expiresAt)
+      }.toEither.left.map(_.toLLMError)
+    } else {
+      Left(
+        AuthenticationError(
+          "vertexai",
+          s"JWT token exchange failed (HTTP ${response.statusCode}): ${response.body}"
+        )
+      )
+    }
+  }
+
+  private def fetchTokenFromMetadataServer(): Result[CachedToken] = {
+    logger.debug("[VertexAI] Attempting to fetch token from GCE metadata server")
+    Try {
+      val response = httpClient.get(
+        METADATA_TOKEN_URL,
+        Map("Metadata-Flavor" -> "Google")
+      )
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        Try {
+          val json      = ujson.read(response.body)
+          val token     = json("access_token").str
+          val expiresIn = Try(json("expires_in").num.toInt).getOrElse(3600)
+          val expiresAt = System.currentTimeMillis() + (expiresIn.toLong - 60) * 1000
+          CachedToken(token, expiresAt)
+        }.toEither.left.map(_.toLLMError)
+      } else {
+        Left(
+          AuthenticationError(
+            "vertexai",
+            "No credentials found. Set GOOGLE_ACCESS_TOKEN, GOOGLE_APPLICATION_CREDENTIALS, " +
+              "run 'gcloud auth application-default login', or deploy on GCE/GKE for Workload Identity."
+          )
+        )
+      }
+    }.toEither.left.map(_.toLLMError).flatten
+  }
+
+  private def enc(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8)
+}
+
+object VertexAIAuthProvider {
+  private[provider] val TOKEN_ENDPOINT     = "https://oauth2.googleapis.com/token"
+  private[provider] val METADATA_TOKEN_URL =
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
+
+  private[provider] case class CachedToken(token: String, expiresAtMillis: Long) {
+    def isExpired: Boolean = System.currentTimeMillis() >= expiresAtMillis
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VertexAIClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VertexAIClient.scala
@@ -92,7 +92,7 @@ class VertexAIClient(
         logger.debug(s"[VertexAI] Request body: $requestText")
 
         for {
-          token  <- authProvider.getAccessToken()
+          token <- authProvider.getAccessToken()
           headers = Map("Content-Type" -> "application/json", "Authorization" -> s"Bearer $token")
           attempt <- Try {
             val response = httpClient.post(url, headers, requestText, timeout = 120000)
@@ -133,7 +133,7 @@ class VertexAIClient(
         logger.debug(s"[VertexAI] Starting stream to $url")
 
         for {
-          token  <- authProvider.getAccessToken()
+          token <- authProvider.getAccessToken()
           headers = Map("Content-Type" -> "application/json", "Authorization" -> s"Bearer $token")
           result <- {
             val response = httpClient.postStream(url, headers, requestText, timeout = 600000)
@@ -188,7 +188,12 @@ class VertexAIClient(
                   }
                 )
                 .tapLeft(error =>
-                  recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(error))
+                  recordExchange(
+                    startedAt,
+                    requestText,
+                    Option.when(rawStream.nonEmpty)(rawStream.result()),
+                    Left(error)
+                  )
                 )
             }
           }
@@ -200,9 +205,9 @@ class VertexAIClient(
   override def getReserveCompletion(): Int = config.reserveCompletion
 
   private def buildRequestBody(conversation: Conversation, options: CompletionOptions): ujson.Value = {
-    val contents             = scala.collection.mutable.ArrayBuffer[ujson.Value]()
-    var systemInstr          = Option.empty[String]
-    val toolCallIdToName     = scala.collection.mutable.Map[String, String]()
+    val contents         = scala.collection.mutable.ArrayBuffer[ujson.Value]()
+    var systemInstr      = Option.empty[String]
+    val toolCallIdToName = scala.collection.mutable.Map[String, String]()
 
     conversation.messages.foreach {
       case SystemMessage(content) =>
@@ -344,10 +349,10 @@ class VertexAIClient(
     Try {
       val candidates = json("candidates").arr
       if (candidates.nonEmpty) {
-        val candidate   = candidates.head
-        val content     = candidate("content")
-        val parts       = content("parts").arr
-        val textContent = parts.filter(p => p.obj.contains("text")).map(_("text").str).mkString
+        val candidate    = candidates.head
+        val content      = candidate("content")
+        val parts        = content("parts").arr
+        val textContent  = parts.filter(p => p.obj.contains("text")).map(_("text").str).mkString
         val finishReason = Try(candidate("finishReason").str).toOption
 
         val toolCallOpt = parts

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VertexAIClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VertexAIClient.scala
@@ -1,0 +1,417 @@
+// scalafix:off DisableSyntax.NoKeywordTry, DisableSyntax.NoKeywordFinally
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.ThrowableOps._
+import org.llm4s.http.Llm4sHttpClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
+import org.llm4s.llmconnect.ProviderExchangeLogging
+import org.llm4s.llmconnect.config.VertexAIConfig
+import org.llm4s.llmconnect.model._
+import org.llm4s.llmconnect.provider.ProviderResultOps.*
+import org.llm4s.llmconnect.streaming._
+import org.llm4s.model.{ ModelRegistryService, TransformationResult }
+import org.llm4s.toolapi.ToolFunction
+import org.llm4s.types.Result
+import org.slf4j.LoggerFactory
+
+import java.io.{ BufferedReader, InputStreamReader }
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.UUID
+import scala.util.Try
+
+/**
+ * [[LLMClient]] implementation for Google Cloud Vertex AI.
+ *
+ * Calls the Vertex AI REST API (`aiplatform.googleapis.com`) using the same
+ * Gemini-compatible JSON format as [[GeminiClient]], but with:
+ *  - A region-scoped endpoint: `https://{location}-aiplatform.googleapis.com/v1/projects/{project}/...`
+ *  - OAuth2 bearer-token auth via [[VertexAIAuthProvider]] (ADC) instead of an API-key query param.
+ *
+ * == Authentication ==
+ *
+ * Tokens are obtained and cached by [[VertexAIAuthProvider]], which supports
+ * `authorized_user` refresh-token credentials (from `gcloud auth application-default login`),
+ * `service_account` JWT credentials, and the GCE/GKE metadata server (Workload Identity).
+ * Set `GOOGLE_ACCESS_TOKEN` as an escape hatch for testing.
+ *
+ * == Message format ==
+ *
+ * Identical to [[GeminiClient]]:
+ *  - Roles are `"user"` and `"model"`.
+ *  - System messages go into `systemInstruction`.
+ *  - Tool results are sent as `functionResponse` parts keyed by function name.
+ *  - Synthetic UUIDs are generated for tool-call IDs (Vertex AI does not return them).
+ *
+ * @param config         [[VertexAIConfig]] with project, location, model, and credential path.
+ * @param metrics        Receives per-call latency and token-usage events.
+ * @param exchangeLogging Controls whether raw request/response bodies are recorded.
+ * @param httpClient     HTTP client (injectable for testing).
+ */
+class VertexAIClient(
+  config: VertexAIConfig,
+  protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop,
+  exchangeLogging: ProviderExchangeLogging = ProviderExchangeLogging.Disabled,
+  private[provider] val httpClient: Llm4sHttpClient = Llm4sHttpClient.create()
+)(using val registryService: ModelRegistryService)
+    extends BaseLifecycleLLMClient {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private val authProvider = new VertexAIAuthProvider(config.credentialFilePath, httpClient)
+
+  protected def clientDescription: String = s"Vertex AI client for model ${config.model}"
+  protected def providerName: String      = "vertexai"
+  protected def modelName: String         = config.model
+
+  private def modelUrl(suffix: String): String = {
+    val base = config.computedBaseUrl
+    s"$base/projects/${config.projectId}/locations/${config.location}/publishers/google/models/${config.model}:$suffix"
+  }
+
+  override def complete(
+    conversation: Conversation,
+    options: CompletionOptions
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt = Instant.now()
+    TransformationResult
+      .transform(
+        config.model,
+        options,
+        conversation.messages,
+        dropUnsupported = true,
+        org.llm4s.model.RequestTransformer.default(registryService)
+      )
+      .flatMap { transformed =>
+        val transformedConversation = conversation.copy(messages = transformed.messages)
+        val requestBody             = buildRequestBody(transformedConversation, transformed.options)
+        val requestText             = requestBody.render()
+        val url                     = modelUrl("generateContent")
+
+        logger.debug(s"[VertexAI] Sending request to $url")
+        logger.debug(s"[VertexAI] Request body: $requestText")
+
+        for {
+          token  <- authProvider.getAccessToken()
+          headers = Map("Content-Type" -> "application/json", "Authorization" -> s"Bearer $token")
+          attempt <- Try {
+            val response = httpClient.post(url, headers, requestText, timeout = 120000)
+            if (response.statusCode >= 200 && response.statusCode < 300) {
+              val completionResult = parseCompletionResponse(response.body)
+              recordExchange(startedAt, requestText, Some(response.body), completionResult)
+              completionResult
+            } else {
+              val errorResult = handleErrorResponse(response.statusCode, response.body)
+              recordExchange(startedAt, requestText, Some(response.body), errorResult)
+              errorResult
+            }
+          }.toEither.left.map(e => e.toLLMError).flatten
+        } yield attempt
+      }
+  }
+
+  override def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions(),
+    onChunk: StreamedChunk => Unit
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt = Instant.now()
+    TransformationResult
+      .transform(
+        config.model,
+        options,
+        conversation.messages,
+        dropUnsupported = true,
+        org.llm4s.model.RequestTransformer.default(registryService)
+      )
+      .flatMap { transformed =>
+        val transformedConversation = conversation.copy(messages = transformed.messages)
+        val requestBody             = buildRequestBody(transformedConversation, transformed.options)
+        val requestText             = requestBody.render()
+        val url                     = s"${modelUrl("streamGenerateContent")}?alt=sse"
+
+        logger.debug(s"[VertexAI] Starting stream to $url")
+
+        for {
+          token  <- authProvider.getAccessToken()
+          headers = Map("Content-Type" -> "application/json", "Authorization" -> s"Bearer $token")
+          result <- {
+            val response = httpClient.postStream(url, headers, requestText, timeout = 600000)
+
+            if (response.statusCode < 200 || response.statusCode >= 300) {
+              val err = new String(response.body.readAllBytes(), StandardCharsets.UTF_8)
+              response.body.close()
+              val errorResult = handleErrorResponse(response.statusCode, err)
+              recordExchange(startedAt, requestText, Some(err), errorResult)
+              errorResult
+            } else {
+              val accumulator = StreamingAccumulator.create()
+              val messageId   = UUID.randomUUID().toString
+              val reader      = new BufferedReader(new InputStreamReader(response.body, StandardCharsets.UTF_8))
+              val rawStream   = StringBuilder()
+
+              Try {
+                try {
+                  var line: String = null
+                  while ({ line = reader.readLine(); line != null }) {
+                    rawStream.append(line).append('\n')
+                    val trimmed = line.trim
+                    if (trimmed.startsWith("data: ")) {
+                      val jsonStr = trimmed.stripPrefix("data: ").trim
+                      if (jsonStr.nonEmpty) {
+                        Try(ujson.read(jsonStr)).foreach { json =>
+                          parseStreamChunk(json, messageId).foreach { chunk =>
+                            accumulator.addChunk(chunk)
+                            onChunk(chunk)
+                          }
+                          for {
+                            usage      <- Try(json("usageMetadata")).toOption
+                            prompt     <- Try(usage("promptTokenCount").num.toInt).toOption
+                            completion <- Try(usage("candidatesTokenCount").num.toInt).toOption
+                          } accumulator.updateTokens(prompt, completion)
+                        }
+                      }
+                    }
+                  }
+                } finally {
+                  Try(reader.close())
+                  Try(response.body.close())
+                }
+              }.toEither.left
+                .map(_.toLLMError)
+                .flatMap(_ =>
+                  accumulator.toCompletion.map { c =>
+                    val cost       = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
+                    val completion = c.copy(model = config.model, estimatedCost = cost)
+                    recordExchange(startedAt, requestText, Some(rawStream.result()), Right(completion))
+                    completion
+                  }
+                )
+                .tapLeft(error =>
+                  recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(error))
+                )
+            }
+          }
+        } yield result
+      }
+  }
+
+  override def getContextWindow(): Int     = config.contextWindow
+  override def getReserveCompletion(): Int = config.reserveCompletion
+
+  private def buildRequestBody(conversation: Conversation, options: CompletionOptions): ujson.Value = {
+    val contents             = scala.collection.mutable.ArrayBuffer[ujson.Value]()
+    var systemInstr          = Option.empty[String]
+    val toolCallIdToName     = scala.collection.mutable.Map[String, String]()
+
+    conversation.messages.foreach {
+      case SystemMessage(content) =>
+        systemInstr = Some(content)
+
+      case UserMessage(content) =>
+        contents += ujson.Obj("role" -> "user", "parts" -> ujson.Arr(ujson.Obj("text" -> content)))
+
+      case AssistantMessage(contentOpt, toolCalls) =>
+        if (toolCalls.nonEmpty) {
+          val parts = scala.collection.mutable.ArrayBuffer[ujson.Value]()
+          contentOpt.foreach(c => parts += ujson.Obj("text" -> c))
+          toolCalls.foreach { tc =>
+            toolCallIdToName(tc.id) = tc.name
+            parts += ujson.Obj("functionCall" -> ujson.Obj("name" -> tc.name, "args" -> tc.arguments))
+          }
+          contents += ujson.Obj("role" -> "model", "parts" -> ujson.Arr(parts.toSeq: _*))
+        } else {
+          contentOpt.foreach { content =>
+            contents += ujson.Obj("role" -> "model", "parts" -> ujson.Arr(ujson.Obj("text" -> content)))
+          }
+        }
+
+      case ToolMessage(content, toolCallId) =>
+        val functionName = toolCallIdToName.getOrElse(toolCallId, toolCallId)
+        contents += ujson.Obj(
+          "role" -> "user",
+          "parts" -> ujson.Arr(
+            ujson.Obj(
+              "functionResponse" -> ujson.Obj(
+                "name"     -> functionName,
+                "response" -> ujson.Obj("result" -> content)
+              )
+            )
+          )
+        )
+    }
+
+    val generationConfig = ujson.Obj("temperature" -> options.temperature, "topP" -> options.topP)
+    options.maxTokens.foreach(mt => generationConfig("maxOutputTokens") = mt)
+
+    options.responseFormat.foreach {
+      case ResponseFormat.Json =>
+        generationConfig("responseMimeType") = "application/json"
+      case js: ResponseFormat.JsonSchema =>
+        generationConfig("responseMimeType") = "application/json"
+        generationConfig("responseSchema") = js.schema
+    }
+
+    val request = ujson.Obj("contents" -> ujson.Arr(contents.toSeq: _*), "generationConfig" -> generationConfig)
+
+    systemInstr.foreach { sysContent =>
+      request("systemInstruction") = ujson.Obj("parts" -> ujson.Arr(ujson.Obj("text" -> sysContent)))
+    }
+
+    if (options.tools.nonEmpty) {
+      val functionDeclarations = options.tools.map(convertToolToVertexFormat)
+      request("tools") = ujson.Arr(
+        ujson.Obj("functionDeclarations" -> ujson.Arr(functionDeclarations: _*))
+      )
+    }
+
+    request
+  }
+
+  private[provider] def convertToolToVertexFormat(tool: ToolFunction[_, _]): ujson.Value = {
+    val schema = ujson.read(tool.schema.toJsonSchema(false).render())
+    schema.obj.remove("strict")
+    schema.obj.remove("additionalProperties")
+    stripAdditionalProperties(schema)
+    ujson.Obj("name" -> tool.name, "description" -> tool.description, "parameters" -> schema)
+  }
+
+  private[provider] def stripAdditionalProperties(json: ujson.Value): Unit =
+    json match {
+      case obj: ujson.Obj =>
+        obj.value.remove("additionalProperties")
+        obj.value.get("properties").foreach(props => props.obj.values.foreach(stripAdditionalProperties))
+        obj.value.get("items").foreach(stripAdditionalProperties)
+        Seq("anyOf", "oneOf", "allOf").foreach { key =>
+          obj.value.get(key).foreach(arr => arr.arr.foreach(stripAdditionalProperties))
+        }
+      case _ => ()
+    }
+
+  private def parseCompletionResponse(responseText: String): Result[Completion] =
+    Try {
+      val json       = ujson.read(responseText)
+      val candidates = json("candidates").arr
+
+      if (candidates.isEmpty) {
+        Left(org.llm4s.error.ValidationError("response", "No candidates in Vertex AI response"))
+      } else {
+        val candidate = candidates.head
+        val content   = candidate("content")
+        val parts     = content("parts").arr
+
+        val textContent = parts.filter(p => p.obj.contains("text")).map(_("text").str).mkString
+
+        val toolCalls = parts
+          .filter(p => p.obj.contains("functionCall"))
+          .map { p =>
+            val fc = p("functionCall")
+            ToolCall(id = UUID.randomUUID().toString, name = fc("name").str, arguments = fc("args"))
+          }
+          .toSeq
+
+        val usageOpt = Try {
+          val usage = json("usageMetadata")
+          TokenUsage(
+            promptTokens = usage("promptTokenCount").num.toInt,
+            completionTokens = usage("candidatesTokenCount").num.toInt,
+            totalTokens = usage("totalTokenCount").num.toInt
+          )
+        }.toOption
+
+        val message = AssistantMessage(
+          contentOpt = if (textContent.nonEmpty) Some(textContent) else None,
+          toolCalls = toolCalls
+        )
+        val cost = usageOpt.flatMap(u => CostEstimator.estimate(config.model, u))
+
+        Right(
+          Completion(
+            id = UUID.randomUUID().toString,
+            content = textContent,
+            model = config.model,
+            toolCalls = toolCalls.toList,
+            created = System.currentTimeMillis() / 1000,
+            message = message,
+            usage = usageOpt,
+            estimatedCost = cost
+          )
+        )
+      }
+    }.toEither.left.map(e => e.toLLMError).flatten
+
+  private def parseStreamChunk(json: ujson.Value, messageId: String): Option[StreamedChunk] =
+    Try {
+      val candidates = json("candidates").arr
+      if (candidates.nonEmpty) {
+        val candidate   = candidates.head
+        val content     = candidate("content")
+        val parts       = content("parts").arr
+        val textContent = parts.filter(p => p.obj.contains("text")).map(_("text").str).mkString
+        val finishReason = Try(candidate("finishReason").str).toOption
+
+        val toolCallOpt = parts
+          .filter(p => p.obj.contains("functionCall"))
+          .headOption
+          .map { p =>
+            val fc = p("functionCall")
+            ToolCall(id = UUID.randomUUID().toString, name = fc("name").str, arguments = fc("args"))
+          }
+
+        Some(
+          StreamedChunk(
+            id = messageId,
+            content = if (textContent.nonEmpty) Some(textContent) else None,
+            toolCall = toolCallOpt,
+            finishReason = finishReason
+          )
+        )
+      } else None
+    }.toOption.flatten
+
+  private def handleErrorResponse(statusCode: Int, body: String): Result[Nothing] = {
+    logger.error(s"[VertexAI] Error response: $statusCode")
+    HttpErrorMapper.mapHttpError(statusCode, body, providerName)
+  }
+
+  private def recordExchange(
+    startedAt: Instant,
+    requestBody: String,
+    responseBody: Option[String],
+    result: Result[?]
+  ): Unit =
+    ProviderExchangeRecorder.record(
+      exchangeLogging = exchangeLogging,
+      provider = providerName,
+      model = Some(config.model),
+      startedAt = startedAt,
+      requestBody = requestBody,
+      responseBody = responseBody,
+      result = result
+    )
+
+  override protected def releaseResources(): Unit =
+    (httpClient: Any) match {
+      case c: AutoCloseable => c.close()
+      case _                => ()
+    }
+}
+
+object VertexAIClient {
+  import org.llm4s.types.TryOps
+
+  def apply(config: VertexAIConfig)(using ModelRegistryService): Result[VertexAIClient] =
+    Try(new VertexAIClient(config)).toResult
+
+  def apply(config: VertexAIConfig, metrics: org.llm4s.metrics.MetricsCollector)(using
+    ModelRegistryService
+  ): Result[VertexAIClient] =
+    Try(new VertexAIClient(config, metrics)).toResult
+
+  def apply(
+    config: VertexAIConfig,
+    metrics: org.llm4s.metrics.MetricsCollector,
+    exchangeLogging: ProviderExchangeLogging
+  )(using ModelRegistryService): Result[VertexAIClient] =
+    Try(new VertexAIClient(config, metrics, exchangeLogging)).toResult
+}

--- a/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
+++ b/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
@@ -35,6 +35,7 @@ object ProviderModelTypes:
     case DeepSeek
     case Cohere
     case Mistral
+    case VertexAI
 
   object ProviderKind:
     val all: Seq[ProviderKind] = Seq(
@@ -47,7 +48,8 @@ object ProviderModelTypes:
       ProviderKind.Gemini,
       ProviderKind.DeepSeek,
       ProviderKind.Cohere,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.VertexAI
     )
 
     def fromString(value: String): Option[ProviderKind] =
@@ -63,6 +65,7 @@ object ProviderModelTypes:
         case "deepseek"   => Some(ProviderKind.DeepSeek)
         case "cohere"     => Some(ProviderKind.Cohere)
         case "mistral"    => Some(ProviderKind.Mistral)
+        case "vertex" | "vertexai" => Some(ProviderKind.VertexAI)
         case _            => None
 
     def fromName(value: String): Option[ProviderKind] =
@@ -81,3 +84,4 @@ object ProviderModelTypes:
         case ProviderKind.DeepSeek   => "deepseek"
         case ProviderKind.Cohere     => "cohere"
         case ProviderKind.Mistral    => "mistral"
+        case ProviderKind.VertexAI   => "vertexai"

--- a/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
+++ b/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
@@ -54,19 +54,19 @@ object ProviderModelTypes:
 
     def fromString(value: String): Option[ProviderKind] =
       value.trim.toLowerCase match
-        case "openai"     => Some(ProviderKind.OpenAI)
-        case "openrouter" => Some(ProviderKind.OpenRouter)
-        case "azure"      => Some(ProviderKind.Azure)
-        case "anthropic"  => Some(ProviderKind.Anthropic)
-        case "ollama"     => Some(ProviderKind.Ollama)
-        case "zai"        => Some(ProviderKind.Zai)
-        case "gemini"     => Some(ProviderKind.Gemini)
-        case "google"     => Some(ProviderKind.Gemini)
-        case "deepseek"   => Some(ProviderKind.DeepSeek)
-        case "cohere"     => Some(ProviderKind.Cohere)
-        case "mistral"    => Some(ProviderKind.Mistral)
+        case "openai"              => Some(ProviderKind.OpenAI)
+        case "openrouter"          => Some(ProviderKind.OpenRouter)
+        case "azure"               => Some(ProviderKind.Azure)
+        case "anthropic"           => Some(ProviderKind.Anthropic)
+        case "ollama"              => Some(ProviderKind.Ollama)
+        case "zai"                 => Some(ProviderKind.Zai)
+        case "gemini"              => Some(ProviderKind.Gemini)
+        case "google"              => Some(ProviderKind.Gemini)
+        case "deepseek"            => Some(ProviderKind.DeepSeek)
+        case "cohere"              => Some(ProviderKind.Cohere)
+        case "mistral"             => Some(ProviderKind.Mistral)
         case "vertex" | "vertexai" => Some(ProviderKind.VertexAI)
-        case _            => None
+        case _                     => None
 
     def fromName(value: String): Option[ProviderKind] =
       fromString(value)

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIAuthProviderSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIAuthProviderSpec.scala
@@ -1,0 +1,208 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.AuthenticationError
+import org.llm4s.http.{ HttpResponse, Llm4sHttpClient }
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import VertexAIAuthProvider._
+
+/**
+ * Unit tests for [[VertexAIAuthProvider]].
+ *
+ * All three credential paths are tested by injecting a mock HTTP client and
+ * controlling the `envReader` / `fileReader` to simulate different environments
+ * without touching the filesystem or real OAuth2 endpoints.
+ */
+class VertexAIAuthProviderSpec extends AnyFlatSpec with Matchers with MockFactory {
+
+  private val tokenResponseBody = """{"access_token":"ya29.test-token","expires_in":3600}"""
+
+  "VertexAIAuthProvider.getAccessToken()" should "return token from GOOGLE_ACCESS_TOKEN env var" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = None,
+      httpClient = mockHttp,
+      envReader = {
+        case "GOOGLE_ACCESS_TOKEN" => Some("direct-token-from-env")
+        case _                     => None
+      }
+    )
+
+    val result = provider.getAccessToken()
+
+    result.isRight shouldBe true
+    result.toOption.get shouldBe "direct-token-from-env"
+  }
+
+  it should "cache the token and not call HTTP again" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenResponseBody, Map.empty))
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = None,
+      httpClient = mockHttp,
+      envReader = _ => None
+    )
+
+    val r1 = provider.getAccessToken()
+    val r2 = provider.getAccessToken()
+
+    r1.isRight shouldBe true
+    r2.isRight shouldBe true
+    r1.toOption.get shouldBe r2.toOption.get
+  }
+
+  it should "return AuthenticationError on metadata server non-200" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(404, "Not Found", Map.empty))
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = None,
+      httpClient = mockHttp,
+      envReader = _ => None
+    )
+
+    val result = provider.getAccessToken()
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[AuthenticationError]
+  }
+
+  it should "fetch token from authorized_user credential file via refresh flow" in {
+    val credFileContent =
+      """{
+        |  "type": "authorized_user",
+        |  "client_id": "test-client-id",
+        |  "client_secret": "test-secret",
+        |  "refresh_token": "test-refresh-token"
+        |}""".stripMargin
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(200, tokenResponseBody, Map.empty))
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = Some("/fake/path/creds.json"),
+      httpClient = mockHttp,
+      envReader = _ => None,
+      fileReader = _ => Right(credFileContent)
+    )
+
+    val result = provider.getAccessToken()
+
+    result.isRight shouldBe true
+    result.toOption.get shouldBe "ya29.test-token"
+  }
+
+  it should "return AuthenticationError when refresh token endpoint returns non-200" in {
+    val credFileContent =
+      """{
+        |  "type": "authorized_user",
+        |  "client_id": "test-client-id",
+        |  "client_secret": "test-secret",
+        |  "refresh_token": "test-refresh-token"
+        |}""".stripMargin
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(401, "Unauthorized", Map.empty))
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = Some("/fake/path/creds.json"),
+      httpClient = mockHttp,
+      envReader = _ => None,
+      fileReader = _ => Right(credFileContent)
+    )
+
+    val result = provider.getAccessToken()
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[AuthenticationError]
+    result.left.toOption.get.message should include("Token refresh failed")
+  }
+
+  it should "return AuthenticationError for unsupported credential type" in {
+    val credFileContent = """{"type": "external_account"}"""
+    val mockHttp        = stub[Llm4sHttpClient]
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = Some("/fake/path/creds.json"),
+      httpClient = mockHttp,
+      envReader = _ => None,
+      fileReader = _ => Right(credFileContent)
+    )
+
+    val result = provider.getAccessToken()
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[AuthenticationError]
+    result.left.toOption.get.message should include("Unsupported credential type")
+  }
+
+  it should "return error for invalid JSON in credential file" in {
+    val mockHttp = stub[Llm4sHttpClient]
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = Some("/fake/path/creds.json"),
+      httpClient = mockHttp,
+      envReader = _ => None,
+      fileReader = _ => Right("{not valid json}")
+    )
+
+    val result = provider.getAccessToken()
+
+    result.isLeft shouldBe true
+  }
+
+  it should "fall back to metadata server when no credentials are configured" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenResponseBody, Map.empty))
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = None,
+      httpClient = mockHttp,
+      envReader = _ => None
+    )
+
+    val result = provider.getAccessToken()
+
+    result.isRight shouldBe true
+    result.toOption.get shouldBe "ya29.test-token"
+  }
+
+  it should "return AuthenticationError when metadata server is not available" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(503, "Service Unavailable", Map.empty))
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = None,
+      httpClient = mockHttp,
+      envReader = _ => None
+    )
+
+    val result = provider.getAccessToken()
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[AuthenticationError]
+  }
+
+  "CachedToken" should "not be expired when expiresAtMillis is in the future" in {
+    val future = System.currentTimeMillis() + 60000
+    val token  = CachedToken("tok", future)
+
+    token.isExpired shouldBe false
+  }
+
+  it should "be expired when expiresAtMillis is in the past" in {
+    val past  = System.currentTimeMillis() - 1
+    val token = CachedToken("tok", past)
+
+    token.isExpired shouldBe true
+  }
+
+  it should "never expire when expiresAtMillis is Long.MaxValue" in {
+    val token = CachedToken("tok", Long.MaxValue)
+
+    token.isExpired shouldBe false
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientClosedStateTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientClosedStateTest.scala
@@ -1,0 +1,88 @@
+package org.llm4s.llmconnect.provider
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.llm4s.error.ConfigurationError
+import org.llm4s.llmconnect.config.VertexAIConfig
+import org.llm4s.llmconnect.model.{ Conversation, CompletionOptions, UserMessage }
+import org.llm4s.model.ModelRegistryService
+
+/**
+ * Tests for VertexAIClient closed state handling.
+ *
+ * Verifies that operations fail with ConfigurationError after close() is called,
+ * and that close() is idempotent.
+ */
+class VertexAIClientClosedStateTest extends AnyFlatSpec with Matchers {
+
+  private given ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+
+  private def createTestConfig: VertexAIConfig = VertexAIConfig(
+    projectId = "test-project",
+    location = "us-central1",
+    model = "gemini-2.0-flash",
+    credentialFilePath = None,
+    contextWindow = 1048576,
+    reserveCompletion = 8192
+  )
+
+  private def createTestConversation: Conversation =
+    Conversation(Seq(UserMessage("Hello")))
+
+  "VertexAIClient" should "return ConfigurationError when complete() is called after close()" in {
+    val client = new VertexAIClient(createTestConfig)
+
+    client.close()
+
+    val result = client.complete(createTestConversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[ConfigurationError]
+    result.left.toOption.get.message should include("already closed")
+    result.left.toOption.get.message should include("gemini-2.0-flash")
+  }
+
+  it should "return ConfigurationError when streamComplete() is called after close()" in {
+    val client         = new VertexAIClient(createTestConfig)
+    var chunksReceived = 0
+
+    client.close()
+
+    val result = client.streamComplete(
+      createTestConversation,
+      CompletionOptions(),
+      _ => chunksReceived += 1
+    )
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[ConfigurationError]
+    result.left.toOption.get.message should include("already closed")
+    chunksReceived shouldBe 0
+  }
+
+  it should "allow close() to be called multiple times (idempotent)" in {
+    val client = new VertexAIClient(createTestConfig)
+
+    noException should be thrownBy {
+      client.close()
+      client.close()
+      client.close()
+    }
+
+    val result = client.complete(createTestConversation, CompletionOptions())
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[ConfigurationError]
+  }
+
+  it should "include model name in the closed error message" in {
+    val config = createTestConfig.copy(model = "gemini-1.5-pro")
+    val client = new VertexAIClient(config)
+
+    client.close()
+
+    val result = client.complete(createTestConversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get.message should include("gemini-1.5-pro")
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientHttpSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientHttpSpec.scala
@@ -1,0 +1,337 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.http.{ HttpResponse, Llm4sHttpClient, StreamingHttpResponse }
+import org.llm4s.llmconnect.{ ProviderExchange, ProviderExchangeLogging, ProviderExchangeSink }
+import org.llm4s.llmconnect.config.VertexAIConfig
+import org.llm4s.llmconnect.model._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues._
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+import scala.collection.mutable.ListBuffer
+import org.llm4s.model.ModelRegistryService
+
+/**
+ * HTTP-level tests for [[VertexAIClient]].
+ *
+ * Both `httpClient.post` (used for generateContent AND oauth2 token endpoint)
+ * and `httpClient.get` (GCE metadata-server fallback) must be stubbed in every
+ * test to prevent NPEs when VertexAIAuthProvider falls through all credential paths.
+ */
+class VertexAIClientHttpSpec extends AnyFlatSpec with Matchers with MockFactory {
+
+  private given ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+
+  private val testConfig = VertexAIConfig(
+    projectId = "my-gcp-project",
+    location = "us-central1",
+    model = "gemini-2.0-flash",
+    credentialFilePath = None,
+    contextWindow = 1048576,
+    reserveCompletion = 8192
+  )
+
+  private val tokenBody    = """{"access_token":"ya29.test-token","expires_in":3600}"""
+  private val successBody  =
+    """|{"candidates":[{"content":{"parts":[{"text":"Hello!"}],"role":"model"},"finishReason":"STOP"}],
+       | "usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}""".stripMargin
+
+  /**
+   * Creates a VertexAIClient backed by a mock HTTP client that:
+   *  - routes POST to the oauth2 token endpoint → returns a valid token
+   *  - routes all other POST calls (generateContent) → returns `completionResponse`
+   *  - stubs GET (metadata server fallback) → returns a valid token
+   *
+   * This covers all three auth-provider code paths, making tests environment-agnostic.
+   */
+  private def stubHttpWithAuth(mockHttp: Llm4sHttpClient, completionResponse: HttpResponse): VertexAIClient = {
+    (mockHttp.post _).when(*, *, *, *).onCall { (url: String, _: Map[String, String], _: String, _: Int) =>
+      if (url.contains("oauth2.googleapis.com")) HttpResponse(200, tokenBody, Map.empty)
+      else completionResponse
+    }
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+  }
+
+  private def httpOk(body: String): HttpResponse = HttpResponse(200, body, Map.empty)
+  private def httpErr(status: Int): HttpResponse = HttpResponse(status, s"Error $status", Map.empty)
+  private def conversation(text: String): Conversation =
+    Conversation(messages = Seq(UserMessage(text)))
+
+  // ============================================================
+  // complete() tests
+  // ============================================================
+
+  "VertexAIClient.complete()" should "parse text content from a 200 response" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    val client   = stubHttpWithAuth(mockHttp, httpOk(successBody))
+
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.content shouldBe "Hello!"
+  }
+
+  it should "parse token usage from the response" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    val client   = stubHttpWithAuth(mockHttp, httpOk(successBody))
+
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isRight shouldBe true
+    val usage = result.toOption.get.usage.get
+    usage.promptTokens shouldBe 10
+    usage.completionTokens shouldBe 5
+    usage.totalTokens shouldBe 15
+  }
+
+  it should "parse a tool call response" in {
+    val toolCallBody =
+      """{"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","args":{"location":"London"}}}],"role":"model"}}]}"""
+    val mockHttp = stub[Llm4sHttpClient]
+    val client   = stubHttpWithAuth(mockHttp, httpOk(toolCallBody))
+
+    val result = client.complete(conversation("What's the weather?"), CompletionOptions())
+
+    result.isRight shouldBe true
+    val completion = result.toOption.get
+    completion.toolCalls should have size 1
+    completion.toolCalls.head.name shouldBe "get_weather"
+  }
+
+  it should "return AuthenticationError on HTTP 401" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    val client   = stubHttpWithAuth(mockHttp, httpErr(401))
+
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.AuthenticationError]
+  }
+
+  it should "return AuthenticationError on HTTP 403" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    val client   = stubHttpWithAuth(mockHttp, httpErr(403))
+
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.AuthenticationError]
+  }
+
+  it should "return RateLimitError on HTTP 429" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    val client   = stubHttpWithAuth(mockHttp, httpErr(429))
+
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.RateLimitError]
+  }
+
+  it should "return ValidationError on HTTP 400" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    val client   = stubHttpWithAuth(mockHttp, httpErr(400))
+
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.ValidationError]
+  }
+
+  it should "return ServiceError on HTTP 500" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    val client   = stubHttpWithAuth(mockHttp, httpErr(500))
+
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.ServiceError]
+  }
+
+  it should "send Authorization Bearer header to the Vertex AI endpoint" in {
+    var capturedHeaders: Map[String, String] = Map.empty
+    val mockHttp                             = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).onCall { (url: String, headers: Map[String, String], _: String, _: Int) =>
+      if (url.contains("oauth2.googleapis.com")) HttpResponse(200, tokenBody, Map.empty)
+      else {
+        capturedHeaders = headers
+        httpOk(successBody)
+      }
+    }
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+
+    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+    client.complete(conversation("Hi"), CompletionOptions())
+
+    capturedHeaders.get("Authorization").value should startWith("Bearer ")
+  }
+
+  it should "build the correct Vertex AI generateContent URL" in {
+    var capturedUrl = ""
+    val mockHttp    = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).onCall { (url: String, _: Map[String, String], _: String, _: Int) =>
+      if (url.contains("oauth2.googleapis.com")) HttpResponse(200, tokenBody, Map.empty)
+      else {
+        capturedUrl = url
+        httpOk(successBody)
+      }
+    }
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+
+    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+    client.complete(conversation("Hi"), CompletionOptions())
+
+    capturedUrl should include("us-central1-aiplatform.googleapis.com")
+    capturedUrl should include("my-gcp-project")
+    capturedUrl should include("gemini-2.0-flash")
+    capturedUrl should include("generateContent")
+  }
+
+  it should "record provider exchanges when logging is enabled" in {
+    val exchanges = ListBuffer.empty[ProviderExchange]
+    val sink = new ProviderExchangeSink {
+      override def record(exchange: ProviderExchange): Unit = exchanges += exchange
+    }
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).onCall { (url: String, _: Map[String, String], _: String, _: Int) =>
+      if (url.contains("oauth2.googleapis.com")) HttpResponse(200, tokenBody, Map.empty)
+      else httpOk(successBody)
+    }
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Enabled(sink),
+      mockHttp
+    )
+    val result = client.complete(conversation("Hi"), CompletionOptions())
+
+    result.isRight shouldBe true
+    exchanges should have size 1
+    exchanges.head.provider shouldBe "vertexai"
+    exchanges.head.model shouldBe Some("gemini-2.0-flash")
+    exchanges.head.requestBody should include("Hi")
+    exchanges.head.responseBody.value should include("Hello!")
+  }
+
+  // ============================================================
+  // streamComplete() tests
+  // ============================================================
+
+  "VertexAIClient.streamComplete()" should "parse SSE lines and accumulate into a Completion" in {
+    val sseData =
+      "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}]}}]}\n" +
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" world\"}]}}]," +
+        "\"usageMetadata\":{\"promptTokenCount\":5,\"candidatesTokenCount\":2,\"totalTokenCount\":7}}\n"
+    val inputStream = new ByteArrayInputStream(sseData.getBytes(StandardCharsets.UTF_8))
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(200, inputStream))
+
+    val chunks = scala.collection.mutable.Buffer[StreamedChunk]()
+    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+    val result = client.streamComplete(conversation("Hi"), CompletionOptions(), chunk => chunks += chunk)
+
+    result.isRight shouldBe true
+    result.toOption.get.content should include("Hello")
+    result.toOption.get.content should include("world")
+    chunks should have size 2
+  }
+
+  it should "parse token usage from the final SSE chunk" in {
+    val sseData =
+      "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Done\"}]}}]," +
+        "\"usageMetadata\":{\"promptTokenCount\":5,\"candidatesTokenCount\":2,\"totalTokenCount\":7}}\n"
+    val inputStream = new ByteArrayInputStream(sseData.getBytes(StandardCharsets.UTF_8))
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(200, inputStream))
+
+    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+    val result = client.streamComplete(conversation("Hi"), CompletionOptions(), _ => ())
+
+    result.isRight shouldBe true
+    val usage = result.toOption.get.usage.get
+    usage.promptTokens shouldBe 5
+    usage.completionTokens shouldBe 2
+  }
+
+  it should "return an error for non-200 stream status" in {
+    val errorBody   = """{"error":{"message":"UNAUTHENTICATED","status":"UNAUTHENTICATED"}}"""
+    val inputStream = new ByteArrayInputStream(errorBody.getBytes(StandardCharsets.UTF_8))
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(401, inputStream))
+
+    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+    val result = client.streamComplete(conversation("Hi"), CompletionOptions(), _ => ())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.AuthenticationError]
+  }
+
+  // ============================================================
+  // Schema conversion tests (convertToolToVertexFormat)
+  // ============================================================
+
+  "VertexAIClient.convertToolToVertexFormat()" should "strip 'strict' and 'additionalProperties' from schema" in {
+    import org.llm4s.toolapi.{ Schema, ToolBuilder }
+
+    val schema = Schema
+      .`object`[Map[String, Any]]("Input")
+      .withProperty(Schema.property("q", Schema.string("query")))
+
+    val toolResult = ToolBuilder[Map[String, Any], String]("search", "Search tool", schema)
+      .withHandler(_ => Right("ok"))
+      .buildSafe()
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+
+    toolResult match {
+      case Right(tool) =>
+        val vertexTool = client.convertToolToVertexFormat(tool)
+        val rendered   = vertexTool.render()
+        (rendered should not).include("\"strict\"")
+        (rendered should not).include("\"additionalProperties\"")
+      case Left(err) => fail(s"Tool build failed: ${err.message}")
+    }
+  }
+
+  it should "include name, description and parameters in the result" in {
+    import org.llm4s.toolapi.{ Schema, ToolBuilder }
+
+    val schema = Schema
+      .`object`[Map[String, Any]]("Input")
+      .withProperty(Schema.property("x", Schema.integer("x")))
+
+    val toolResult = ToolBuilder[Map[String, Any], String]("my_tool", "My tool description", schema)
+      .withHandler(_ => Right("ok"))
+      .buildSafe()
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+
+    toolResult match {
+      case Right(tool) =>
+        val vertexTool = client.convertToolToVertexFormat(tool)
+        vertexTool("name").str shouldBe "my_tool"
+        vertexTool("description").str shouldBe "My tool description"
+        vertexTool.obj.contains("parameters") shouldBe true
+      case Left(err) => fail(s"Tool build failed: ${err.message}")
+    }
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientHttpSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientHttpSpec.scala
@@ -34,8 +34,8 @@ class VertexAIClientHttpSpec extends AnyFlatSpec with Matchers with MockFactory 
     reserveCompletion = 8192
   )
 
-  private val tokenBody    = """{"access_token":"ya29.test-token","expires_in":3600}"""
-  private val successBody  =
+  private val tokenBody = """{"access_token":"ya29.test-token","expires_in":3600}"""
+  private val successBody =
     """|{"candidates":[{"content":{"parts":[{"text":"Hello!"}],"role":"model"},"finishReason":"STOP"}],
        | "usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}""".stripMargin
 
@@ -164,7 +164,12 @@ class VertexAIClientHttpSpec extends AnyFlatSpec with Matchers with MockFactory 
     }
     (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
 
-    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
     client.complete(conversation("Hi"), CompletionOptions())
 
     capturedHeaders.get("Authorization").value should startWith("Bearer ")
@@ -182,7 +187,12 @@ class VertexAIClientHttpSpec extends AnyFlatSpec with Matchers with MockFactory 
     }
     (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
 
-    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
     client.complete(conversation("Hi"), CompletionOptions())
 
     capturedUrl should include("us-central1-aiplatform.googleapis.com")
@@ -236,7 +246,12 @@ class VertexAIClientHttpSpec extends AnyFlatSpec with Matchers with MockFactory 
     (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(200, inputStream))
 
     val chunks = scala.collection.mutable.Buffer[StreamedChunk]()
-    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
     val result = client.streamComplete(conversation("Hi"), CompletionOptions(), chunk => chunks += chunk)
 
     result.isRight shouldBe true
@@ -256,7 +271,12 @@ class VertexAIClientHttpSpec extends AnyFlatSpec with Matchers with MockFactory 
     (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
     (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(200, inputStream))
 
-    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
     val result = client.streamComplete(conversation("Hi"), CompletionOptions(), _ => ())
 
     result.isRight shouldBe true
@@ -274,7 +294,12 @@ class VertexAIClientHttpSpec extends AnyFlatSpec with Matchers with MockFactory 
     (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
     (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(401, inputStream))
 
-    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
     val result = client.streamComplete(conversation("Hi"), CompletionOptions(), _ => ())
 
     result.isLeft shouldBe true
@@ -298,7 +323,12 @@ class VertexAIClientHttpSpec extends AnyFlatSpec with Matchers with MockFactory 
 
     val mockHttp = stub[Llm4sHttpClient]
     (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
-    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
 
     toolResult match {
       case Right(tool) =>
@@ -323,7 +353,12 @@ class VertexAIClientHttpSpec extends AnyFlatSpec with Matchers with MockFactory 
 
     val mockHttp = stub[Llm4sHttpClient]
     (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
-    val client = new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
 
     toolResult match {
       case Right(tool) =>

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientSpec.scala
@@ -1,0 +1,60 @@
+package org.llm4s.llmconnect.provider
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.llm4s.llmconnect.config.VertexAIConfig
+import org.llm4s.metrics.MockMetricsCollector
+import org.llm4s.model.ModelRegistryService
+
+class VertexAIClientSpec extends AnyFunSuite {
+
+  private given ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+
+  private val testConfig = VertexAIConfig(
+    projectId = "my-gcp-project",
+    location = "us-central1",
+    model = "gemini-2.0-flash",
+    credentialFilePath = None,
+    contextWindow = 1048576,
+    reserveCompletion = 8192
+  )
+
+  test("vertex ai client accepts custom metrics collector") {
+    val mockMetrics = new MockMetricsCollector()
+    val client      = new VertexAIClient(testConfig, mockMetrics)
+
+    assert(client != null)
+    assert(mockMetrics.totalRequests == 0)
+  }
+
+  test("vertex ai client uses noop metrics by default") {
+    val client = new VertexAIClient(testConfig)
+
+    assert(client != null)
+  }
+
+  test("vertex ai client returns correct context window") {
+    val client = new VertexAIClient(testConfig)
+
+    assert(client.getContextWindow() == 1048576)
+  }
+
+  test("vertex ai client returns correct reserve completion") {
+    val client = new VertexAIClient(testConfig)
+
+    assert(client.getReserveCompletion() == 8192)
+  }
+
+  test("vertex ai client computes correct base URL from location") {
+    val config = testConfig.copy(location = "europe-west4")
+
+    assert(config.computedBaseUrl == "https://europe-west4-aiplatform.googleapis.com/v1")
+  }
+
+  test("vertex ai config defaults to us-central1 location") {
+    assert(VertexAIConfig.DEFAULT_LOCATION == "us-central1")
+  }
+
+  test("vertex ai config computes us-central1 base URL") {
+    assert(testConfig.computedBaseUrl == "https://us-central1-aiplatform.googleapis.com/v1")
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAICoverageSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAICoverageSpec.scala
@@ -1,0 +1,558 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.http.{ HttpRawResponse, HttpResponse, Llm4sHttpClient, MultipartPart, StreamingHttpResponse }
+import org.llm4s.llmconnect.ProviderExchangeLogging
+import org.llm4s.llmconnect.config.VertexAIConfig
+import org.llm4s.llmconnect.model._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+import java.security.KeyPairGenerator
+import java.util.Base64
+import org.llm4s.model.ModelRegistryService
+
+/** Concrete AutoCloseable HTTP client used in lifecycle tests. */
+private class TrackingAutoCloseableHttpClient extends Llm4sHttpClient with AutoCloseable {
+  var closeCalled: Boolean = false
+
+  override def get(url: String, headers: Map[String, String], params: Map[String, String], timeout: Int): HttpResponse =
+    HttpResponse(200, """{"access_token":"tok","expires_in":3600}""", Map.empty)
+  override def post(url: String, headers: Map[String, String], body: String, timeout: Int): HttpResponse =
+    HttpResponse(200, """{"access_token":"tok","expires_in":3600}""", Map.empty)
+  override def postBytes(url: String, headers: Map[String, String], data: Array[Byte], timeout: Int): HttpResponse =
+    HttpResponse(200, "", Map.empty)
+  override def postMultipart(
+    url: String,
+    headers: Map[String, String],
+    parts: Seq[MultipartPart],
+    timeout: Int
+  ): HttpResponse = HttpResponse(200, "", Map.empty)
+  override def put(url: String, headers: Map[String, String], body: String, timeout: Int): HttpResponse =
+    HttpResponse(200, "", Map.empty)
+  override def delete(url: String, headers: Map[String, String], timeout: Int): HttpResponse =
+    HttpResponse(200, "", Map.empty)
+  override def postRaw(url: String, headers: Map[String, String], body: String, timeout: Int): HttpRawResponse =
+    HttpRawResponse(200, Array.emptyByteArray)
+  override def postStream(
+    url: String,
+    headers: Map[String, String],
+    body: String,
+    timeout: Int
+  ): StreamingHttpResponse = StreamingHttpResponse(200, new ByteArrayInputStream(Array.emptyByteArray))
+  override def close(): Unit = closeCalled = true
+}
+
+/**
+ * Additional coverage tests for [[VertexAIClient]] and [[VertexAIAuthProvider]].
+ *
+ * Covers service-account auth, request-body message types, response edge cases,
+ * streaming edge cases, lifecycle management, and the apply factory methods.
+ */
+class VertexAICoverageSpec extends AnyFlatSpec with Matchers with MockFactory {
+
+  private given ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+
+  private val testConfig = VertexAIConfig(
+    projectId = "my-gcp-project",
+    location = "us-central1",
+    model = "gemini-2.0-flash",
+    credentialFilePath = None,
+    contextWindow = 1048576,
+    reserveCompletion = 8192
+  )
+
+  private val tokenBody = """{"access_token":"ya29.test-token","expires_in":3600}"""
+  private val successBody =
+    """|{"candidates":[{"content":{"parts":[{"text":"Hello!"}],"role":"model"},"finishReason":"STOP"}],
+       | "usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}""".stripMargin
+
+  private def captureBodyClient(onCompletion: String => Unit): VertexAIClient = {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).onCall { (url: String, _: Map[String, String], body: String, _: Int) =>
+      if (url.contains("oauth2.googleapis.com")) HttpResponse(200, tokenBody, Map.empty)
+      else {
+        onCompletion(body)
+        HttpResponse(200, successBody, Map.empty)
+      }
+    }
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    new VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, mockHttp)
+  }
+
+  // ============================================================
+  // VertexAIAuthProvider — additional auth-path coverage
+  // ============================================================
+
+  "VertexAIAuthProvider" should "resolve credential file from GOOGLE_APPLICATION_CREDENTIALS env var" in {
+    val credFileContent =
+      """{
+        |  "type": "authorized_user",
+        |  "client_id": "test-client-id",
+        |  "client_secret": "test-secret",
+        |  "refresh_token": "test-refresh-token"
+        |}""".stripMargin
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = None,
+      httpClient = mockHttp,
+      envReader = {
+        case "GOOGLE_ACCESS_TOKEN"            => None
+        case "GOOGLE_APPLICATION_CREDENTIALS" => Some("/env/application_default_credentials.json")
+        case _                                => None
+      },
+      fileReader = _ => Right(credFileContent)
+    )
+
+    val result = provider.getAccessToken()
+    result.isRight shouldBe true
+    result.toOption.get shouldBe "ya29.test-token"
+  }
+
+  it should "return error when credential file JSON is missing the 'type' field" in {
+    val mockHttp = stub[Llm4sHttpClient]
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = Some("/fake/creds.json"),
+      httpClient = mockHttp,
+      envReader = _ => None,
+      fileReader = _ => Right("""{"client_id": "some-id"}""")
+    )
+
+    val result = provider.getAccessToken()
+    result.isLeft shouldBe true
+    result.left.toOption.get.message should include("missing 'type' field")
+  }
+
+  it should "fetch a token via service_account JWT-assertion flow" in {
+    val kpg = KeyPairGenerator.getInstance("RSA")
+    kpg.initialize(1024)
+    val kp = kpg.generateKeyPair()
+    val pem = "-----BEGIN PRIVATE KEY-----\n" +
+      Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8)).encodeToString(kp.getPrivate.getEncoded) +
+      "\n-----END PRIVATE KEY-----\n"
+    val credJson = ujson
+      .Obj(
+        "type"         -> "service_account",
+        "client_email" -> "test@my-project.iam.gserviceaccount.com",
+        "private_key"  -> pem,
+        "token_uri"    -> "https://oauth2.googleapis.com/token"
+      )
+      .render()
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = Some("/fake/sa_creds.json"),
+      httpClient = mockHttp,
+      envReader = _ => None,
+      fileReader = _ => Right(credJson)
+    )
+
+    val result = provider.getAccessToken()
+    result.isRight shouldBe true
+    result.toOption.get shouldBe "ya29.test-token"
+  }
+
+  it should "return AuthenticationError when JWT exchange returns non-200" in {
+    val kpg = KeyPairGenerator.getInstance("RSA")
+    kpg.initialize(1024)
+    val kp = kpg.generateKeyPair()
+    val pem = "-----BEGIN PRIVATE KEY-----\n" +
+      Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8)).encodeToString(kp.getPrivate.getEncoded) +
+      "\n-----END PRIVATE KEY-----\n"
+    val credJson = ujson
+      .Obj(
+        "type"         -> "service_account",
+        "client_email" -> "test@my-project.iam.gserviceaccount.com",
+        "private_key"  -> pem,
+        "token_uri"    -> "https://oauth2.googleapis.com/token"
+      )
+      .render()
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(401, "Unauthorized", Map.empty))
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = Some("/fake/sa_creds.json"),
+      httpClient = mockHttp,
+      envReader = _ => None,
+      fileReader = _ => Right(credJson)
+    )
+
+    val result = provider.getAccessToken()
+    result.isLeft shouldBe true
+    result.left.toOption.get.message should include("JWT token exchange failed")
+  }
+
+  it should "return AuthenticationError for an invalid RSA private key in service_account credentials" in {
+    val credJson = ujson
+      .Obj(
+        "type"         -> "service_account",
+        "client_email" -> "test@my-project.iam.gserviceaccount.com",
+        "private_key"  -> "-----BEGIN PRIVATE KEY-----\nYWFh\n-----END PRIVATE KEY-----\n",
+        "token_uri"    -> "https://oauth2.googleapis.com/token"
+      )
+      .render()
+
+    val mockHttp = stub[Llm4sHttpClient]
+
+    val provider = new VertexAIAuthProvider(
+      credentialFilePath = Some("/fake/sa_creds.json"),
+      httpClient = mockHttp,
+      envReader = _ => None,
+      fileReader = _ => Right(credJson)
+    )
+
+    val result = provider.getAccessToken()
+    result.isLeft shouldBe true
+    result.left.toOption.get.message should include("Failed to parse private key")
+  }
+
+  // ============================================================
+  // VertexAIClient — request body: message type coverage
+  // ============================================================
+
+  "VertexAIClient request body" should "include systemInstruction when a SystemMessage is present" in {
+    var capturedBody = ""
+    val client       = captureBodyClient(capturedBody = _)
+    val conv         = Conversation(Seq(SystemMessage("You are a helpful assistant."), UserMessage("Hi")))
+
+    val result = client.complete(conv, CompletionOptions())
+
+    result.isRight shouldBe true
+    val req = ujson.read(capturedBody)
+    req.obj.contains("systemInstruction") shouldBe true
+    req("systemInstruction")("parts")(0)("text").str should include("helpful assistant")
+  }
+
+  it should "include functionCall parts for AssistantMessage with tool calls" in {
+    var capturedBody = ""
+    val client       = captureBodyClient(capturedBody = _)
+    val conv = Conversation(
+      Seq(
+        UserMessage("What is the weather?"),
+        AssistantMessage(None, Seq(ToolCall("tc-1", "get_weather", ujson.Obj("location" -> "London"))))
+      )
+    )
+
+    val result = client.complete(conv, CompletionOptions())
+
+    result.isRight shouldBe true
+    capturedBody should include("functionCall")
+    capturedBody should include("get_weather")
+  }
+
+  it should "include functionResponse parts for ToolMessage after a tool call" in {
+    var capturedBody = ""
+    val client       = captureBodyClient(capturedBody = _)
+    val conv = Conversation(
+      Seq(
+        UserMessage("What is the weather?"),
+        AssistantMessage(None, Seq(ToolCall("tc-1", "get_weather", ujson.Obj("location" -> "London")))),
+        ToolMessage("Sunny, 22 C", "tc-1")
+      )
+    )
+
+    val result = client.complete(conv, CompletionOptions())
+
+    result.isRight shouldBe true
+    capturedBody should include("functionResponse")
+    capturedBody should include("get_weather")
+    capturedBody should include("Sunny")
+  }
+
+  it should "set maxOutputTokens when maxTokens is provided" in {
+    var capturedBody = ""
+    val client       = captureBodyClient(capturedBody = _)
+
+    val result = client.complete(
+      Conversation(Seq(UserMessage("Hi"))),
+      CompletionOptions().copy(maxTokens = Some(512))
+    )
+
+    result.isRight shouldBe true
+    ujson.read(capturedBody)("generationConfig")("maxOutputTokens").num.toInt shouldBe 512
+  }
+
+  it should "set responseMimeType for ResponseFormat.Json" in {
+    var capturedBody = ""
+    val client       = captureBodyClient(capturedBody = _)
+
+    val result = client.complete(
+      Conversation(Seq(UserMessage("Hi"))),
+      CompletionOptions().withResponseFormat(ResponseFormat.Json)
+    )
+
+    result.isRight shouldBe true
+    ujson.read(capturedBody)("generationConfig")("responseMimeType").str shouldBe "application/json"
+  }
+
+  it should "set responseMimeType and responseSchema for ResponseFormat.JsonSchema" in {
+    var capturedBody = ""
+    val client       = captureBodyClient(capturedBody = _)
+    val schema =
+      ujson.Obj("type" -> "object", "properties" -> ujson.Obj("name" -> ujson.Obj("type" -> "string")))
+
+    val result = client.complete(
+      Conversation(Seq(UserMessage("Hi"))),
+      CompletionOptions().withResponseFormat(ResponseFormat.JsonSchema(schema))
+    )
+
+    result.isRight shouldBe true
+    val genCfg = ujson.read(capturedBody)("generationConfig")
+    genCfg("responseMimeType").str shouldBe "application/json"
+    genCfg.obj.contains("responseSchema") shouldBe true
+  }
+
+  it should "include functionDeclarations when tools are passed in CompletionOptions" in {
+    import org.llm4s.toolapi.{ Schema, ToolBuilder }
+    var capturedBody = ""
+    val client       = captureBodyClient(capturedBody = _)
+    val schema       = Schema.`object`[Map[String, Any]]("In").withProperty(Schema.property("q", Schema.string("q")))
+
+    ToolBuilder[Map[String, Any], String]("search", "Search tool", schema)
+      .withHandler(_ => Right("ok"))
+      .buildSafe() match {
+      case Right(tool) =>
+        val result = client.complete(
+          Conversation(Seq(UserMessage("Hi"))),
+          CompletionOptions().copy(tools = Seq(tool))
+        )
+        result.isRight shouldBe true
+        ujson.read(capturedBody)("tools")(0)("functionDeclarations")(0)("name").str shouldBe "search"
+      case Left(err) => fail(s"Tool build failed: ${err.message}")
+    }
+  }
+
+  // ============================================================
+  // VertexAIClient.stripAdditionalProperties
+  // ============================================================
+
+  "VertexAIClient.stripAdditionalProperties" should "remove additionalProperties from anyOf sub-schemas" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
+
+    val schema = ujson.Obj(
+      "type" -> "object",
+      "anyOf" -> ujson.Arr(
+        ujson.Obj("type" -> "string", "additionalProperties"  -> false),
+        ujson.Obj("type" -> "integer", "additionalProperties" -> false)
+      )
+    )
+    client.stripAdditionalProperties(schema)
+
+    schema("anyOf")(0).obj.contains("additionalProperties") shouldBe false
+    schema("anyOf")(1).obj.contains("additionalProperties") shouldBe false
+  }
+
+  it should "remove additionalProperties from oneOf sub-schemas" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
+
+    val schema = ujson.Obj(
+      "oneOf" -> ujson.Arr(
+        ujson.Obj("type" -> "string", "additionalProperties" -> ujson.Bool(true))
+      )
+    )
+    client.stripAdditionalProperties(schema)
+
+    schema("oneOf")(0).obj.contains("additionalProperties") shouldBe false
+  }
+
+  it should "remove additionalProperties from allOf sub-schemas" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
+
+    val schema = ujson.Obj(
+      "allOf" -> ujson.Arr(
+        ujson.Obj("type" -> "object", "additionalProperties" -> ujson.Obj())
+      )
+    )
+    client.stripAdditionalProperties(schema)
+
+    schema("allOf")(0).obj.contains("additionalProperties") shouldBe false
+  }
+
+  it should "be a no-op for non-object JSON values" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
+
+    noException should be thrownBy {
+      client.stripAdditionalProperties(ujson.Str("a string value"))
+      client.stripAdditionalProperties(ujson.Num(42))
+      client.stripAdditionalProperties(ujson.True)
+    }
+  }
+
+  // ============================================================
+  // VertexAIClient — response parsing edge cases
+  // ============================================================
+
+  "VertexAIClient.complete()" should "return a ValidationError when candidates array is empty" in {
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).onCall { (url: String, _: Map[String, String], _: String, _: Int) =>
+      if (url.contains("oauth2.googleapis.com")) HttpResponse(200, tokenBody, Map.empty)
+      else HttpResponse(200, """{"candidates":[]}""", Map.empty)
+    }
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
+
+    val result = client.complete(Conversation(Seq(UserMessage("Hi"))), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get.message should include("No candidates")
+  }
+
+  // ============================================================
+  // VertexAIClient — streaming edge cases
+  // ============================================================
+
+  "VertexAIClient.streamComplete()" should "emit a tool-call chunk for functionCall SSE data" in {
+    val sseData =
+      "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":" +
+        "{\"name\":\"get_weather\",\"args\":{\"location\":\"London\"}}}]}}]}\n"
+    val inputStream = new ByteArrayInputStream(sseData.getBytes(StandardCharsets.UTF_8))
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(200, inputStream))
+
+    val chunks = scala.collection.mutable.Buffer[StreamedChunk]()
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
+    val result = client.streamComplete(
+      Conversation(Seq(UserMessage("What is the weather?"))),
+      CompletionOptions(),
+      chunk => chunks += chunk
+    )
+
+    result.isRight shouldBe true
+    chunks should have size 1
+    chunks.head.toolCall should not be empty
+    chunks.head.toolCall.get.name shouldBe "get_weather"
+  }
+
+  it should "skip non-data SSE lines (comment and event lines)" in {
+    val sseData =
+      ": keep-alive\n" +
+        "event: content\n" +
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}]}}]," +
+        "\"usageMetadata\":{\"promptTokenCount\":2,\"candidatesTokenCount\":1,\"totalTokenCount\":3}}\n"
+    val inputStream = new ByteArrayInputStream(sseData.getBytes(StandardCharsets.UTF_8))
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(200, inputStream))
+
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
+    val result = client.streamComplete(Conversation(Seq(UserMessage("Hi"))), CompletionOptions(), _ => ())
+
+    result.isRight shouldBe true
+    result.toOption.get.content shouldBe "Hello"
+  }
+
+  it should "handle a data line with empty candidates gracefully" in {
+    val sseData =
+      "data: {\"candidates\":[]," +
+        "\"usageMetadata\":{\"promptTokenCount\":2,\"candidatesTokenCount\":0,\"totalTokenCount\":2}}\n"
+    val inputStream = new ByteArrayInputStream(sseData.getBytes(StandardCharsets.UTF_8))
+
+    val mockHttp = stub[Llm4sHttpClient]
+    (mockHttp.post _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    (mockHttp.get _).when(*, *, *, *).returns(HttpResponse(200, tokenBody, Map.empty))
+    (mockHttp.postStream _).when(*, *, *, *).returns(StreamingHttpResponse(200, inputStream))
+
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      mockHttp
+    )
+    val result = client.streamComplete(Conversation(Seq(UserMessage("Hi"))), CompletionOptions(), _ => ())
+
+    result.isRight shouldBe true
+  }
+
+  // ============================================================
+  // VertexAIClient — lifecycle: releaseResources
+  // ============================================================
+
+  "VertexAIClient" should "call close() on httpClient when it is AutoCloseable" in {
+    val trackingHttp = new TrackingAutoCloseableHttpClient()
+    val client = new VertexAIClient(
+      testConfig,
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Disabled,
+      trackingHttp
+    )
+    client.close()
+
+    trackingHttp.closeCalled shouldBe true
+  }
+
+  // ============================================================
+  // VertexAIClient.apply — factory method coverage
+  // ============================================================
+
+  "VertexAIClient.apply" should "construct a client using the single-argument overload" in {
+    val result = VertexAIClient(testConfig)
+    result.isRight shouldBe true
+  }
+
+  it should "construct a client using the two-argument (config + metrics) overload" in {
+    val result = VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop)
+    result.isRight shouldBe true
+  }
+
+  it should "construct a client using the three-argument (config + metrics + logging) overload" in {
+    val result = VertexAIClient(testConfig, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled)
+    result.isRight shouldBe true
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 class ProviderKindSpec extends AnyFlatSpec with Matchers:
 
   "ProviderKind" should "expose all expected provider instances" in {
-    ProviderKind.all should have size 10
+    ProviderKind.all should have size 11
     (ProviderKind.all should contain).allOf(
       ProviderKind.OpenAI,
       ProviderKind.Azure,
@@ -18,7 +18,8 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       ProviderKind.Gemini,
       ProviderKind.Cohere,
       ProviderKind.DeepSeek,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.VertexAI
     )
   }
 
@@ -33,6 +34,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     ProviderKind.DeepSeek.name shouldBe "deepseek"
     ProviderKind.Cohere.name shouldBe "cohere"
     ProviderKind.Mistral.name shouldBe "mistral"
+    ProviderKind.VertexAI.name shouldBe "vertexai"
   }
 
   "ProviderKind.fromName" should "parse supported providers case-insensitively" in {
@@ -47,6 +49,9 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     ProviderKind.fromName("DEEPSEEK") shouldBe Some(ProviderKind.DeepSeek)
     ProviderKind.fromName("COHERE") shouldBe Some(ProviderKind.Cohere)
     ProviderKind.fromName("MISTRAL") shouldBe Some(ProviderKind.Mistral)
+    ProviderKind.fromName("vertex") shouldBe Some(ProviderKind.VertexAI)
+    ProviderKind.fromName("vertexai") shouldBe Some(ProviderKind.VertexAI)
+    ProviderKind.fromName("VertexAI") shouldBe Some(ProviderKind.VertexAI)
   }
 
   it should "return None for unknown providers" in {
@@ -72,6 +77,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       case ProviderKind.DeepSeek   => "cloud-deepseek"
       case ProviderKind.Cohere     => "cloud-cohere"
       case ProviderKind.Mistral    => "cloud-mistral"
+      case ProviderKind.VertexAI   => "cloud-vertexai"
 
     describe(ProviderKind.OpenAI) shouldBe "cloud-openai"
     describe(ProviderKind.Ollama) shouldBe "local"

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/VertexAIExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/VertexAIExample.scala
@@ -23,28 +23,26 @@ import org.llm4s.llmconnect.model.{ Conversation, CompletionOptions, UserMessage
 object VertexAIExample extends App {
 
   val result = for {
-    registry   <- Llm4sConfig.modelRegistryService()
-    config      = VertexAIConfig(
-                    projectId = sys.env.getOrElse("VERTEX_PROJECT_ID", "my-gcp-project"),
-                    location = sys.env.getOrElse("VERTEX_LOCATION", "us-central1"),
-                    model = sys.env.getOrElse("VERTEX_MODEL", "gemini-2.0-flash"),
-                    credentialFilePath = sys.env.get("GOOGLE_APPLICATION_CREDENTIALS"),
-                    contextWindow = 1048576,
-                    reserveCompletion = 8192
-                  )
-    client     <- LLMConnect.getClient(config)(using registry)
+    registry <- Llm4sConfig.modelRegistryService()
+    config = VertexAIConfig(
+      projectId = sys.env.getOrElse("VERTEX_PROJECT_ID", "my-gcp-project"),
+      location = sys.env.getOrElse("VERTEX_LOCATION", "us-central1"),
+      model = sys.env.getOrElse("VERTEX_MODEL", "gemini-2.0-flash"),
+      credentialFilePath = sys.env.get("GOOGLE_APPLICATION_CREDENTIALS"),
+      contextWindow = 1048576,
+      reserveCompletion = 8192
+    )
+    client <- LLMConnect.getClient(config)(using registry)
     completion <- client.complete(
-                    Conversation(Seq(UserMessage("What is the capital of France? Reply in one sentence."))),
-                    CompletionOptions()
-                  )
+      Conversation(Seq(UserMessage("What is the capital of France? Reply in one sentence."))),
+      CompletionOptions()
+    )
   } yield completion
 
   result match {
     case Right(completion) =>
       println(s"Vertex AI response: ${completion.content}")
-      completion.usage.foreach(u =>
-        println(s"Token usage: prompt=${u.promptTokens}, completion=${u.completionTokens}")
-      )
+      completion.usage.foreach(u => println(s"Token usage: prompt=${u.promptTokens}, completion=${u.completionTokens}"))
     case Left(error) =>
       println(s"Error: ${error.message}")
       sys.exit(1)

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/VertexAIExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/VertexAIExample.scala
@@ -2,49 +2,71 @@ package org.llm4s.samples.basic
 
 import org.llm4s.config.Llm4sConfig
 import org.llm4s.llmconnect.LLMConnect
-import org.llm4s.llmconnect.config.VertexAIConfig
-import org.llm4s.llmconnect.model.{ Conversation, CompletionOptions, UserMessage }
+import org.llm4s.llmconnect.model._
+import org.slf4j.LoggerFactory
 
 /**
  * Demonstrates basic usage of the Vertex AI provider.
  *
- * Prerequisites:
- *   - Set `LLM_PROVIDER_0_PROVIDER=vertexai` (or use `fromValues` directly)
- *   - Set `LLM_PROVIDER_0_ENDPOINT=<your-gcp-project-id>`
- *   - Authenticate via one of:
- *     - `export GOOGLE_ACCESS_TOKEN=$(gcloud auth print-access-token)`
- *     - `gcloud auth application-default login`
- *     - Set `GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json`
- *     - Deploy on GCE/GKE (Workload Identity)
+ * Configure a named provider in `application.local.conf`:
+ * {{{
+ * llm4s {
+ *   providers {
+ *     provider = "vertexai-main"
+ *
+ *     vertexai-main {
+ *       provider  = "vertexai"
+ *       model     = "gemini-2.0-flash"
+ *       endpoint  = "my-gcp-project"   // GCP project ID
+ *       organization = "us-central1"   // GCP region (optional, defaults to us-central1)
+ *       // apiKey = "/path/to/service-account.json"  // optional credential file path
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * Then authenticate via one of:
+ *   - `export GOOGLE_ACCESS_TOKEN=$(gcloud auth print-access-token)`
+ *   - `gcloud auth application-default login`
+ *   - Set `GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json`
+ *   - Deploy on GCE/GKE (Workload Identity)
  *
  * Run with:
  *   sbt "samples/runMain org.llm4s.samples.basic.VertexAIExample"
  */
-object VertexAIExample extends App {
+object VertexAIExample {
+  private val logger = LoggerFactory.getLogger(getClass)
 
-  val result = for {
-    registry <- Llm4sConfig.modelRegistryService()
-    config = VertexAIConfig(
-      projectId = sys.env.getOrElse("VERTEX_PROJECT_ID", "my-gcp-project"),
-      location = sys.env.getOrElse("VERTEX_LOCATION", "us-central1"),
-      model = sys.env.getOrElse("VERTEX_MODEL", "gemini-2.0-flash"),
-      credentialFilePath = sys.env.get("GOOGLE_APPLICATION_CREDENTIALS"),
-      contextWindow = 1048576,
-      reserveCompletion = 8192
-    )
-    client <- LLMConnect.getClient(config)(using registry)
-    completion <- client.complete(
-      Conversation(Seq(UserMessage("What is the capital of France? Reply in one sentence."))),
-      CompletionOptions()
-    )
-  } yield completion
+  def main(args: Array[String]): Unit = {
 
-  result match {
-    case Right(completion) =>
-      println(s"Vertex AI response: ${completion.content}")
-      completion.usage.foreach(u => println(s"Token usage: prompt=${u.promptTokens}, completion=${u.completionTokens}"))
-    case Left(error) =>
-      println(s"Error: ${error.message}")
-      sys.exit(1)
+    val result = for {
+      providerCfg     <- Llm4sConfig.defaultProvider()
+      registryService <- Llm4sConfig.modelRegistryService()
+      given org.llm4s.model.ModelRegistryService = registryService
+      client     <- LLMConnect.getClient(providerCfg)
+      completion <- client.complete(
+                      Conversation(
+                        Seq(UserMessage("What is the capital of France? Reply in one sentence."))
+                      )
+                    )
+    } yield completion
+
+    result match {
+      case Right(completion) =>
+        logger.info("Vertex AI response: {}", completion.content)
+        completion.usage.foreach { u =>
+          logger.info(
+            "Token usage: prompt={}, completion={}",
+            u.promptTokens,
+            u.completionTokens
+          )
+        }
+      case Left(error) =>
+        logger.error("Error: {}", error.formatted)
+        logger.info(
+          "Tip: Configure a 'vertexai' named provider in application.local.conf"
+        )
+        sys.exit(1)
+    }
   }
 }

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/VertexAIExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/VertexAIExample.scala
@@ -43,12 +43,12 @@ object VertexAIExample {
       providerCfg     <- Llm4sConfig.defaultProvider()
       registryService <- Llm4sConfig.modelRegistryService()
       given org.llm4s.model.ModelRegistryService = registryService
-      client     <- LLMConnect.getClient(providerCfg)
+      client <- LLMConnect.getClient(providerCfg)
       completion <- client.complete(
-                      Conversation(
-                        Seq(UserMessage("What is the capital of France? Reply in one sentence."))
-                      )
-                    )
+        Conversation(
+          Seq(UserMessage("What is the capital of France? Reply in one sentence."))
+        )
+      )
     } yield completion
 
     result match {

--- a/modules/samples/src/main/scala/org/llm4s/samples/basic/VertexAIExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/basic/VertexAIExample.scala
@@ -1,0 +1,52 @@
+package org.llm4s.samples.basic
+
+import org.llm4s.config.Llm4sConfig
+import org.llm4s.llmconnect.LLMConnect
+import org.llm4s.llmconnect.config.VertexAIConfig
+import org.llm4s.llmconnect.model.{ Conversation, CompletionOptions, UserMessage }
+
+/**
+ * Demonstrates basic usage of the Vertex AI provider.
+ *
+ * Prerequisites:
+ *   - Set `LLM_PROVIDER_0_PROVIDER=vertexai` (or use `fromValues` directly)
+ *   - Set `LLM_PROVIDER_0_ENDPOINT=<your-gcp-project-id>`
+ *   - Authenticate via one of:
+ *     - `export GOOGLE_ACCESS_TOKEN=$(gcloud auth print-access-token)`
+ *     - `gcloud auth application-default login`
+ *     - Set `GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json`
+ *     - Deploy on GCE/GKE (Workload Identity)
+ *
+ * Run with:
+ *   sbt "samples/runMain org.llm4s.samples.basic.VertexAIExample"
+ */
+object VertexAIExample extends App {
+
+  val result = for {
+    registry   <- Llm4sConfig.modelRegistryService()
+    config      = VertexAIConfig(
+                    projectId = sys.env.getOrElse("VERTEX_PROJECT_ID", "my-gcp-project"),
+                    location = sys.env.getOrElse("VERTEX_LOCATION", "us-central1"),
+                    model = sys.env.getOrElse("VERTEX_MODEL", "gemini-2.0-flash"),
+                    credentialFilePath = sys.env.get("GOOGLE_APPLICATION_CREDENTIALS"),
+                    contextWindow = 1048576,
+                    reserveCompletion = 8192
+                  )
+    client     <- LLMConnect.getClient(config)(using registry)
+    completion <- client.complete(
+                    Conversation(Seq(UserMessage("What is the capital of France? Reply in one sentence."))),
+                    CompletionOptions()
+                  )
+  } yield completion
+
+  result match {
+    case Right(completion) =>
+      println(s"Vertex AI response: ${completion.content}")
+      completion.usage.foreach(u =>
+        println(s"Token usage: prompt=${u.promptTokens}, completion=${u.completionTokens}")
+      )
+    case Left(error) =>
+      println(s"Error: ${error.message}")
+      sys.exit(1)
+  }
+}

--- a/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
@@ -372,6 +372,13 @@ private[providersetup] object ProviderSetupRuntime:
           apiKey = input.flatMap(_.apiKey).getOrElse(cfg.apiKey),
           baseUrl = input.flatMap(_.baseUrl).getOrElse(cfg.baseUrl)
         )
+      case cfg: VertexAIConfig =>
+        cfg.copy(
+          model = input.flatMap(_.model).getOrElse(cfg.model),
+          projectId = input.flatMap(_.endpoint).getOrElse(cfg.projectId),
+          location = input.flatMap(_.organization).getOrElse(cfg.location),
+          credentialFilePath = input.flatMap(_.apiKey).orElse(cfg.credentialFilePath)
+        )
 
   def demoCompletionCmd(
     providerConfig: ProviderConfig,
@@ -580,3 +587,4 @@ private[providersetup] object ProviderSetupRuntime:
       case cfg: CohereConfig    => cfg.copy(model = modelName)
       case cfg: MistralConfig   => cfg.copy(model = modelName)
       case cfg: ZaiConfig       => cfg.copy(model = modelName)
+      case cfg: VertexAIConfig  => cfg.copy(model = modelName)

--- a/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
@@ -141,6 +141,7 @@ object PrometheusMetricsExample {
                 case _: org.llm4s.llmconnect.config.DeepSeekConfig  => "deepseek"
                 case _: org.llm4s.llmconnect.config.CohereConfig    => "cohere"
                 case _: org.llm4s.llmconnect.config.MistralConfig   => "mistral"
+                case _: org.llm4s.llmconnect.config.VertexAIConfig  => "vertexai"
               }
 
               println(s"Using model: ${config.model}")


### PR DESCRIPTION
## Summary

- Implements Google Cloud Vertex AI as a full `LLMClient` provider (fixes #930)
- `VertexAIAuthProvider`: Application Default Credentials token resolution (env var `GOOGLE_ACCESS_TOKEN` → JSON credential file → GCE/GKE metadata server), RS256 JWT for service accounts, token caching until 1 min before expiry — no new library dependencies (uses `java.security`)
- `VertexAIClient`: Gemini-compatible JSON format (`contents`/`parts`, `systemInstruction`, `functionCall`/`functionResponse`) with region-scoped endpoint `https://{location}-aiplatform.googleapis.com/v1` and Bearer-token auth
- `VertexAIConfig`: holds `projectId`, `location`, `credentialFilePath`; `computedBaseUrl` derived from location; `ProviderKind.VertexAI` added to the enum
- `NamedProviderLoader`: `endpoint` = projectId, `organization` = location (default `us-central1`), `apiKey` = optional credential file path
- `LLMConnect.buildClient` / `fromProvider` updated for `VertexAIConfig`
- `VertexAIExample` sample showing simple completion

## Test plan

- [x] `VertexAIClientSpec` — basic client construction, context window, base URL computation
- [x] `VertexAIClientClosedStateTest` — `complete()`/`streamComplete()` after `close()` → `ConfigurationError`, idempotent close
- [x] `VertexAIAuthProviderSpec` — all credential paths: `GOOGLE_ACCESS_TOKEN` env var, `authorized_user` refresh flow, failed refresh, unsupported credential type, invalid JSON, metadata-server fallback, non-200 metadata server; `CachedToken` expiry logic
- [x] `VertexAIClientHttpSpec` — HTTP-level tests with mocked client: 200 text parse, token usage, tool call, 401/403/429/400/500 error mapping, Bearer header, correct Vertex AI URL format, exchange logging, SSE streaming, non-200 stream, schema `additionalProperties` stripping
- [x] `ProviderKindSpec` — updated to include `VertexAI` in `all` (size 11), `name`/`fromName` round-trip, pattern match
- [x] All 6779 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)