### PR TITLE
[DOCS] Expand metrics ScalaDoc

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/metrics/MetricsCollector.scala
+++ b/modules/core/src/main/scala/org/llm4s/metrics/MetricsCollector.scala
@@ -5,6 +5,11 @@ import scala.concurrent.duration.FiniteDuration
 /**
  * Minimal algebra for collecting metrics about LLM operations.
  *
+ * The core metrics model tracks request latency, request outcome, token usage,
+ * estimated cost, retry attempts, circuit-breaker transitions, generic errors,
+ * and image generation usage. Concrete implementations decide where these
+ * observations are stored or exported.
+ *
  * Implementations should be safe: failures must not propagate to callers.
  * All methods should catch and log errors internally without throwing.
  *
@@ -30,9 +35,14 @@ trait MetricsCollector {
   /**
    * Record an LLM request with its outcome and duration.
    *
+   * The `outcome` dimension separates successful requests from failures. Error
+   * outcomes carry a stable [[ErrorKind]] such as [[ErrorKind.RateLimit]],
+   * [[ErrorKind.Timeout]], or [[ErrorKind.ServiceError]] so metrics backends can
+   * aggregate failures without depending on exception class names.
+   *
    * @param provider Provider name (e.g., "openai", "anthropic", "ollama")
    * @param model Model name (e.g., "gpt-4o", "claude-3-5-sonnet-latest")
-   * @param outcome Success or Error with error kind
+   * @param outcome Success or Error with stable error kind
    * @param duration Request duration
    */
   def observeRequest(
@@ -44,6 +54,9 @@ trait MetricsCollector {
 
   /**
    * Record token usage.
+   *
+   * Implementations typically record input and output tokens separately so
+   * dashboards can show prompt and completion usage independently.
    *
    * @param provider Provider name
    * @param model Model name
@@ -60,6 +73,10 @@ trait MetricsCollector {
   /**
    * Record estimated cost in USD.
    *
+   * Use this after pricing metadata is available for a request or image
+   * generation operation. Implementations should treat the value as an
+   * additive counter.
+   *
    * @param provider Provider name
    * @param model Model name
    * @param costUsd Estimated cost in USD
@@ -73,6 +90,9 @@ trait MetricsCollector {
   /**
    * Record a retry attempt for reliability tracking.
    *
+   * The first retry after the original request fails should use
+   * `attemptNumber = 1`.
+   *
    * @param provider Provider name
    * @param attemptNumber Which retry attempt (1 = first retry, 2 = second, etc.)
    */
@@ -83,6 +103,9 @@ trait MetricsCollector {
 
   /**
    * Record circuit breaker state transition.
+   *
+   * Expected states are stable labels such as "open", "closed", and
+   * "half-open".
    *
    * @param provider Provider name
    * @param newState New circuit breaker state ("open", "closed", "half-open")
@@ -95,6 +118,9 @@ trait MetricsCollector {
   /**
    * Record a generic error for metrics (when full request tracking not applicable).
    *
+   * Use this for failures that occur outside a complete request timing scope,
+   * such as configuration, validation, or setup failures.
+   *
    * @param errorKind Type of error
    * @param provider Provider name
    */
@@ -106,10 +132,14 @@ trait MetricsCollector {
   /**
    * Record an image generation operation.
    *
+   * The `outcome` dimension has the same meaning as in [[observeRequest]].
+   * `imageCount` records the number of generated images only for successful
+   * operations.
+   *
    * @param provider Provider name (e.g., "openai", "stability-ai")
    * @param model Model name (e.g., "gpt-image-1", "dall-e-3")
    * @param operation Operation type: "generate" or "edit"
-   * @param outcome Success or Error with error kind
+   * @param outcome Success or Error with stable error kind
    * @param duration Request duration
    * @param imageCount Number of images generated
    */
@@ -140,10 +170,6 @@ trait MetricsCollector {
 
 object MetricsCollector {
 
-  /**
-   * No-op implementation that does nothing.
-   * Use as default when metrics are disabled.
-   */
   /**
    * Combine multiple collectors into one that fans out every call to all of them.
    *
@@ -193,6 +219,11 @@ object MetricsCollector {
     ): Unit = safeForEach(_.recordError(errorKind, provider))
   }
 
+  /**
+   * No-op implementation that does nothing.
+   *
+   * Use as the default collector when metrics are disabled.
+   */
   val noop: MetricsCollector = new MetricsCollector {
     override def observeRequest(
       provider: String,
@@ -218,6 +249,9 @@ object MetricsCollector {
 
 /**
  * Outcome of an LLM request.
+ *
+ * Use [[Outcome.Success]] when the operation completed normally and
+ * [[Outcome.Error]] when it failed with a categorized [[ErrorKind]].
  */
 sealed trait Outcome
 
@@ -243,14 +277,30 @@ object Outcome {
 sealed trait ErrorKind
 
 object ErrorKind {
-  case object RateLimit      extends ErrorKind
-  case object Timeout        extends ErrorKind
+
+  /** Provider or gateway rate limit. */
+  case object RateLimit extends ErrorKind
+
+  /** Request or operation timeout. */
+  case object Timeout extends ErrorKind
+
+  /** Missing, invalid, or unauthorized credentials. */
   case object Authentication extends ErrorKind
-  case object Network        extends ErrorKind
-  case object Validation     extends ErrorKind
-  case object ServiceError   extends ErrorKind
+
+  /** Network transport or connectivity failure. */
+  case object Network extends ErrorKind
+
+  /** Invalid request, schema, or configuration input. */
+  case object Validation extends ErrorKind
+
+  /** Provider-side service error. */
+  case object ServiceError extends ErrorKind
+
+  /** Local execution failure outside the provider API. */
   case object ExecutionError extends ErrorKind
-  case object Unknown        extends ErrorKind
+
+  /** Fallback category when no more specific kind is available. */
+  case object Unknown extends ErrorKind
 
   /**
    * Map LLMError to stable ErrorKind.

--- a/modules/core/src/main/scala/org/llm4s/metrics/PrometheusEndpoint.scala
+++ b/modules/core/src/main/scala/org/llm4s/metrics/PrometheusEndpoint.scala
@@ -11,20 +11,20 @@ import org.slf4j.LoggerFactory
  * HTTP endpoint for exposing Prometheus metrics.
  *
  * Wraps the Prometheus HTTPServer and provides lifecycle management.
- * Use this to expose metrics at /metrics for Prometheus scraping.
+ * Use this to expose metrics at `/metrics` for Prometheus scraping.
  *
- * Example:
+ * @example
  * {{{
  * val registry = new PrometheusRegistry()
- * val endpointResult = PrometheusEndpoint.start(9090, registry)
+ * val metrics = new PrometheusMetrics(registry)
  *
- * endpointResult match {
+ * PrometheusEndpoint.start(9090, registry) match {
  *   case Right(endpoint) =>
- *     println(s"Metrics at: \${endpoint.url}")
- *     // ... application runs ...
+ *     // Use `metrics` with LLM clients while Prometheus scrapes:
+ *     // http://localhost:9090/metrics
  *     endpoint.stop()
  *   case Left(error) =>
- *     println(s"Failed to start: \${error.message}")
+ *     println(s"Failed to start Prometheus endpoint: \${error.message}")
  * }
  * }}}
  *
@@ -40,11 +40,16 @@ final class PrometheusEndpoint private (
 
   /**
    * Get the metrics endpoint URL.
+   *
+   * Prometheus should scrape this URL, for example
+   * `http://localhost:9090/metrics` when the endpoint was started on port
+   * 9090.
    */
   def url: String = s"http://localhost:$port/metrics"
 
   /**
    * Stop the HTTP server.
+   *
    * Safe to call multiple times.
    */
   def stop(): Unit =
@@ -65,7 +70,9 @@ object PrometheusEndpoint {
    * Start Prometheus HTTP endpoint.
    *
    * Creates an HTTP server that exposes the metrics from the given registry
-   * at the /metrics endpoint on the specified port.
+   * at the `/metrics` endpoint on the specified port. Passing port `0` lets
+   * the operating system choose an available port; the returned endpoint's
+   * [[PrometheusEndpoint.url]] includes the actual bound port when available.
    *
    * @param port Port to listen on (default: 9090)
    * @param registry Prometheus collector registry containing metrics

--- a/modules/core/src/main/scala/org/llm4s/metrics/PrometheusMetrics.scala
+++ b/modules/core/src/main/scala/org/llm4s/metrics/PrometheusMetrics.scala
@@ -8,10 +8,22 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
 /**
- * Prometheus implementation of MetricsCollector.
+ * Prometheus implementation of [[MetricsCollector]].
  *
  * Tracks request volumes, token usage, errors, and latency across
  * different providers and models using Prometheus metrics.
+ *
+ * Registered metric names:
+ * - `llm4s_requests_total`
+ * - `llm4s_tokens_total`
+ * - `llm4s_cost_usd_total`
+ * - `llm4s_errors_total`
+ * - `llm4s_request_duration_seconds`
+ * - `llm4s_image_generations_total`
+ * - `llm4s_images_generated_total`
+ * - `llm4s_image_generation_duration_seconds`
+ * - `llm4s_image_generation_cost_usd_total`
+ * - `llm4s_image_generation_errors_total`
  *
  * All operations are wrapped in try-catch to ensure metric failures
  * never propagate to callers. This implementation is thread-safe.
@@ -128,6 +140,10 @@ final class PrometheusMetrics(
   /**
    * Record an LLM request with its outcome and duration.
    *
+   * Updates `llm4s_requests_total` and
+   * `llm4s_request_duration_seconds`. Error outcomes also increment
+   * `llm4s_errors_total`.
+   *
    * Safe: catches and logs any Prometheus errors without propagating.
    */
   override def observeRequest(
@@ -157,6 +173,8 @@ final class PrometheusMetrics(
   /**
    * Record token usage.
    *
+   * Updates `llm4s_tokens_total` with `type` labels of `input` and `output`.
+   *
    * Safe: catches and logs any Prometheus errors without propagating.
    */
   override def addTokens(
@@ -175,6 +193,8 @@ final class PrometheusMetrics(
   /**
    * Record estimated cost in USD.
    *
+   * Updates `llm4s_cost_usd_total`.
+   *
    * Safe: catches and logs any Prometheus errors without propagating.
    */
   override def recordCost(
@@ -190,6 +210,11 @@ final class PrometheusMetrics(
 
   /**
    * Record an image generation operation.
+   *
+   * Updates `llm4s_image_generations_total` and
+   * `llm4s_image_generation_duration_seconds`. Successful operations with
+   * images also update `llm4s_images_generated_total`; error outcomes update
+   * `llm4s_errors_total` and `llm4s_image_generation_errors_total`.
    *
    * Safe: catches and logs any Prometheus errors without propagating.
    */
@@ -227,6 +252,8 @@ final class PrometheusMetrics(
 
   /**
    * Record estimated image generation cost in USD.
+   *
+   * Updates `llm4s_image_generation_cost_usd_total`.
    *
    * Safe: catches and logs any Prometheus errors without propagating.
    */


### PR DESCRIPTION
## What does this PR do?
Adds more complete ScalaDoc for the metrics APIs requested in #949.

This documents the `MetricsCollector` metrics model and outcome semantics, lists the Prometheus metric names registered by `PrometheusMetrics`, describes which metrics each public method updates, and expands the `PrometheusEndpoint` example and scrape URL guidance.

## Related issue
Fixes #949

## How was this tested?
- `sbt scalafmtAll`
- `sbt doc`
- `sbt core/test`

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [ ] `sbt test` — tests pass on Scala 3
- [ ] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"