### PR TITLE
feat(effect/zio): cats-effect IO and ZIO integration modules (fixes #935)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,6 +129,8 @@ lazy val commonSettings = Seq(
 lazy val llm4s = (project in file("."))
   .aggregate(
     core,
+    llm4sEffect,
+    llm4sZio,
     samples,
     workspaceShared,
     workspaceRunner,
@@ -139,6 +141,33 @@ lazy val llm4s = (project in file("."))
   )
   .settings(
     publish / skip := true
+  )
+
+lazy val llm4sEffect = (project in file("modules/llm4s-effect"))
+  .dependsOn(core)
+  .settings(
+    name := "llm4s-effect",
+    commonSettings,
+    libraryDependencies ++= Seq(
+      Deps.catsEffect,
+      Deps.fs2,
+      Deps.catsEffectTestingScalatest % Test,
+      Deps.scalatest                  % Test
+    )
+  )
+
+lazy val llm4sZio = (project in file("modules/llm4s-zio"))
+  .dependsOn(core)
+  .settings(
+    name := "llm4s-zio",
+    commonSettings,
+    libraryDependencies ++= Seq(
+      Deps.zio,
+      Deps.zioStreams,
+      Deps.zioTest    % Test,
+      Deps.zioTestSbt % Test
+    ),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
   )
 
 lazy val core = (project in file("modules/core"))
@@ -257,13 +286,19 @@ lazy val workspaceRunner = (project in file("modules/workspace/workspaceRunner")
   .settings(WorkspaceRunnerDocker.settings)
 
 lazy val samples = (project in file("modules//samples"))
-  .dependsOn(core)
+  .dependsOn(core, llm4sEffect, llm4sZio)
   .settings(
     name := "samples",
     commonSettings,
     publish / skip := true,
     coverageEnabled := false,
-    libraryDependencies += Deps.termflow
+    libraryDependencies ++= Seq(
+      Deps.termflow,
+      Deps.catsEffect,
+      Deps.fs2,
+      Deps.zio,
+      Deps.zioStreams
+    )
   )
 
 lazy val workspaceSamples = (project in file("modules/workspace/workspaceSamples"))

--- a/docs/guide/cats-effect.md
+++ b/docs/guide/cats-effect.md
@@ -1,0 +1,101 @@
+# cats-effect Integration
+
+The `llm4s-effect` module wraps the synchronous `LLMClient` and `Agent` APIs in
+[cats-effect](https://typelevel.org/cats-effect/) `IO` (or any `Async[F]` type),
+keeping the compute thread pool free while long-running LLM calls block on the
+dedicated blocking pool.
+
+## Dependency
+
+```scala
+// build.sbt
+libraryDependencies += "org.llm4s" %% "llm4s-effect" % "<version>"
+```
+
+## LLMClientIO
+
+`LLMClientIO[F[_]]` is the cats-effect wrapper for `LLMClient`.
+
+### Acquire from the environment
+
+Use `LLMClientIO.resource[F]` to load provider config from the environment,
+build the client, and release it on scope exit:
+
+```scala
+import cats.effect.{IO, IOApp}
+import org.llm4s.effect.cats.LLMClientIO
+import org.llm4s.llmconnect.model.{Conversation, UserMessage}
+
+object MyApp extends IOApp.Simple {
+  def run: IO[Unit] =
+    LLMClientIO.resource[IO].use { client =>
+      for {
+        completion <- client.complete(Conversation(Seq(UserMessage("What is 2 + 2?"))))
+        _          <- IO.println(completion.content)
+      } yield ()
+    }
+}
+```
+
+### Wrap an existing client
+
+If you already hold an `LLMClient` (e.g. constructed manually):
+
+```scala
+import org.llm4s.effect.cats.LLMClientIO
+
+val wrapped = LLMClientIO[IO](existingClient)
+```
+
+### Streaming
+
+`streamComplete` returns an `fs2.Stream[F, StreamedChunk]` whose evaluation
+runs on the blocking pool:
+
+```scala
+client
+  .streamComplete(conversation)
+  .evalMap(chunk => IO.print(chunk.content.getOrElse("")))
+  .compile
+  .drain
+```
+
+## AgentIO
+
+`AgentIO[F[_]]` wraps `Agent`, shifting the blocking agent loop to the blocking pool.
+
+```scala
+val agentIO = client.agent()
+
+for {
+  state <- agentIO.run(query = "Summarise this", tools = myTools)
+  _     <- IO.println(state.conversation.messages.last)
+} yield ()
+```
+
+### Multi-turn conversations
+
+```scala
+for {
+  s1 <- agentIO.run("What's the weather in Paris?", tools)
+  s2 <- agentIO.continueConversation(s1, "And London?")
+} yield s2
+```
+
+## Error handling
+
+All `LLMError` values are raised as `LLMException` in the `F` error channel:
+
+```scala
+import org.llm4s.effect.cats.LLMException
+
+client.complete(conversation).handleErrorWith {
+  case e: LLMException => IO.println(s"LLM error: ${e.error.message}")
+  case t               => IO.raiseError(t)
+}
+```
+
+## Environment variables
+
+See [CLAUDE.md](../../CLAUDE.md) for the full list of supported environment
+variables (`LLM_MODEL`, `OPENAI_API_KEY`, etc.).

--- a/docs/guide/zio.md
+++ b/docs/guide/zio.md
@@ -1,0 +1,96 @@
+# ZIO Integration
+
+The `llm4s-zio` module wraps the synchronous `LLMClient` and `Agent` APIs in
+[ZIO](https://zio.dev) effects, shifting blocking LLM calls to ZIO's blocking
+thread pool and surfacing `LLMError` directly in the ZIO error channel.
+
+## Dependency
+
+```scala
+// build.sbt
+libraryDependencies += "org.llm4s" %% "llm4s-zio" % "<version>"
+```
+
+## LLMClientZ
+
+`LLMClientZ` is the ZIO wrapper for `LLMClient`.
+
+### Acquire via ZLayer
+
+Use `LLMClientZ.layer` to load provider config from the environment, build the
+client, and release it on scope exit:
+
+```scala
+import org.llm4s.agent.AgentContext
+import org.llm4s.llmconnect.model.{Conversation, UserMessage}
+import org.llm4s.toolapi.ToolRegistry
+import org.llm4s.zio.LLMClientZ
+import zio.{ZIO, ZIOAppDefault}
+
+object MyApp extends ZIOAppDefault {
+  def run: ZIO[Any, Any, Any] =
+    (for {
+      client <- ZIO.service[LLMClientZ]
+      c      <- client.complete(Conversation(Seq(UserMessage("What is 2 + 2?"))))
+      _      <- ZIO.debug(c.content)
+    } yield ()).provide(LLMClientZ.layer)
+}
+```
+
+### Wrap an existing client
+
+```scala
+import org.llm4s.zio.LLMClientZ
+
+val wrapped: LLMClientZ = LLMClientZ(existingClient)
+```
+
+### Streaming
+
+`streamComplete` returns a `ZStream[Any, LLMError, StreamedChunk]`:
+
+```scala
+client
+  .streamComplete(conversation)
+  .map(_.content.getOrElse(""))
+  .runCollect
+  .map(_.mkString)
+```
+
+## AgentZ
+
+`AgentZ` wraps `Agent`, shifting the blocking agent loop to ZIO's blocking pool.
+`LLMError` is the native error type — no wrapping needed.
+
+```scala
+val agentZ = client.agent()
+
+for {
+  state <- agentZ.run(query = "Summarise this", tools = myTools)
+  _     <- ZIO.debug(state.conversation.messages.last.toString)
+} yield ()
+```
+
+### Multi-turn conversations
+
+```scala
+for {
+  s1 <- agentZ.run("What's the weather in Paris?", tools)
+  s2 <- agentZ.continueConversation(s1, "And London?")
+} yield s2
+```
+
+## Error handling
+
+`LLMError` flows naturally in the ZIO error channel:
+
+```scala
+client.complete(conversation).catchAll { err =>
+  ZIO.debug(s"LLM error: ${err.message}") *> ZIO.fail(err)
+}
+```
+
+## Environment variables
+
+See [CLAUDE.md](../../CLAUDE.md) for the full list of supported environment
+variables (`LLM_MODEL`, `OPENAI_API_KEY`, etc.).

--- a/modules/llm4s-effect/src/main/scala/org/llm4s/effect/cats/AgentIO.scala
+++ b/modules/llm4s-effect/src/main/scala/org/llm4s/effect/cats/AgentIO.scala
@@ -1,0 +1,96 @@
+package org.llm4s.effect.cats
+
+import cats.effect.kernel.Async
+import cats.syntax.flatMap.*
+import org.llm4s.agent.guardrails.{ InputGuardrail, OutputGuardrail }
+import org.llm4s.agent.{ Agent, AgentContext, AgentState }
+import org.llm4s.llmconnect.model.CompletionOptions
+import org.llm4s.toolapi.ToolRegistry
+
+/**
+ * cats-effect wrapper for [[Agent]].
+ *
+ * Lifts every `Result[AgentState]` return value into `F[AgentState]`,
+ * raising `LLMError` as [[LLMException]] in the error channel.
+ * The underlying [[Agent.run]] and related methods are blocking — each
+ * call is dispatched to the blocking thread pool via `Async[F].blocking`.
+ */
+trait AgentIO[F[_]] {
+
+  def run(
+    query: String,
+    tools: ToolRegistry,
+    inputGuardrails: Seq[InputGuardrail] = Seq.empty,
+    outputGuardrails: Seq[OutputGuardrail] = Seq.empty,
+    maxSteps: Option[Int] = Some(Agent.DefaultMaxSteps),
+    systemPromptAddition: Option[String] = None,
+    completionOptions: CompletionOptions = CompletionOptions(),
+    context: AgentContext = AgentContext.Default
+  ): F[AgentState]
+
+  def continueConversation(
+    previousState: AgentState,
+    newUserMessage: String,
+    inputGuardrails: Seq[InputGuardrail] = Seq.empty,
+    outputGuardrails: Seq[OutputGuardrail] = Seq.empty,
+    maxSteps: Option[Int] = None,
+    context: AgentContext = AgentContext.Default
+  ): F[AgentState]
+}
+
+object AgentIO {
+
+  /** Wraps an already-constructed [[Agent]]. */
+  def apply[F[_]: Async](agent: Agent): AgentIO[F] = new Impl[F](agent)
+
+  final private class Impl[F[_]](agent: Agent)(using F: Async[F]) extends AgentIO[F] {
+
+    def run(
+      query: String,
+      tools: ToolRegistry,
+      inputGuardrails: Seq[InputGuardrail] = Seq.empty,
+      outputGuardrails: Seq[OutputGuardrail] = Seq.empty,
+      maxSteps: Option[Int] = Some(Agent.DefaultMaxSteps),
+      systemPromptAddition: Option[String] = None,
+      completionOptions: CompletionOptions = CompletionOptions(),
+      context: AgentContext = AgentContext.Default
+    ): F[AgentState] =
+      F.blocking(
+        agent.run(
+          query,
+          tools,
+          inputGuardrails,
+          outputGuardrails,
+          maxSteps = maxSteps,
+          systemPromptAddition = systemPromptAddition,
+          completionOptions = completionOptions,
+          context = context
+        )
+      ).flatMap {
+        case Right(s) => F.pure(s)
+        case Left(e)  => F.raiseError(new LLMException(e))
+      }
+
+    def continueConversation(
+      previousState: AgentState,
+      newUserMessage: String,
+      inputGuardrails: Seq[InputGuardrail] = Seq.empty,
+      outputGuardrails: Seq[OutputGuardrail] = Seq.empty,
+      maxSteps: Option[Int] = None,
+      context: AgentContext = AgentContext.Default
+    ): F[AgentState] =
+      F.blocking(
+        agent.continueConversation(
+          previousState,
+          newUserMessage,
+          inputGuardrails,
+          outputGuardrails,
+          maxSteps,
+          context = context
+        )
+      ).flatMap {
+        case Right(s) => F.pure(s)
+        case Left(e)  => F.raiseError(new LLMException(e))
+      }
+  }
+}

--- a/modules/llm4s-effect/src/main/scala/org/llm4s/effect/cats/LLMClientIO.scala
+++ b/modules/llm4s-effect/src/main/scala/org/llm4s/effect/cats/LLMClientIO.scala
@@ -1,0 +1,90 @@
+package org.llm4s.effect.cats
+
+import cats.effect.kernel.{ Async, Resource }
+import cats.syntax.flatMap.*
+import fs2.{ Chunk, Stream }
+import org.llm4s.agent.Agent
+import org.llm4s.config.Llm4sConfig
+import org.llm4s.llmconnect.{ LLMClient, LLMConnect }
+import org.llm4s.llmconnect.model.{ Completion, CompletionOptions, Conversation, StreamedChunk }
+
+/**
+ * cats-effect wrapper for [[LLMClient]].
+ *
+ * All blocking LLM calls are shifted to the blocking thread pool via
+ * `Async[F].blocking`, keeping the compute pool free for fibers.
+ * `LLMError` values are surfaced as [[LLMException]] in the `F` error channel.
+ */
+trait LLMClientIO[F[_]] {
+
+  def complete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions()
+  ): F[Completion]
+
+  /** Runs the streaming call on the blocking pool, emits all chunks as an fs2 [[Stream]]. */
+  def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions()
+  ): Stream[F, StreamedChunk]
+
+  /** Creates an [[AgentIO]] backed by this client. */
+  def agent(): AgentIO[F]
+}
+
+object LLMClientIO {
+
+  /** Wraps an already-constructed [[LLMClient]]. Does not manage its lifecycle. */
+  def apply[F[_]: Async](underlying: LLMClient): LLMClientIO[F] =
+    new Impl[F](underlying)
+
+  /**
+   * Creates a [[Resource]] that acquires an [[LLMClient]] from the environment
+   * (via [[Llm4sConfig]]) on the blocking thread pool and releases it on scope exit.
+   */
+  def resource[F[_]](using F: Async[F]): Resource[F, LLMClientIO[F]] =
+    Resource
+      .fromAutoCloseable {
+        F.blocking {
+          for {
+            registry <- Llm4sConfig.modelRegistryService()
+            config   <- Llm4sConfig.defaultProvider()
+            client   <- LLMConnect.getClient(config)(using registry)
+          } yield client
+        }.flatMap {
+          case Right(client) => F.pure(client)
+          case Left(err)     => F.raiseError(new LLMException(err))
+        }
+      }
+      .map(apply[F])
+
+  final private class Impl[F[_]](underlying: LLMClient)(using F: Async[F]) extends LLMClientIO[F] {
+
+    def complete(
+      conversation: Conversation,
+      options: CompletionOptions = CompletionOptions()
+    ): F[Completion] =
+      F.blocking(underlying.complete(conversation, options)).flatMap {
+        case Right(c) => F.pure(c)
+        case Left(e)  => F.raiseError(new LLMException(e))
+      }
+
+    def streamComplete(
+      conversation: Conversation,
+      options: CompletionOptions = CompletionOptions()
+    ): Stream[F, StreamedChunk] =
+      Stream.evalUnChunk {
+        F.blocking {
+          val buf = scala.collection.mutable.ListBuffer.empty[StreamedChunk]
+          (underlying.streamComplete(conversation, options, buf += _), buf)
+        }.flatMap { case (result, buf) =>
+          result match {
+            case Right(_)  => F.pure(Chunk.from(buf.toSeq))
+            case Left(err) => F.raiseError(new LLMException(err))
+          }
+        }
+      }
+
+    def agent(): AgentIO[F] = AgentIO[F](new Agent(underlying))
+  }
+}

--- a/modules/llm4s-effect/src/main/scala/org/llm4s/effect/cats/LLMException.scala
+++ b/modules/llm4s-effect/src/main/scala/org/llm4s/effect/cats/LLMException.scala
@@ -1,0 +1,6 @@
+package org.llm4s.effect.cats
+
+import org.llm4s.error.LLMError
+
+/** Bridges [[LLMError]] into the cats-effect error channel as a [[Throwable]]. */
+final class LLMException(val error: LLMError) extends RuntimeException(error.message)

--- a/modules/llm4s-effect/src/test/scala/org/llm4s/effect/cats/AgentIOSpec.scala
+++ b/modules/llm4s-effect/src/test/scala/org/llm4s/effect/cats/AgentIOSpec.scala
@@ -1,0 +1,105 @@
+package org.llm4s.effect.cats
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.llm4s.agent.{ Agent, AgentStatus }
+import org.llm4s.error.SimpleError
+import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.model.{ AssistantMessage, Completion, CompletionOptions, Conversation, StreamedChunk }
+import org.llm4s.toolapi.ToolRegistry
+import org.llm4s.types.Result
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AgentIOSpec extends AnyFlatSpec with Matchers {
+
+  private def completion(text: String) = Completion(
+    id = "test-id",
+    created = 0L,
+    content = text,
+    model = "test-model",
+    message = AssistantMessage(contentOpt = Some(text))
+  )
+
+  private def successClient(text: String): LLMClient = new LLMClient {
+    def complete(c: Conversation, o: CompletionOptions): Result[Completion] =
+      Right(completion(text))
+    def streamComplete(c: Conversation, o: CompletionOptions, onChunk: StreamedChunk => Unit): Result[Completion] =
+      Right(completion(text))
+    def getContextWindow(): Int     = 4096
+    def getReserveCompletion(): Int = 256
+  }
+
+  private val failingClient: LLMClient = new LLMClient {
+    def complete(c: Conversation, o: CompletionOptions): Result[Completion] =
+      Left(SimpleError("agent-fail"))
+    def streamComplete(c: Conversation, o: CompletionOptions, onChunk: StreamedChunk => Unit): Result[Completion] =
+      Left(SimpleError("agent-fail"))
+    def getContextWindow(): Int     = 4096
+    def getReserveCompletion(): Int = 256
+  }
+
+  "AgentIO.run" should "return AgentState with Complete status when the agent finishes" in {
+    val state = AgentIO[IO](new Agent(successClient("4")))
+      .run("What is 2+2?", ToolRegistry.empty)
+      .unsafeRunSync()
+    state.status shouldBe AgentStatus.Complete
+  }
+
+  it should "include the query in the conversation" in {
+    val state = AgentIO[IO](new Agent(successClient("answer")))
+      .run("my query", ToolRegistry.empty)
+      .unsafeRunSync()
+    val messages = state.conversation.messages.map(_.content)
+    messages should contain("my query")
+  }
+
+  it should "raise LLMException when the underlying LLM call fails" in {
+    a[LLMException] should be thrownBy {
+      AgentIO[IO](new Agent(failingClient))
+        .run("What is 2+2?", ToolRegistry.empty)
+        .unsafeRunSync()
+    }
+  }
+
+  it should "wrap the original LLMError inside the LLMException" in {
+    val result = AgentIO[IO](new Agent(failingClient))
+      .run("query", ToolRegistry.empty)
+      .attempt
+      .unsafeRunSync()
+    result.isLeft shouldBe true
+    val ex = result.left.toOption.get
+    ex shouldBe a[LLMException]
+    ex.asInstanceOf[LLMException].error shouldBe SimpleError("agent-fail")
+  }
+
+  "AgentIO.continueConversation" should "return AgentState with Complete status on a follow-up turn" in {
+    val agentIO = AgentIO[IO](new Agent(successClient("6")))
+    val state = for {
+      s1 <- agentIO.run("What is 2+2?", ToolRegistry.empty)
+      s2 <- agentIO.continueConversation(s1, "And 3+3?")
+    } yield s2
+    state.unsafeRunSync().status shouldBe AgentStatus.Complete
+  }
+
+  it should "append the follow-up question to the conversation history" in {
+    val agentIO = AgentIO[IO](new Agent(successClient("6")))
+    val state = for {
+      s1 <- agentIO.run("First question", ToolRegistry.empty)
+      s2 <- agentIO.continueConversation(s1, "Second question")
+    } yield s2
+    val messages = state.unsafeRunSync().conversation.messages.map(_.content)
+    messages should contain("Second question")
+  }
+
+  it should "raise LLMException when the continuation LLM call fails" in {
+    val s1 = AgentIO[IO](new Agent(successClient("4")))
+      .run("First", ToolRegistry.empty)
+      .unsafeRunSync()
+    a[LLMException] should be thrownBy {
+      AgentIO[IO](new Agent(failingClient))
+        .continueConversation(s1, "Follow-up")
+        .unsafeRunSync()
+    }
+  }
+}

--- a/modules/llm4s-effect/src/test/scala/org/llm4s/effect/cats/LLMClientIOSpec.scala
+++ b/modules/llm4s-effect/src/test/scala/org/llm4s/effect/cats/LLMClientIOSpec.scala
@@ -1,0 +1,86 @@
+package org.llm4s.effect.cats
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.llm4s.error.SimpleError
+import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.model.{
+  AssistantMessage,
+  Completion,
+  CompletionOptions,
+  Conversation,
+  StreamedChunk,
+  UserMessage
+}
+import org.llm4s.types.Result
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LLMClientIOSpec extends AnyFlatSpec with Matchers {
+
+  private val testCompletion = Completion(
+    id = "test-id",
+    created = 0L,
+    content = "hello",
+    model = "test-model",
+    message = AssistantMessage(Some("hello"))
+  )
+
+  private val testConversation = Conversation(Seq(UserMessage("ping")))
+
+  private def mockClient(completion: Completion, chunks: Seq[StreamedChunk] = Seq.empty): LLMClient =
+    new LLMClient {
+      def complete(c: Conversation, o: CompletionOptions): Result[Completion] = Right(completion)
+      def streamComplete(c: Conversation, o: CompletionOptions, onChunk: StreamedChunk => Unit): Result[Completion] = {
+        chunks.foreach(onChunk)
+        Right(completion)
+      }
+      def getContextWindow(): Int     = 4096
+      def getReserveCompletion(): Int = 256
+    }
+
+  private val failingClient: LLMClient = new LLMClient {
+    def complete(c: Conversation, o: CompletionOptions): Result[Completion] =
+      Left(SimpleError("boom"))
+    def streamComplete(c: Conversation, o: CompletionOptions, onChunk: StreamedChunk => Unit): Result[Completion] =
+      Left(SimpleError("boom"))
+    def getContextWindow(): Int     = 4096
+    def getReserveCompletion(): Int = 256
+  }
+
+  "LLMClientIO.complete" should "return the completion from the underlying client" in {
+    val c = LLMClientIO[IO](mockClient(testCompletion)).complete(testConversation).unsafeRunSync()
+    c.content shouldBe "hello"
+    c.id shouldBe "test-id"
+  }
+
+  it should "raise LLMException when the underlying client returns Left" in {
+    a[LLMException] should be thrownBy {
+      LLMClientIO[IO](failingClient).complete(testConversation).unsafeRunSync()
+    }
+  }
+
+  "LLMClientIO.streamComplete" should "emit all chunks from the underlying streaming call" in {
+    val chunks = Seq(
+      StreamedChunk(id = "c1", content = Some("hi")),
+      StreamedChunk(id = "c2", content = Some(" world"))
+    )
+    val emitted = LLMClientIO[IO](mockClient(testCompletion, chunks))
+      .streamComplete(testConversation)
+      .compile
+      .toList
+      .unsafeRunSync()
+    emitted.length shouldBe 2
+    emitted.head.id shouldBe "c1"
+  }
+
+  it should "raise LLMException on stream error" in {
+    a[LLMException] should be thrownBy {
+      LLMClientIO[IO](failingClient)
+        .streamComplete(testConversation)
+        .compile
+        .drain
+        .unsafeRunSync()
+    }
+  }
+}

--- a/modules/llm4s-effect/src/test/scala/org/llm4s/effect/cats/LLMExceptionSpec.scala
+++ b/modules/llm4s-effect/src/test/scala/org/llm4s/effect/cats/LLMExceptionSpec.scala
@@ -1,0 +1,24 @@
+package org.llm4s.effect.cats
+
+import org.llm4s.error.SimpleError
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LLMExceptionSpec extends AnyFlatSpec with Matchers {
+
+  "LLMException" should "wrap an LLMError and expose it via .error" in {
+    val error = SimpleError("something went wrong")
+    val ex    = new LLMException(error)
+    ex.error shouldBe error
+  }
+
+  it should "carry the LLMError message as its exception message" in {
+    val ex = new LLMException(SimpleError("provider timeout"))
+    ex.getMessage shouldBe "provider timeout"
+  }
+
+  it should "be a RuntimeException" in {
+    val ex = new LLMException(SimpleError("test"))
+    ex shouldBe a[RuntimeException]
+  }
+}

--- a/modules/llm4s-zio/src/main/scala/org/llm4s/zio/AgentZ.scala
+++ b/modules/llm4s-zio/src/main/scala/org/llm4s/zio/AgentZ.scala
@@ -1,0 +1,92 @@
+package org.llm4s.zio
+
+import org.llm4s.agent.guardrails.{ InputGuardrail, OutputGuardrail }
+import org.llm4s.agent.{ Agent, AgentContext, AgentState }
+import org.llm4s.error.LLMError
+import org.llm4s.llmconnect.model.CompletionOptions
+import org.llm4s.toolapi.ToolRegistry
+import zio.ZIO
+
+/**
+ * ZIO wrapper for [[Agent]].
+ *
+ * Lifts every `Result[AgentState]` return value into `ZIO[Any, LLMError, AgentState]`.
+ * The underlying blocking [[Agent]] methods are shifted to ZIO's blocking thread pool.
+ */
+trait AgentZ {
+
+  def run(
+    query: String,
+    tools: ToolRegistry,
+    inputGuardrails: Seq[InputGuardrail] = Seq.empty,
+    outputGuardrails: Seq[OutputGuardrail] = Seq.empty,
+    maxSteps: Option[Int] = Some(Agent.DefaultMaxSteps),
+    systemPromptAddition: Option[String] = None,
+    completionOptions: CompletionOptions = CompletionOptions(),
+    context: AgentContext = AgentContext.Default
+  ): ZIO[Any, LLMError, AgentState]
+
+  def continueConversation(
+    previousState: AgentState,
+    newUserMessage: String,
+    inputGuardrails: Seq[InputGuardrail] = Seq.empty,
+    outputGuardrails: Seq[OutputGuardrail] = Seq.empty,
+    maxSteps: Option[Int] = None,
+    context: AgentContext = AgentContext.Default
+  ): ZIO[Any, LLMError, AgentState]
+}
+
+object AgentZ {
+
+  /** Wraps an already-constructed [[Agent]]. */
+  def apply(agent: Agent): AgentZ = new Impl(agent)
+
+  final private class Impl(agent: Agent) extends AgentZ {
+
+    def run(
+      query: String,
+      tools: ToolRegistry,
+      inputGuardrails: Seq[InputGuardrail] = Seq.empty,
+      outputGuardrails: Seq[OutputGuardrail] = Seq.empty,
+      maxSteps: Option[Int] = Some(Agent.DefaultMaxSteps),
+      systemPromptAddition: Option[String] = None,
+      completionOptions: CompletionOptions = CompletionOptions(),
+      context: AgentContext = AgentContext.Default
+    ): ZIO[Any, LLMError, AgentState] =
+      ZIO.blocking {
+        ZIO.fromEither(
+          agent.run(
+            query,
+            tools,
+            inputGuardrails,
+            outputGuardrails,
+            maxSteps = maxSteps,
+            systemPromptAddition = systemPromptAddition,
+            completionOptions = completionOptions,
+            context = context
+          )
+        )
+      }
+
+    def continueConversation(
+      previousState: AgentState,
+      newUserMessage: String,
+      inputGuardrails: Seq[InputGuardrail] = Seq.empty,
+      outputGuardrails: Seq[OutputGuardrail] = Seq.empty,
+      maxSteps: Option[Int] = None,
+      context: AgentContext = AgentContext.Default
+    ): ZIO[Any, LLMError, AgentState] =
+      ZIO.blocking {
+        ZIO.fromEither(
+          agent.continueConversation(
+            previousState,
+            newUserMessage,
+            inputGuardrails,
+            outputGuardrails,
+            maxSteps,
+            context = context
+          )
+        )
+      }
+  }
+}

--- a/modules/llm4s-zio/src/main/scala/org/llm4s/zio/LLMClientZ.scala
+++ b/modules/llm4s-zio/src/main/scala/org/llm4s/zio/LLMClientZ.scala
@@ -1,0 +1,84 @@
+package org.llm4s.zio
+
+import org.llm4s.agent.Agent
+import org.llm4s.config.Llm4sConfig
+import org.llm4s.error.LLMError
+import org.llm4s.llmconnect.{ LLMClient, LLMConnect }
+import org.llm4s.llmconnect.model.{ Completion, CompletionOptions, Conversation, StreamedChunk }
+import zio.{ ZIO, ZLayer }
+import zio.stream.ZStream
+
+/**
+ * ZIO wrapper for [[LLMClient]].
+ *
+ * Blocking LLM calls are shifted to ZIO's blocking thread pool via
+ * `ZIO.blocking`, keeping the fiber executor free.
+ * `LLMError` is used directly as the error channel type — no wrapping needed.
+ */
+trait LLMClientZ {
+
+  def complete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions()
+  ): ZIO[Any, LLMError, Completion]
+
+  /** Runs the streaming call on the blocking pool, emits all chunks as a [[ZStream]]. */
+  def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions()
+  ): ZStream[Any, LLMError, StreamedChunk]
+
+  /** Creates an [[AgentZ]] backed by this client. */
+  def agent(): AgentZ
+}
+
+object LLMClientZ {
+
+  /** Wraps an already-constructed [[LLMClient]]. Does not manage its lifecycle. */
+  def apply(underlying: LLMClient): LLMClientZ = new Impl(underlying)
+
+  /**
+   * ZLayer that acquires an [[LLMClient]] from the environment (via [[Llm4sConfig]])
+   * on the blocking thread pool and finalises it on scope exit.
+   */
+  val layer: ZLayer[Any, LLMError, LLMClientZ] =
+    ZLayer.scoped {
+      ZIO
+        .blocking {
+          ZIO.fromEither {
+            for {
+              registry <- Llm4sConfig.modelRegistryService()
+              config   <- Llm4sConfig.defaultProvider()
+              client   <- LLMConnect.getClient(config)(using registry)
+            } yield client
+          }
+        }
+        .flatMap(client => ZIO.acquireRelease(ZIO.succeed(LLMClientZ(client)))(_ => ZIO.succeed(client.close())))
+    }
+
+  final private class Impl(underlying: LLMClient) extends LLMClientZ {
+
+    def complete(
+      conversation: Conversation,
+      options: CompletionOptions = CompletionOptions()
+    ): ZIO[Any, LLMError, Completion] =
+      ZIO.blocking {
+        ZIO.fromEither(underlying.complete(conversation, options))
+      }
+
+    def streamComplete(
+      conversation: Conversation,
+      options: CompletionOptions = CompletionOptions()
+    ): ZStream[Any, LLMError, StreamedChunk] = {
+      val fetchChunks: ZIO[Any, LLMError, List[StreamedChunk]] = ZIO.blocking {
+        ZIO.fromEither {
+          val buf = scala.collection.mutable.ListBuffer.empty[StreamedChunk]
+          underlying.streamComplete(conversation, options, buf.append(_)).map(_ => buf.toList)
+        }
+      }
+      ZStream.fromZIO(fetchChunks).flatMap(ZStream.fromIterable(_))
+    }
+
+    def agent(): AgentZ = AgentZ(new Agent(underlying))
+  }
+}

--- a/modules/llm4s-zio/src/test/scala/org/llm4s/zio/AgentZSpec.scala
+++ b/modules/llm4s-zio/src/test/scala/org/llm4s/zio/AgentZSpec.scala
@@ -1,0 +1,81 @@
+package org.llm4s.zio
+
+import org.llm4s.agent.{ Agent, AgentStatus }
+import org.llm4s.error.SimpleError
+import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.model.{ AssistantMessage, Completion, CompletionOptions, Conversation, StreamedChunk }
+import org.llm4s.toolapi.ToolRegistry
+import org.llm4s.types.Result
+import zio.test.*
+
+object AgentZSpec extends ZIOSpecDefault {
+
+  private def completion(text: String) = Completion(
+    id = "test-id",
+    created = 0L,
+    content = text,
+    model = "test-model",
+    message = AssistantMessage(contentOpt = Some(text))
+  )
+
+  private def successClient(text: String): LLMClient = new LLMClient {
+    def complete(c: Conversation, o: CompletionOptions): Result[Completion] =
+      Right(completion(text))
+    def streamComplete(c: Conversation, o: CompletionOptions, onChunk: StreamedChunk => Unit): Result[Completion] =
+      Right(completion(text))
+    def getContextWindow(): Int     = 4096
+    def getReserveCompletion(): Int = 256
+  }
+
+  private val failingClient: LLMClient = new LLMClient {
+    def complete(c: Conversation, o: CompletionOptions): Result[Completion] =
+      Left(SimpleError("agent-fail"))
+    def streamComplete(c: Conversation, o: CompletionOptions, onChunk: StreamedChunk => Unit): Result[Completion] =
+      Left(SimpleError("agent-fail"))
+    def getContextWindow(): Int     = 4096
+    def getReserveCompletion(): Int = 256
+  }
+
+  val spec = suite("AgentZ")(
+    test("run returns AgentState with Complete status when the agent finishes") {
+      for {
+        state <- AgentZ(new Agent(successClient("4"))).run("What is 2+2?", ToolRegistry.empty)
+      } yield assertTrue(state.status == AgentStatus.Complete)
+    },
+    test("run includes the query in the conversation history") {
+      for {
+        state <- AgentZ(new Agent(successClient("answer"))).run("my query", ToolRegistry.empty)
+      } yield {
+        val messages = state.conversation.messages.map(_.content)
+        assertTrue(messages.contains("my query"))
+      }
+    },
+    test("run propagates LLMError on failure") {
+      AgentZ(new Agent(failingClient))
+        .run("What is 2+2?", ToolRegistry.empty)
+        .flip
+        .map(err => assertTrue(err == SimpleError("agent-fail")))
+    },
+    test("continueConversation returns AgentState with Complete status") {
+      for {
+        s1 <- AgentZ(new Agent(successClient("4"))).run("What is 2+2?", ToolRegistry.empty)
+        s2 <- AgentZ(new Agent(successClient("6"))).continueConversation(s1, "And 3+3?")
+      } yield assertTrue(s2.status == AgentStatus.Complete)
+    },
+    test("continueConversation appends follow-up to conversation history") {
+      for {
+        s1 <- AgentZ(new Agent(successClient("4"))).run("First question", ToolRegistry.empty)
+        s2 <- AgentZ(new Agent(successClient("6"))).continueConversation(s1, "Second question")
+      } yield {
+        val messages = s2.conversation.messages.map(_.content)
+        assertTrue(messages.contains("Second question"))
+      }
+    },
+    test("continueConversation propagates LLMError on failure") {
+      for {
+        s1  <- AgentZ(new Agent(successClient("4"))).run("First", ToolRegistry.empty)
+        err <- AgentZ(new Agent(failingClient)).continueConversation(s1, "Follow-up").flip
+      } yield assertTrue(err == SimpleError("agent-fail"))
+    }
+  )
+}

--- a/modules/llm4s-zio/src/test/scala/org/llm4s/zio/LLMClientZSpec.scala
+++ b/modules/llm4s-zio/src/test/scala/org/llm4s/zio/LLMClientZSpec.scala
@@ -1,0 +1,80 @@
+package org.llm4s.zio
+
+import org.llm4s.error.SimpleError
+import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.model.{
+  AssistantMessage,
+  Completion,
+  CompletionOptions,
+  Conversation,
+  StreamedChunk,
+  UserMessage
+}
+import org.llm4s.types.Result
+import zio.test.*
+
+object LLMClientZSpec extends ZIOSpecDefault {
+
+  private val testCompletion = Completion(
+    id = "test-id",
+    created = 0L,
+    content = "hello",
+    model = "test-model",
+    message = AssistantMessage(Some("hello"))
+  )
+
+  private val testConversation = Conversation(Seq(UserMessage("ping")))
+
+  private def mockClient(completion: Completion, chunks: Seq[StreamedChunk] = Seq.empty): LLMClient =
+    new LLMClient {
+      def complete(c: Conversation, o: CompletionOptions): Result[Completion] = Right(completion)
+      def streamComplete(c: Conversation, o: CompletionOptions, onChunk: StreamedChunk => Unit): Result[Completion] = {
+        chunks.foreach(onChunk)
+        Right(completion)
+      }
+      def getContextWindow(): Int     = 4096
+      def getReserveCompletion(): Int = 256
+    }
+
+  private val failingClient: LLMClient = new LLMClient {
+    def complete(c: Conversation, o: CompletionOptions): Result[Completion] =
+      Left(SimpleError("boom"))
+    def streamComplete(c: Conversation, o: CompletionOptions, onChunk: StreamedChunk => Unit): Result[Completion] =
+      Left(SimpleError("boom"))
+    def getContextWindow(): Int     = 4096
+    def getReserveCompletion(): Int = 256
+  }
+
+  val spec =
+    suite("LLMClientZ")(
+      test("complete returns the completion value") {
+        for {
+          c <- LLMClientZ(mockClient(testCompletion)).complete(testConversation)
+        } yield assertTrue(c.content == "hello") && assertTrue(c.id == "test-id")
+      },
+      test("complete propagates LLMError on failure") {
+        LLMClientZ(failingClient)
+          .complete(testConversation)
+          .flip
+          .map(err => assertTrue(err == SimpleError("boom")))
+      },
+      test("streamComplete emits all chunks") {
+        val chunks = Seq(
+          StreamedChunk(id = "c1", content = Some("hi")),
+          StreamedChunk(id = "c2", content = Some(" there"))
+        )
+        for {
+          emitted <- LLMClientZ(mockClient(testCompletion, chunks))
+            .streamComplete(testConversation)
+            .runCollect
+        } yield assertTrue(emitted.length == 2) && assertTrue(emitted.head.id == "c1")
+      },
+      test("streamComplete propagates LLMError on failure") {
+        LLMClientZ(failingClient)
+          .streamComplete(testConversation)
+          .runCollect
+          .flip
+          .map(err => assertTrue(err == SimpleError("boom")))
+      }
+    )
+}

--- a/modules/samples/src/main/scala/org/llm4s/samples/catseffect/CatsEffectAgentExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/catseffect/CatsEffectAgentExample.scala
@@ -1,0 +1,51 @@
+package org.llm4s.samples.catseffect
+
+import cats.effect.{ IO, IOApp }
+import org.llm4s.agent.AgentContext
+import org.llm4s.effect.cats.LLMClientIO
+import org.llm4s.llmconnect.model.{ Conversation, UserMessage }
+import org.llm4s.toolapi.ToolRegistry
+
+/**
+ * Demonstrates cats-effect / fs2 integration with llm4s.
+ *
+ * Run with:
+ * {{{
+ * sbt "samples/runMain org.llm4s.samples.catseffect.CatsEffectAgentExample"
+ * }}}
+ *
+ * Required environment:
+ *   LLM_MODEL=openai/gpt-4o  (or any supported provider)
+ *   OPENAI_API_KEY=sk-...
+ */
+object CatsEffectAgentExample extends IOApp.Simple {
+
+  def run: IO[Unit] =
+    LLMClientIO.resource[IO].use { client =>
+      for {
+        // Direct completion — blocking call runs on the blocking pool
+        completion <- client.complete(
+                        Conversation(Seq(UserMessage("What is 2 + 2?")))
+                      )
+        _ <- IO.println(s"Completion: ${completion.content}")
+
+        // Streaming — chunks flow as fs2 Stream elements
+        _ <- IO.println("Streaming response:")
+        _ <- client
+               .streamComplete(Conversation(Seq(UserMessage("Count to 5 slowly."))))
+               .evalMap(chunk => IO.print(chunk.content.getOrElse("")))
+               .compile
+               .drain
+        _ <- IO.println("")
+
+        // Agent with tool support
+        agentIO = client.agent()
+        state <- agentIO.run(
+                   query = "What day is it today?",
+                   tools = ToolRegistry.empty,
+                   context = AgentContext.Default
+                 )
+        _ <- IO.println(s"Agent: ${state.conversation.messages.last}")
+      } yield ()
+    }
+}

--- a/modules/samples/src/main/scala/org/llm4s/samples/catseffect/CatsEffectAgentExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/catseffect/CatsEffectAgentExample.scala
@@ -25,26 +25,26 @@ object CatsEffectAgentExample extends IOApp.Simple {
       for {
         // Direct completion — blocking call runs on the blocking pool
         completion <- client.complete(
-                        Conversation(Seq(UserMessage("What is 2 + 2?")))
-                      )
+          Conversation(Seq(UserMessage("What is 2 + 2?")))
+        )
         _ <- IO.println(s"Completion: ${completion.content}")
 
         // Streaming — chunks flow as fs2 Stream elements
         _ <- IO.println("Streaming response:")
         _ <- client
-               .streamComplete(Conversation(Seq(UserMessage("Count to 5 slowly."))))
-               .evalMap(chunk => IO.print(chunk.content.getOrElse("")))
-               .compile
-               .drain
+          .streamComplete(Conversation(Seq(UserMessage("Count to 5 slowly."))))
+          .evalMap(chunk => IO.print(chunk.content.getOrElse("")))
+          .compile
+          .drain
         _ <- IO.println("")
 
         // Agent with tool support
         agentIO = client.agent()
         state <- agentIO.run(
-                   query = "What day is it today?",
-                   tools = ToolRegistry.empty,
-                   context = AgentContext.Default
-                 )
+          query = "What day is it today?",
+          tools = ToolRegistry.empty,
+          context = AgentContext.Default
+        )
         _ <- IO.println(s"Agent: ${state.conversation.messages.last}")
       } yield ()
     }

--- a/modules/samples/src/main/scala/org/llm4s/samples/zio/ZIOAgentExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/zio/ZIOAgentExample.scala
@@ -1,0 +1,46 @@
+package org.llm4s.samples.zio
+
+import org.llm4s.agent.AgentContext
+import org.llm4s.llmconnect.model.{ Conversation, UserMessage }
+import org.llm4s.toolapi.ToolRegistry
+import org.llm4s.zio.LLMClientZ
+import zio.{ ZIO, ZIOAppDefault }
+
+/**
+ * Demonstrates ZIO integration with llm4s.
+ *
+ * Run with:
+ * {{{
+ * sbt "samples/runMain org.llm4s.samples.zio.ZIOAgentExample"
+ * }}}
+ *
+ * Required environment:
+ *   LLM_MODEL=openai/gpt-4o  (or any supported provider)
+ *   OPENAI_API_KEY=sk-...
+ */
+object ZIOAgentExample extends ZIOAppDefault {
+
+  def run: ZIO[Any, Any, Any] =
+    (for {
+      client <- ZIO.service[LLMClientZ]
+
+      // Direct completion — blocking call runs on ZIO's blocking pool
+      completion <- client.complete(Conversation(Seq(UserMessage("What is 2 + 2?"))))
+      _          <- ZIO.debug(s"Completion: ${completion.content}")
+
+      // Streaming — chunks flow as ZStream elements, collected here
+      chunks <- client
+                  .streamComplete(Conversation(Seq(UserMessage("Count to 5 slowly."))))
+                  .runCollect
+      _      <- ZIO.debug(chunks.map(_.content.getOrElse("")).mkString)
+
+      // Agent with tool support
+      agentZ = client.agent()
+      state <- agentZ.run(
+                 query = "What day is it today?",
+                 tools = ToolRegistry.empty,
+                 context = AgentContext.Default
+               )
+      _ <- ZIO.debug(s"Agent: ${state.conversation.messages.last}")
+    } yield ()).provide(LLMClientZ.layer)
+}

--- a/modules/samples/src/main/scala/org/llm4s/samples/zio/ZIOAgentExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/zio/ZIOAgentExample.scala
@@ -30,17 +30,17 @@ object ZIOAgentExample extends ZIOAppDefault {
 
       // Streaming — chunks flow as ZStream elements, collected here
       chunks <- client
-                  .streamComplete(Conversation(Seq(UserMessage("Count to 5 slowly."))))
-                  .runCollect
-      _      <- ZIO.debug(chunks.map(_.content.getOrElse("")).mkString)
+        .streamComplete(Conversation(Seq(UserMessage("Count to 5 slowly."))))
+        .runCollect
+      _ <- ZIO.debug(chunks.map(_.content.getOrElse("")).mkString)
 
       // Agent with tool support
       agentZ = client.agent()
       state <- agentZ.run(
-                 query = "What day is it today?",
-                 tools = ToolRegistry.empty,
-                 context = AgentContext.Default
-               )
+        query = "What day is it today?",
+        tools = ToolRegistry.empty,
+        context = AgentContext.Default
+      )
       _ <- ZIO.debug(s"Agent: ${state.conversation.messages.last}")
     } yield ()).provide(LLMClientZ.layer)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,6 +37,14 @@ object Versions {
 
   val cask       = "0.10.2"
 
+  // cats-effect + fs2
+  val catsEffect = "3.5.7"
+  val fs2        = "3.11.0"
+  val catsEffectTestingScalatest = "1.5.0"
+
+  // ZIO
+  val zio = "2.1.16"
+
   // AWS SDK
   val awsSdk     = "2.29.51"
   val opentelemetry = "1.34.1"
@@ -82,6 +90,18 @@ object Deps {
   val vosk        = "com.alphacephei"  % "vosk"         % Versions.vosk
 
   val cask       = "com.lihaoyi" %% "cask" % Versions.cask
+
+  // cats-effect + fs2
+  val catsEffect = "org.typelevel" %% "cats-effect" % Versions.catsEffect
+  val fs2        = "co.fs2"        %% "fs2-core"    % Versions.fs2
+  val catsEffectTestingScalatest =
+    "org.typelevel" %% "cats-effect-testing-scalatest" % Versions.catsEffectTestingScalatest
+
+  // ZIO
+  val zio        = "dev.zio" %% "zio"         % Versions.zio
+  val zioStreams  = "dev.zio" %% "zio-streams" % Versions.zio
+  val zioTest    = "dev.zio" %% "zio-test"    % Versions.zio
+  val zioTestSbt = "dev.zio" %% "zio-test-sbt" % Versions.zio
 
   // AWS SDK
   val awsS3      = "software.amazon.awssdk" % "s3"  % Versions.awsSdk


### PR DESCRIPTION
## Summary

Adds two optional companion modules so functional Scala teams can use llm4s idiomatically with their effect system of choice — without any changes to the existing synchronous core API.

- **`llm4s-effect`** — cats-effect 3 / fs2 integration
- **`llm4s-zio`** — ZIO 2 / ZIO Streams integration

Both modules are purely additive: the synchronous `core` API is untouched, and teams that don't use an effect system pick up zero new transitive dependencies.

## Backward compatibility

The existing `LLMClient` / `Agent` synchronous API is **unchanged**. The new modules are optional; they wrap the core API without altering it. Users on the synchronous path see no diff.

## Changes

### `modules/llm4s-effect` (cats-effect 3 / fs2)

| Class | Role |
|---|---|
| `LLMException` | Bridges `LLMError` → `Throwable` error channel |
| `LLMClientIO[F[_]: Async]` | Wraps `LLMClient` — all blocking calls via `F.blocking` |
| `AgentIO[F[_]: Async]` | Wraps `Agent` — all blocking calls via `F.blocking` |

- `streamComplete` returns `fs2.Stream[F, StreamedChunk]`
- `LLMClientIO.resource[F]` manages lifecycle via `Resource.fromAutoCloseable`

### `modules/llm4s-zio` (ZIO 2 / ZIO Streams)

| Class | Role |
|---|---|
| `LLMClientZ` | Wraps `LLMClient` — all calls via `ZIO.blocking { ZIO.fromEither }` |
| `AgentZ` | Wraps `Agent` — same blocking approach |

- `LLMError` is the native ZIO error channel type (no wrapping needed)
- `streamComplete` returns `ZStream[Any, LLMError, StreamedChunk]`
- `LLMClientZ.layer` is a `ZLayer[Any, LLMError, LLMClientZ]` via `ZLayer.scoped + ZIO.acquireRelease`

### Samples

- `CatsEffectAgentExample` — `IOApp.Simple` end-to-end demo
- `ZIOAgentExample` — `ZIOAppDefault` end-to-end demo

### Docs

- `docs/guide/cats-effect.md`
- `docs/guide/zio.md`

## Test coverage

**24 tests, all green** under Scala 3.7.1 with `-Werror -Wunused:all`:

| Suite | Tests |
|---|---|
| `LLMClientIOSpec` | complete success/error, stream success/error |
| `LLMExceptionSpec` | wrapping, message propagation, instanceof |
| `AgentIOSpec` | run success/error, LLMError wrapping, continue success/error/history |
| `LLMClientZSpec` | complete success/error, stream success/error |
| `AgentZSpec` | run success/error, query history, continue success/error/history |

Zero regressions in the 6,743 existing `core` tests.

## Dependencies added

| Dep | Scope |
|---|---|
| `cats-effect 3.5.7` | `llm4s-effect` compile |
| `fs2-core 3.11.0` | `llm4s-effect` compile |
| `cats-effect-testing-scalatest 1.5.0` | `llm4s-effect` test |
| `zio 2.1.16` | `llm4s-zio` compile + test |
| `zio-streams 2.1.16` | `llm4s-zio` compile + test |
| `zio-test-sbt 2.1.16` | `llm4s-zio` test |

## Test plan

- [x] `sbt llm4sEffect/test` — 14 tests passed
- [x] `sbt llm4sZio/test` — 10 tests passed
- [x] `sbt core/test` — 6,743 tests passed, zero regressions
- [x] `sbt samples/compile` — sample apps compile cleanly
- [ ] End-to-end sample runs require live API keys (LLM_MODEL + provider key)

Closes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)