### PR TITLE
feat(kotlin-api): Kotlin coroutine integration module (fixes #937)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,11 +142,52 @@ jobs:
             **/target/scala-3.7.1/test-reports/
           retention-days: 5
 
+  # Kotlin coroutine API — separate Gradle build, depends on java-api published to local Maven
+  kotlin-api:
+    name: Kotlin API
+    needs: quick-checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+
+      - name: Publish core and java-api to local Maven
+        # Pin to 0.1.0-SNAPSHOT so the Gradle build.gradle.kts can reference a
+        # stable coordinate without chasing dynver-generated snapshot versions.
+        run: sbt 'set ThisBuild / version := "0.1.0-SNAPSHOT"' "core/publishM2" "javaApi/publishM2"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.11.1'
+
+      - name: Build and test Kotlin API with coverage check
+        working-directory: modules/kotlin-api
+        run: gradle check
+
+      - name: Upload Kotlin coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kotlin-coverage-report
+          path: modules/kotlin-api/build/reports/jacoco/
+          retention-days: 14
+
   # All tests must pass
   all-tests-pass:
     name: All Tests Pass
     if: always()
-    needs: [test, coverage]
+    needs: [test, coverage, kotlin-api]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -160,6 +201,10 @@ jobs:
           fi
           if [[ "${{ needs.coverage.result }}" != "success" ]]; then
             echo "Coverage job failed"
+            exit 1
+          fi
+          if [[ "${{ needs.kotlin-api.result }}" != "success" ]]; then
+            echo "Kotlin API tests failed"
             exit 1
           fi
           echo "All tests passed!"

--- a/build.sbt
+++ b/build.sbt
@@ -129,6 +129,7 @@ lazy val commonSettings = Seq(
 lazy val llm4s = (project in file("."))
   .aggregate(
     core,
+    javaApi,
     samples,
     workspaceShared,
     workspaceRunner,
@@ -310,6 +311,16 @@ lazy val it = (project in file("modules/it"))
     commonSettings,
     publish / skip := true,
     Test / fork := true,
+    libraryDependencies ++= Seq(
+      Deps.scalatest % Test
+    )
+  )
+
+lazy val javaApi = (project in file("modules/java-api"))
+  .dependsOn(core)
+  .settings(
+    name           := "java-api",
+    commonSettings,
     libraryDependencies ++= Seq(
       Deps.scalatest % Test
     )

--- a/modules/java-api/src/main/scala/org/llm4s/java/ConversationBuilder.scala
+++ b/modules/java-api/src/main/scala/org/llm4s/java/ConversationBuilder.scala
@@ -1,0 +1,34 @@
+package org.llm4s.java
+
+import org.llm4s.llmconnect.model.{ AssistantMessage, Conversation, Message, SystemMessage, UserMessage }
+
+/**
+ * Builder for constructing a [[Conversation]] without using Scala case-class
+ * syntax or sequence literals.
+ *
+ * {{{
+ * Conversation conv = ConversationBuilder.create()
+ *     .system("You are a helpful assistant.")
+ *     .user("What is the capital of France?")
+ *     .build();
+ * }}}
+ */
+final class ConversationBuilder private (private val messages: Seq[Message]) {
+
+  def system(content: String): ConversationBuilder =
+    new ConversationBuilder(messages :+ SystemMessage(content))
+
+  def user(content: String): ConversationBuilder =
+    new ConversationBuilder(messages :+ UserMessage(content))
+
+  def assistant(content: String): ConversationBuilder =
+    new ConversationBuilder(messages :+ AssistantMessage(content))
+
+  def build(): Conversation = Conversation(messages)
+}
+
+object ConversationBuilder {
+
+  /** Returns a new empty builder. */
+  def create(): ConversationBuilder = new ConversationBuilder(Seq.empty)
+}

--- a/modules/java-api/src/main/scala/org/llm4s/java/JAgent.scala
+++ b/modules/java-api/src/main/scala/org/llm4s/java/JAgent.scala
@@ -1,0 +1,31 @@
+package org.llm4s.java
+
+import org.llm4s.agent.{ Agent, AgentState }
+import org.llm4s.toolapi.ToolRegistry
+
+/**
+ * Java-friendly wrapper around [[Agent]].
+ *
+ * Exposes a simplified `run(query)` entry point that returns
+ * [[LlmResult]]`[`[[AgentState]]`]` so Java callers do not need to deal with
+ * Scala's `Either` or `Result` types directly.
+ *
+ * Obtain instances via [[Llm4s.createAgent]].
+ *
+ * {{{
+ * JAgent agent = Llm4s.createAgent(client);
+ * LlmResult<AgentState> result = agent.run("Summarise the news today");
+ * result.ifSuccess(state -> System.out.println(state.conversation()))
+ *       .ifFailure(e -> System.err.println(e.getMessage()));
+ * }}}
+ */
+final class JAgent private[java] (private val underlying: Agent) {
+
+  /** Runs the agent with an empty tool registry. */
+  def run(query: String): LlmResult[AgentState] =
+    LlmResult.from(underlying.run(query, ToolRegistry.empty))
+
+  /** Runs the agent with an explicit [[ToolRegistry]]. */
+  def run(query: String, tools: ToolRegistry): LlmResult[AgentState] =
+    LlmResult.from(underlying.run(query, tools))
+}

--- a/modules/java-api/src/main/scala/org/llm4s/java/JLlmClient.scala
+++ b/modules/java-api/src/main/scala/org/llm4s/java/JLlmClient.scala
@@ -1,0 +1,41 @@
+package org.llm4s.java
+
+import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.model.{ CompletionOptions, Conversation, UserMessage }
+
+/**
+ * Java-friendly wrapper around [[LLMClient]].
+ *
+ * The underlying Scala client returns `Result[Completion]`; this wrapper
+ * unwraps the content string and surfaces it as [[LlmResult]] so Java
+ * callers never import any Scala types.
+ *
+ * Obtain instances via [[Llm4s.createDefaultClient]] or
+ * [[Llm4s.createClient]].
+ *
+ * {{{
+ * LlmResult<String> r = client.complete("What is 2+2?");
+ * r.ifSuccess(System.out::println).ifFailure(e -> System.err.println(e.getMessage()));
+ * }}}
+ */
+final class JLlmClient private[java] (private[java] val underlying: LLMClient) extends AutoCloseable {
+
+  /** Sends a single user query and returns the assistant's text response. */
+  def complete(query: String): LlmResult[String] = {
+    val conversation = Conversation(Seq(UserMessage(query)))
+    LlmResult.from(underlying.complete(conversation).map(_.content))
+  }
+
+  /** Sends a pre-built conversation and returns the assistant's text response. */
+  def complete(conversation: Conversation): LlmResult[String] =
+    LlmResult.from(underlying.complete(conversation).map(_.content))
+
+  /**
+   * Full access: send a conversation with explicit [[CompletionOptions]],
+   * returning the raw text content.
+   */
+  def complete(conversation: Conversation, options: CompletionOptions): LlmResult[String] =
+    LlmResult.from(underlying.complete(conversation, options).map(_.content))
+
+  override def close(): Unit = underlying.close()
+}

--- a/modules/java-api/src/main/scala/org/llm4s/java/Llm4s.scala
+++ b/modules/java-api/src/main/scala/org/llm4s/java/Llm4s.scala
@@ -1,0 +1,58 @@
+package org.llm4s.java
+
+import org.llm4s.agent.Agent
+import org.llm4s.config.Llm4sConfig
+import org.llm4s.llmconnect.LLMConnect
+import org.llm4s.llmconnect.config.ProviderConfig
+
+/**
+ * Entry-point factory for Java callers.
+ *
+ * All methods return [[LlmResult]] so Java code never imports Scala `Either`
+ * or deals with implicit/given parameters directly. The Scala-level
+ * `ModelRegistryService` given is resolved internally and passed explicitly.
+ *
+ * === Quick-start (Java) ===
+ * {{{
+ * LlmResult<JLlmClient> r = Llm4s.createDefaultClient();
+ * if (r.isSuccess()) {
+ *     JLlmClient client = r.get();
+ *     client.complete("Hello").ifSuccess(System.out::println);
+ * }
+ * }}}
+ */
+object Llm4s {
+
+  /**
+   * Creates a [[JLlmClient]] from the default provider configured via
+   * environment variables (e.g. `LLM_MODEL`, `OPENAI_API_KEY`).
+   */
+  def createDefaultClient(): LlmResult[JLlmClient] = {
+    val result = for {
+      registry <- Llm4sConfig.modelRegistryService()
+      config   <- Llm4sConfig.defaultProvider()
+      client   <- LLMConnect.getClient(config)(using registry)
+    } yield new JLlmClient(client)
+    LlmResult.from(result)
+  }
+
+  /**
+   * Creates a [[JLlmClient]] from an explicit [[ProviderConfig]].  Useful
+   * when the caller constructs the config programmatically rather than relying
+   * on environment variables.
+   */
+  def createClient(config: ProviderConfig): LlmResult[JLlmClient] = {
+    val result = for {
+      registry <- Llm4sConfig.modelRegistryService()
+      client   <- LLMConnect.getClient(config)(using registry)
+    } yield new JLlmClient(client)
+    LlmResult.from(result)
+  }
+
+  /**
+   * Wraps a [[JLlmClient]] in a [[JAgent]] ready to accept natural-language
+   * queries and call tools.
+   */
+  def createAgent(client: JLlmClient): JAgent =
+    new JAgent(new Agent(client.underlying))
+}

--- a/modules/java-api/src/main/scala/org/llm4s/java/LlmException.scala
+++ b/modules/java-api/src/main/scala/org/llm4s/java/LlmException.scala
@@ -1,0 +1,9 @@
+package org.llm4s.java
+
+import org.llm4s.error.LLMError
+
+/**
+ * A checked-free runtime exception wrapping an [[LLMError]], thrown only when
+ * Java callers dereference a failed [[LlmResult]] via [[LlmResult#get]].
+ */
+final class LlmException(val error: LLMError) extends RuntimeException(error.message)

--- a/modules/java-api/src/main/scala/org/llm4s/java/LlmResult.scala
+++ b/modules/java-api/src/main/scala/org/llm4s/java/LlmResult.scala
@@ -1,0 +1,86 @@
+package org.llm4s.java
+
+import org.llm4s.error.LLMError
+import org.llm4s.types.Result
+
+import java.util.Optional
+import java.util.concurrent.CompletableFuture
+import java.util.function.{ Consumer, Function => JFunction }
+
+/**
+ * Java-friendly wrapper for [[org.llm4s.types.Result]], which is an
+ * `Either[LLMError, A]`.
+ *
+ * Rather than requiring Java callers to deal with Scala's `Either`, `Option`,
+ * or `Left`/`Right`, this class surfaces a familiar API modelled after
+ * `java.util.Optional` and `CompletableFuture`.
+ *
+ * {{{
+ * LlmResult<String> result = client.complete("What is 2+2?");
+ * result.ifSuccess(System.out::println)
+ *       .ifFailure(e -> System.err.println(e.getMessage()));
+ * }}}
+ */
+final class LlmResult[A] private (private val underlying: Result[A]) {
+
+  def isSuccess: Boolean = underlying.isRight
+  def isFailure: Boolean = underlying.isLeft
+
+  /** Returns the value on success, or throws [[LlmException]] on failure. */
+  def get(): A = underlying match {
+    case Right(v) => v
+    case Left(e)  => throw new LlmException(e)
+  }
+
+  /** Returns the value on success, or `null` on failure. */
+  def getOrNull(): A = underlying.getOrElse(null.asInstanceOf[A])
+
+  /** Returns the [[LlmException]] on failure, or `null` on success. */
+  def getError(): LlmException = underlying match {
+    case Left(e)  => new LlmException(e)
+    case Right(_) => null
+  }
+
+  /**
+   * Invokes `action` with the value if this result is a success. Returns
+   * `this` to allow chaining with [[ifFailure]].
+   */
+  def ifSuccess(action: Consumer[A]): LlmResult[A] = {
+    underlying.foreach(action.accept)
+    this
+  }
+
+  /**
+   * Invokes `action` with the exception if this result is a failure. Returns
+   * `this` to allow chaining with [[ifSuccess]].
+   */
+  def ifFailure(action: Consumer[LlmException]): LlmResult[A] = {
+    underlying.left.foreach(e => action.accept(new LlmException(e)))
+    this
+  }
+
+  /** Transforms the success value; failures pass through unchanged. */
+  def map[B](f: JFunction[A, B]): LlmResult[B] =
+    new LlmResult(underlying.map(a => f.apply(a)))
+
+  /** Returns `Optional.of(value)` on success, `Optional.empty()` on failure. */
+  def toOptional: Optional[A] =
+    underlying.fold(_ => Optional.empty[A](), v => Optional.of(v))
+
+  /** Returns an already-completed `CompletableFuture` wrapping the result. */
+  def toCompletableFuture: CompletableFuture[A] = {
+    val cf = new CompletableFuture[A]()
+    underlying match {
+      case Right(v) => cf.complete(v)
+      case Left(e)  => cf.completeExceptionally(new LlmException(e))
+    }
+    cf
+  }
+}
+
+object LlmResult {
+  def success[A](value: A): LlmResult[A]        = new LlmResult(Right(value))
+  def failure[A](error: LLMError): LlmResult[A] = new LlmResult(Left(error))
+
+  private[java] def from[A](result: Result[A]): LlmResult[A] = new LlmResult(result)
+}

--- a/modules/java-api/src/test/scala/org/llm4s/java/ConversationBuilderSpec.scala
+++ b/modules/java-api/src/test/scala/org/llm4s/java/ConversationBuilderSpec.scala
@@ -1,0 +1,56 @@
+package org.llm4s.java
+
+import org.llm4s.llmconnect.model.{ AssistantMessage, SystemMessage, UserMessage }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ConversationBuilderSpec extends AnyFlatSpec with Matchers {
+
+  "ConversationBuilder.create()" should "produce an empty conversation" in {
+    ConversationBuilder.create().build().messages shouldBe empty
+  }
+
+  "system()" should "add a SystemMessage" in {
+    val conv = ConversationBuilder.create().system("You are helpful.").build()
+    conv.messages should have size 1
+    conv.messages.head shouldBe a[SystemMessage]
+    conv.messages.head.content shouldBe "You are helpful."
+  }
+
+  "user()" should "add a UserMessage" in {
+    val conv = ConversationBuilder.create().user("Hello").build()
+    conv.messages.head shouldBe a[UserMessage]
+    conv.messages.head.content shouldBe "Hello"
+  }
+
+  "assistant()" should "add an AssistantMessage" in {
+    val conv = ConversationBuilder.create().assistant("Hi there").build()
+    conv.messages.head shouldBe a[AssistantMessage]
+    conv.messages.head.content shouldBe "Hi there"
+  }
+
+  "chained calls" should "preserve insertion order" in {
+    val conv = ConversationBuilder
+      .create()
+      .system("Be concise.")
+      .user("What is Scala?")
+      .assistant("A JVM language.")
+      .user("And Kotlin?")
+      .build()
+
+    conv.messages should have size 4
+    conv.messages(0) shouldBe a[SystemMessage]
+    conv.messages(1) shouldBe a[UserMessage]
+    conv.messages(2) shouldBe a[AssistantMessage]
+    conv.messages(3) shouldBe a[UserMessage]
+  }
+
+  "build()" should "return independent snapshots" in {
+    val builder = ConversationBuilder.create().user("First")
+    val conv1   = builder.build()
+    val conv2   = builder.user("Second").build()
+
+    conv1.messages should have size 1
+    conv2.messages should have size 2
+  }
+}

--- a/modules/java-api/src/test/scala/org/llm4s/java/JAgentSpec.scala
+++ b/modules/java-api/src/test/scala/org/llm4s/java/JAgentSpec.scala
@@ -1,0 +1,86 @@
+package org.llm4s.java
+
+import org.llm4s.agent.AgentStatus
+import org.llm4s.error.{ APIError, LLMError }
+import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.model._
+import org.llm4s.toolapi.ToolRegistry
+import org.llm4s.types.Result
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class JAgentSpec extends AnyFlatSpec with Matchers {
+
+  private def completingClient(answer: String): LLMClient = new LLMClient {
+    override def complete(
+      conversation: Conversation,
+      options: CompletionOptions
+    ): Result[Completion] =
+      Right(
+        Completion(
+          id = "test-id",
+          created = 0L,
+          content = answer,
+          model = "test-model",
+          message = AssistantMessage(answer),
+          toolCalls = List.empty
+        )
+      )
+    override def streamComplete(
+      conversation: Conversation,
+      options: CompletionOptions,
+      onChunk: StreamedChunk => Unit
+    ): Result[Completion] = complete(conversation, options)
+    override def getContextWindow(): Int     = 4096
+    override def getReserveCompletion(): Int = 512
+  }
+
+  private def failingClient(error: LLMError): LLMClient = new LLMClient {
+    override def complete(conversation: Conversation, options: CompletionOptions): Result[Completion] =
+      Left(error)
+    override def streamComplete(
+      conversation: Conversation,
+      options: CompletionOptions,
+      onChunk: StreamedChunk => Unit
+    ): Result[Completion] = Left(error)
+    override def getContextWindow(): Int     = 4096
+    override def getReserveCompletion(): Int = 512
+  }
+
+  "run(String)" should "return a successful AgentState when the LLM completes normally" in {
+    val agent  = Llm4s.createAgent(new JLlmClient(completingClient("42")))
+    val result = agent.run("What is 6*7?")
+    result.isSuccess shouldBe true
+    val state = result.get()
+    state.status shouldBe AgentStatus.Complete
+  }
+
+  it should "return the LLM answer in the final conversation" in {
+    val agent  = Llm4s.createAgent(new JLlmClient(completingClient("Paris")))
+    val result = agent.run("Capital of France?")
+    result.isSuccess shouldBe true
+    val lastMessage = result.get().conversation.messages.last
+    lastMessage.content shouldBe "Paris"
+  }
+
+  it should "return a failure result when the underlying LLM call fails" in {
+    val error  = APIError("test-provider", "timeout")
+    val agent  = Llm4s.createAgent(new JLlmClient(failingClient(error)))
+    val result = agent.run("hello")
+    result.isFailure shouldBe true
+  }
+
+  "run(String, ToolRegistry)" should "succeed with an empty tool registry" in {
+    val agent  = Llm4s.createAgent(new JLlmClient(completingClient("done")))
+    val result = agent.run("query", ToolRegistry.empty)
+    result.isSuccess shouldBe true
+  }
+
+  it should "return failure when the LLM fails, even with tools provided" in {
+    val error  = APIError("test-provider", "server error")
+    val agent  = Llm4s.createAgent(new JLlmClient(failingClient(error)))
+    val result = agent.run("query", ToolRegistry.empty)
+    result.isFailure shouldBe true
+    result.getError().error shouldBe error
+  }
+}

--- a/modules/java-api/src/test/scala/org/llm4s/java/JLlmClientSpec.scala
+++ b/modules/java-api/src/test/scala/org/llm4s/java/JLlmClientSpec.scala
@@ -1,0 +1,113 @@
+package org.llm4s.java
+
+import org.llm4s.error.{ APIError, LLMError }
+import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.model._
+import org.llm4s.types.Result
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class JLlmClientSpec extends AnyFlatSpec with Matchers {
+
+  private def successClient(content: String): LLMClient = new LLMClient {
+    override def complete(conversation: Conversation, options: CompletionOptions): Result[Completion] =
+      Right(Completion("id", 0L, content, "test-model", AssistantMessage(content)))
+    override def streamComplete(
+      conversation: Conversation,
+      options: CompletionOptions,
+      onChunk: StreamedChunk => Unit
+    ): Result[Completion] = complete(conversation, options)
+    override def getContextWindow(): Int     = 4096
+    override def getReserveCompletion(): Int = 512
+  }
+
+  private def errorClient(error: LLMError): LLMClient = new LLMClient {
+    override def complete(conversation: Conversation, options: CompletionOptions): Result[Completion] =
+      Left(error)
+    override def streamComplete(
+      conversation: Conversation,
+      options: CompletionOptions,
+      onChunk: StreamedChunk => Unit
+    ): Result[Completion] = Left(error)
+    override def getContextWindow(): Int     = 4096
+    override def getReserveCompletion(): Int = 512
+  }
+
+  private val apiError: LLMError = APIError("test-provider", "service unavailable")
+
+  "complete(String)" should "return the assistant text on success" in {
+    val client = new JLlmClient(successClient("4"))
+    val result = client.complete("What is 2+2?")
+    result.isSuccess shouldBe true
+    result.get() shouldBe "4"
+  }
+
+  it should "return a failure result when the underlying client fails" in {
+    val client = new JLlmClient(errorClient(apiError))
+    val result = client.complete("hello")
+    result.isFailure shouldBe true
+    result.getError().error shouldBe apiError
+  }
+
+  "complete(Conversation)" should "return the assistant text on success" in {
+    val conv   = ConversationBuilder.create().user("ping").build()
+    val client = new JLlmClient(successClient("pong"))
+    val result = client.complete(conv)
+    result.isSuccess shouldBe true
+    result.get() shouldBe "pong"
+  }
+
+  it should "return a failure result when the underlying client fails" in {
+    val conv   = ConversationBuilder.create().user("ping").build()
+    val client = new JLlmClient(errorClient(apiError))
+    val result = client.complete(conv)
+    result.isFailure shouldBe true
+  }
+
+  "complete(Conversation, CompletionOptions)" should "pass options to the underlying client" in {
+    var capturedOptions: Option[CompletionOptions] = None
+    val capturingClient = new LLMClient {
+      override def complete(
+        conversation: Conversation,
+        options: CompletionOptions
+      ): Result[Completion] = {
+        capturedOptions = Some(options)
+        Right(Completion("id", 0L, "ok", "test-model", AssistantMessage("ok")))
+      }
+      override def streamComplete(
+        conversation: Conversation,
+        options: CompletionOptions,
+        onChunk: StreamedChunk => Unit
+      ): Result[Completion] = complete(conversation, options)
+      override def getContextWindow(): Int     = 4096
+      override def getReserveCompletion(): Int = 512
+    }
+
+    val options = CompletionOptions(temperature = 0.5)
+    val conv    = ConversationBuilder.create().user("test").build()
+    val client  = new JLlmClient(capturingClient)
+    client.complete(conv, options)
+
+    capturedOptions shouldBe Some(options)
+  }
+
+  "close()" should "delegate to the underlying client" in {
+    var closed = false
+    val trackingClient = new LLMClient {
+      override def complete(conversation: Conversation, options: CompletionOptions): Result[Completion] =
+        Right(Completion("id", 0L, "", "m", AssistantMessage("")))
+      override def streamComplete(
+        conversation: Conversation,
+        options: CompletionOptions,
+        onChunk: StreamedChunk => Unit
+      ): Result[Completion] = complete(conversation, options)
+      override def getContextWindow(): Int     = 4096
+      override def getReserveCompletion(): Int = 512
+      override def close(): Unit               = closed = true
+    }
+
+    val client = new JLlmClient(trackingClient)
+    client.close()
+    closed shouldBe true
+  }
+}

--- a/modules/java-api/src/test/scala/org/llm4s/java/Llm4sSpec.scala
+++ b/modules/java-api/src/test/scala/org/llm4s/java/Llm4sSpec.scala
@@ -1,0 +1,61 @@
+package org.llm4s.java
+
+import org.llm4s.llmconnect.LLMClient
+import org.llm4s.llmconnect.model._
+import org.llm4s.types.Result
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class Llm4sSpec extends AnyFlatSpec with Matchers {
+
+  private val stubClient: LLMClient = new LLMClient {
+    override def complete(conversation: Conversation, options: CompletionOptions): Result[Completion] =
+      Right(Completion("id", 0L, "ok", "test-model", AssistantMessage("ok")))
+    override def streamComplete(
+      conversation: Conversation,
+      options: CompletionOptions,
+      onChunk: StreamedChunk => Unit
+    ): Result[Completion] = complete(conversation, options)
+    override def getContextWindow(): Int     = 4096
+    override def getReserveCompletion(): Int = 512
+  }
+
+  "createAgent" should "return a JAgent wrapping the given client" in {
+    val jClient = new JLlmClient(stubClient)
+    val agent   = Llm4s.createAgent(jClient)
+    agent shouldBe a[JAgent]
+  }
+
+  it should "produce an agent that can run a query" in {
+    val jClient = new JLlmClient(stubClient)
+    val agent   = Llm4s.createAgent(jClient)
+    val result  = agent.run("hello")
+    result.isSuccess shouldBe true
+  }
+
+  "createDefaultClient" should "return a failure result when no LLM provider is configured" in {
+    // No LLM_MODEL or API keys in the test environment, so config loading fails.
+    // The key assertion is that a failed config surfaces as LlmResult.isFailure
+    // (not a thrown exception), keeping the Java API exception-free.
+    val result = Llm4s.createDefaultClient()
+    result shouldBe a[LlmResult[?]]
+    // We cannot assert isSuccess without real API credentials, but we can assert
+    // that the call itself does not throw regardless of config state.
+  }
+
+  "createClient" should "return a failure result without throwing when given any ProviderConfig" in {
+    import org.llm4s.llmconnect.config.OpenAIConfig
+
+    val config = OpenAIConfig(
+      apiKey = "sk-test-key",
+      model = "gpt-4o",
+      organization = None,
+      baseUrl = "https://api.openai.com/v1",
+      contextWindow = 128000,
+      reserveCompletion = 4096
+    )
+    val result = Llm4s.createClient(config)
+    // Result is always an LlmResult — never throws
+    result shouldBe a[LlmResult[?]]
+  }
+}

--- a/modules/java-api/src/test/scala/org/llm4s/java/LlmExceptionSpec.scala
+++ b/modules/java-api/src/test/scala/org/llm4s/java/LlmExceptionSpec.scala
@@ -1,0 +1,32 @@
+package org.llm4s.java
+
+import org.llm4s.error.{ LLMError, ValidationError }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LlmExceptionSpec extends AnyFlatSpec with Matchers {
+
+  private val error: LLMError = ValidationError("something went wrong", "field")
+
+  "LlmException" should "expose the underlying LLMError" in {
+    val ex = new LlmException(error)
+    ex.error shouldBe error
+  }
+
+  it should "use the LLMError message as the exception message" in {
+    val ex = new LlmException(error)
+    ex.getMessage shouldBe error.message
+  }
+
+  it should "be a RuntimeException" in {
+    val ex = new LlmException(error)
+    ex shouldBe a[RuntimeException]
+  }
+
+  it should "be throwable and catchable" in {
+    val caught = intercept[LlmException] {
+      throw new LlmException(error)
+    }
+    caught.error shouldBe error
+  }
+}

--- a/modules/java-api/src/test/scala/org/llm4s/java/LlmResultSpec.scala
+++ b/modules/java-api/src/test/scala/org/llm4s/java/LlmResultSpec.scala
@@ -1,0 +1,111 @@
+package org.llm4s.java
+
+import org.llm4s.error.{ LLMError, ValidationError }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.Optional
+
+class LlmResultSpec extends AnyFlatSpec with Matchers {
+
+  private val error: LLMError = ValidationError("test error", "field")
+
+  "LlmResult.success" should "report isSuccess" in {
+    LlmResult.success("hello").isSuccess shouldBe true
+    LlmResult.success("hello").isFailure shouldBe false
+  }
+
+  "LlmResult.failure" should "report isFailure" in {
+    LlmResult.failure[String](error).isFailure shouldBe true
+    LlmResult.failure[String](error).isSuccess shouldBe false
+  }
+
+  "get()" should "return value on success" in {
+    LlmResult.success(42).get() shouldBe 42
+  }
+
+  it should "throw LlmException on failure" in {
+    val ex = intercept[LlmException] {
+      LlmResult.failure[Int](error).get()
+    }
+    ex.error shouldBe error
+  }
+
+  "getOrNull()" should "return null on failure" in {
+    LlmResult.failure[String](error).getOrNull() shouldBe null
+  }
+
+  "getError()" should "return exception on failure" in {
+    val ex = LlmResult.failure[String](error).getError()
+    ex.error shouldBe error
+  }
+
+  it should "return null on success" in {
+    LlmResult.success("ok").getError() shouldBe null
+  }
+
+  "ifSuccess" should "invoke action with value" in {
+    var seen: Option[String] = None
+    LlmResult.success("hi").ifSuccess(v => seen = Some(v))
+    seen shouldBe Some("hi")
+  }
+
+  it should "not invoke action on failure" in {
+    var called = false
+    LlmResult.failure[String](error).ifSuccess(_ => called = true)
+    called shouldBe false
+  }
+
+  "ifFailure" should "invoke action with exception" in {
+    var seen: Option[LlmException] = None
+    LlmResult.failure[String](error).ifFailure(e => seen = Some(e))
+    seen.isDefined shouldBe true
+    seen.get.error shouldBe error
+  }
+
+  it should "not invoke action on success" in {
+    var called = false
+    LlmResult.success("ok").ifFailure(_ => called = true)
+    called shouldBe false
+  }
+
+  "map" should "transform value on success" in {
+    LlmResult.success(3).map(n => n * 2).get() shouldBe 6
+  }
+
+  it should "pass failure through unchanged" in {
+    LlmResult.failure[Int](error).map(n => n * 2).isFailure shouldBe true
+  }
+
+  "toOptional" should "return Optional.of on success" in {
+    LlmResult.success("value").toOptional shouldBe Optional.of("value")
+  }
+
+  it should "return Optional.empty on failure" in {
+    LlmResult.failure[String](error).toOptional shouldBe Optional.empty()
+  }
+
+  "toCompletableFuture" should "complete normally on success" in {
+    val cf = LlmResult.success("done").toCompletableFuture
+    cf.isDone shouldBe true
+    cf.get() shouldBe "done"
+  }
+
+  it should "complete exceptionally on failure" in {
+    val cf = LlmResult.failure[String](error).toCompletableFuture
+    cf.isCompletedExceptionally shouldBe true
+  }
+
+  "chaining ifSuccess and ifFailure" should "only trigger the matching branch" in {
+    var successCalled = false
+    var failureCalled = false
+
+    LlmResult
+      .success("ok")
+      .ifSuccess(_ => successCalled = true)
+      .ifFailure(_ => failureCalled = true)
+
+    successCalled shouldBe true
+    failureCalled shouldBe false
+  }
+}

--- a/modules/kotlin-api/.gitignore
+++ b/modules/kotlin-api/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+.kotlin/

--- a/modules/kotlin-api/build.gradle.kts
+++ b/modules/kotlin-api/build.gradle.kts
@@ -1,0 +1,66 @@
+plugins {
+    kotlin("jvm") version "2.0.21"
+    jacoco
+}
+
+group = "org.llm4s"
+version = "0.1.0-SNAPSHOT"
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+// Pin JVM target to 17 so the build is compatible with JDK 17+ regardless of the
+// installed JDK version (Kotlin 2.x doesn't yet support JDK 25+ as a target).
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(17)
+}
+
+dependencies {
+    implementation("org.llm4s:java-api_3:0.1.0-SNAPSHOT")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+    // mockk 1.13.x uses ByteBuddy self-attachment (no separate -javaagent needed).
+    // mockk-agent-jvm must be on the test classpath so the instrumentation classes are available.
+    testImplementation("io.mockk:mockk:1.13.16")
+    testImplementation("io.mockk:mockk-agent-jvm:1.13.16")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    // Enable self-attachment for ByteBuddy (needed on Java 9+ for inline mocking of final classes).
+    jvmArgs("-Djdk.attach.allowAttachSelf=true")
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "1.00".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.check {
+    dependsOn(tasks.jacocoTestCoverageVerification)
+}

--- a/modules/kotlin-api/settings.gradle.kts
+++ b/modules/kotlin-api/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "llm4s-kotlin"

--- a/modules/kotlin-api/src/main/kotlin/org/llm4s/kotlin/AgentKt.kt
+++ b/modules/kotlin-api/src/main/kotlin/org/llm4s/kotlin/AgentKt.kt
@@ -1,0 +1,36 @@
+package org.llm4s.kotlin
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.llm4s.agent.AgentState
+import org.llm4s.java.JAgent
+
+/**
+ * Kotlin coroutine wrapper around [JAgent].
+ *
+ * Dispatches the blocking agent run on [Dispatchers.IO] and converts
+ * Scala [org.llm4s.java.LlmResult] errors into [LLMException].
+ *
+ * Obtain instances via [Llm4s.createAgent].
+ *
+ * ```kotlin
+ * val agent = Llm4s.createAgent(client)
+ * val state = agent.run("Summarise today's news")
+ * ```
+ */
+class AgentKt internal constructor(private val underlying: JAgent) {
+
+    /**
+     * Suspends until the agent completes the given [query] and returns the
+     * resulting [AgentState]. Throws [LLMException] on failure.
+     */
+    suspend fun run(query: String): AgentState = withContext(Dispatchers.IO) {
+        val result = underlying.run(query)
+        if (result.isSuccess) {
+            result.get()
+        } else {
+            val err = result.getError()
+            throw LLMException(err.message ?: "Agent run failed", err)
+        }
+    }
+}

--- a/modules/kotlin-api/src/main/kotlin/org/llm4s/kotlin/LLMClientKt.kt
+++ b/modules/kotlin-api/src/main/kotlin/org/llm4s/kotlin/LLMClientKt.kt
@@ -1,0 +1,51 @@
+package org.llm4s.kotlin
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
+import org.llm4s.java.JLlmClient
+
+/**
+ * Kotlin coroutine wrapper around [JLlmClient].
+ *
+ * All blocking calls are dispatched on [Dispatchers.IO] automatically. Errors
+ * surface as [LLMException] rather than Scala [Either], so callers never need
+ * to import any Scala types.
+ *
+ * Obtain instances via [Llm4s.createDefaultClient].
+ *
+ * ```kotlin
+ * val client = Llm4s.createDefaultClient()
+ * val reply = client.complete("What is 2 + 2?")
+ * ```
+ */
+class LLMClientKt internal constructor(internal val underlying: JLlmClient) : AutoCloseable {
+
+    /**
+     * Suspends until the LLM returns a response for the given [query].
+     *
+     * Throws [LLMException] if the underlying call fails.
+     */
+    suspend fun complete(query: String): String = withContext(Dispatchers.IO) {
+        val result = underlying.complete(query)
+        if (result.isSuccess) {
+            result.get()
+        } else {
+            val err = result.getError()
+            throw LLMException(err.message ?: "LLM call failed", err)
+        }
+    }
+
+    /**
+     * Returns a cold [Flow] that emits text chunks for the given [prompt].
+     *
+     * Currently emits a single chunk (the full response). Chunk-level streaming
+     * will be added when the underlying java-api gains streaming support.
+     */
+    fun streamComplete(prompt: String): Flow<String> = flow {
+        emit(complete(prompt))
+    }
+
+    override fun close(): Unit = underlying.close()
+}

--- a/modules/kotlin-api/src/main/kotlin/org/llm4s/kotlin/LLMException.kt
+++ b/modules/kotlin-api/src/main/kotlin/org/llm4s/kotlin/LLMException.kt
@@ -1,0 +1,6 @@
+package org.llm4s.kotlin
+
+import org.llm4s.java.LlmException
+
+/** Runtime exception thrown by Kotlin coroutine wrappers instead of returning Scala [Either]. */
+class LLMException(message: String, cause: LlmException? = null) : RuntimeException(message, cause)

--- a/modules/kotlin-api/src/main/kotlin/org/llm4s/kotlin/Llm4s.kt
+++ b/modules/kotlin-api/src/main/kotlin/org/llm4s/kotlin/Llm4s.kt
@@ -1,0 +1,52 @@
+package org.llm4s.kotlin
+
+import org.llm4s.java.JAgent
+import org.llm4s.java.JLlmClient
+import org.llm4s.java.LlmResult
+import org.llm4s.java.Llm4s as JLlm4s
+
+/**
+ * Internal seam that allows tests to replace the calls to [JLlm4s] static
+ * methods without requiring real LLM credentials in unit tests.
+ */
+internal interface ClientFactory {
+    fun createDefault(): LlmResult<JLlmClient>
+    fun createAgent(client: JLlmClient): JAgent
+}
+
+internal object DefaultClientFactory : ClientFactory {
+    override fun createDefault(): LlmResult<JLlmClient> = JLlm4s.createDefaultClient()
+    override fun createAgent(client: JLlmClient): JAgent = JLlm4s.createAgent(client)
+}
+
+/**
+ * Entry-point factory for Kotlin callers.
+ *
+ * ```kotlin
+ * val client = Llm4s.createDefaultClient()   // reads LLM_MODEL + API key env vars
+ * val agent  = Llm4s.createAgent(client)
+ * ```
+ */
+object Llm4s {
+    internal var factory: ClientFactory = DefaultClientFactory
+
+    /**
+     * Creates an [LLMClientKt] from the default provider configured via
+     * environment variables (e.g. `LLM_MODEL`, `OPENAI_API_KEY`).
+     * Throws [LLMException] if the provider cannot be configured.
+     */
+    fun createDefaultClient(): LLMClientKt {
+        val result = factory.createDefault()
+        if (result.isSuccess) return LLMClientKt(result.get())
+        val err = result.getError()
+        throw LLMException(err.message ?: "Failed to create client", err)
+    }
+
+    /**
+     * Wraps an [LLMClientKt] in an [AgentKt] ready for natural-language queries.
+     */
+    fun createAgent(client: LLMClientKt): AgentKt {
+        val jAgent = factory.createAgent(client.underlying)
+        return AgentKt(jAgent)
+    }
+}

--- a/modules/kotlin-api/src/test/kotlin/org/llm4s/kotlin/AgentKtTest.kt
+++ b/modules/kotlin-api/src/test/kotlin/org/llm4s/kotlin/AgentKtTest.kt
@@ -1,0 +1,41 @@
+package org.llm4s.kotlin
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.llm4s.agent.AgentState
+import org.llm4s.java.JAgent
+import org.llm4s.java.LlmException
+import org.llm4s.java.LlmResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AgentKtTest {
+
+    private val mockJAgent = mockk<JAgent>()
+    private val agent = AgentKt(mockJAgent)
+
+    @Test
+    fun `run returns AgentState on success`() = runTest {
+        val state = mockk<AgentState>()
+        val result = mockk<LlmResult<AgentState>>()
+        every { result.isSuccess } returns true
+        every { result.get() } returns state
+        every { mockJAgent.run("query") } returns result
+
+        assertEquals(state, agent.run("query"))
+    }
+
+    @Test
+    fun `run throws LLMException on failure`() = runTest {
+        val result = mockk<LlmResult<AgentState>>()
+        val err = mockk<LlmException>(relaxed = true)
+        every { result.isSuccess } returns false
+        every { result.getError() } returns err
+        every { err.message } returns "agent failed"
+        every { mockJAgent.run("query") } returns result
+
+        assertFailsWith<LLMException> { agent.run("query") }
+    }
+}

--- a/modules/kotlin-api/src/test/kotlin/org/llm4s/kotlin/DefaultClientFactoryTest.kt
+++ b/modules/kotlin-api/src/test/kotlin/org/llm4s/kotlin/DefaultClientFactoryTest.kt
@@ -1,0 +1,50 @@
+package org.llm4s.kotlin
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.llm4s.java.JAgent
+import org.llm4s.java.JLlmClient
+import org.llm4s.java.LlmResult
+import org.llm4s.java.Llm4s as JLlm4s
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests [DefaultClientFactory] by mocking the Scala static forwarders on
+ * [org.llm4s.java.Llm4s] so no real LLM credentials are needed.
+ */
+class DefaultClientFactoryTest {
+
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(JLlm4s::class)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkStatic(JLlm4s::class)
+    }
+
+    @Test
+    fun `createDefault delegates to JLlm4s createDefaultClient`() {
+        val expected = mockk<LlmResult<JLlmClient>>()
+        every { JLlm4s.createDefaultClient() } returns expected
+
+        val result = DefaultClientFactory.createDefault()
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `createAgent delegates to JLlm4s createAgent`() {
+        val jClient = mockk<JLlmClient>()
+        val expected = mockk<JAgent>()
+        every { JLlm4s.createAgent(jClient) } returns expected
+
+        val agent = DefaultClientFactory.createAgent(jClient)
+        assertEquals(expected, agent)
+    }
+}

--- a/modules/kotlin-api/src/test/kotlin/org/llm4s/kotlin/LLMClientKtTest.kt
+++ b/modules/kotlin-api/src/test/kotlin/org/llm4s/kotlin/LLMClientKtTest.kt
@@ -1,0 +1,76 @@
+package org.llm4s.kotlin
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.llm4s.java.JLlmClient
+import org.llm4s.java.LlmException
+import org.llm4s.java.LlmResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class LLMClientKtTest {
+
+    private val mockJClient = mockk<JLlmClient>()
+    private val client = LLMClientKt(mockJClient)
+
+    @Test
+    fun `complete returns text on success`() = runTest {
+        val result = mockk<LlmResult<String>>()
+        every { result.isSuccess } returns true
+        every { result.get() } returns "Hello LLM!"
+        every { mockJClient.complete("hello") } returns result
+
+        assertEquals("Hello LLM!", client.complete("hello"))
+    }
+
+    @Test
+    fun `complete throws LLMException on failure`() = runTest {
+        val result = mockk<LlmResult<String>>()
+        val err = mockk<LlmException>(relaxed = true)
+        every { result.isSuccess } returns false
+        every { result.getError() } returns err
+        every { err.message } returns "provider error"
+        every { mockJClient.complete("hello") } returns result
+
+        assertFailsWith<LLMException> { client.complete("hello") }
+    }
+
+    @Test
+    fun `streamComplete emits single text chunk on success`() = runTest {
+        val result = mockk<LlmResult<String>>()
+        every { result.isSuccess } returns true
+        every { result.get() } returns "streamed response"
+        every { mockJClient.complete("prompt") } returns result
+
+        val items = client.streamComplete("prompt").toList()
+        assertEquals(listOf("streamed response"), items)
+    }
+
+    @Test
+    fun `streamComplete propagates LLMException from complete`() = runTest {
+        val result = mockk<LlmResult<String>>()
+        val err = mockk<LlmException>(relaxed = true)
+        every { result.isSuccess } returns false
+        every { result.getError() } returns err
+        every { err.message } returns "LLM failed"
+        every { mockJClient.complete("prompt") } returns result
+
+        assertFailsWith<LLMException> {
+            client.streamComplete("prompt").collect()
+        }
+    }
+
+    @Test
+    fun `close delegates to underlying JLlmClient`() {
+        every { mockJClient.close() } just Runs
+        client.close()
+        verify { mockJClient.close() }
+    }
+}

--- a/modules/kotlin-api/src/test/kotlin/org/llm4s/kotlin/LLMExceptionTest.kt
+++ b/modules/kotlin-api/src/test/kotlin/org/llm4s/kotlin/LLMExceptionTest.kt
@@ -1,0 +1,25 @@
+package org.llm4s.kotlin
+
+import io.mockk.mockk
+import org.llm4s.java.LlmException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LLMExceptionTest {
+
+    @Test
+    fun `message only constructor sets message and null cause`() {
+        val ex = LLMException("test error")
+        assertEquals("test error", ex.message)
+        assertNull(ex.cause)
+    }
+
+    @Test
+    fun `message and cause constructor sets both properties`() {
+        val cause = mockk<LlmException>(relaxed = true)
+        val ex = LLMException("wrapped error", cause)
+        assertEquals("wrapped error", ex.message)
+        assertEquals(cause, ex.cause)
+    }
+}

--- a/modules/kotlin-api/src/test/kotlin/org/llm4s/kotlin/Llm4sTest.kt
+++ b/modules/kotlin-api/src/test/kotlin/org/llm4s/kotlin/Llm4sTest.kt
@@ -1,0 +1,72 @@
+package org.llm4s.kotlin
+
+import io.mockk.every
+import io.mockk.mockk
+import org.llm4s.java.JAgent
+import org.llm4s.java.JLlmClient
+import org.llm4s.java.LlmException
+import org.llm4s.java.LlmResult
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class Llm4sTest {
+
+    private val mockFactory = mockk<ClientFactory>()
+    private lateinit var originalFactory: ClientFactory
+
+    @BeforeTest
+    fun setUp() {
+        originalFactory = Llm4s.factory
+        Llm4s.factory = mockFactory
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Llm4s.factory = originalFactory
+    }
+
+    @Test
+    fun `createDefaultClient returns LLMClientKt on success`() {
+        val jClient = mockk<JLlmClient>()
+        val result = mockk<LlmResult<JLlmClient>>()
+        every { result.isSuccess } returns true
+        every { result.get() } returns jClient
+        every { mockFactory.createDefault() } returns result
+
+        val client = Llm4s.createDefaultClient()
+        assertNotNull(client)
+    }
+
+    @Test
+    fun `createDefaultClient throws LLMException on failure`() {
+        val result = mockk<LlmResult<JLlmClient>>()
+        val err = mockk<LlmException>(relaxed = true)
+        every { result.isSuccess } returns false
+        every { result.getError() } returns err
+        every { err.message } returns "no provider configured"
+        every { mockFactory.createDefault() } returns result
+
+        assertFailsWith<LLMException> { Llm4s.createDefaultClient() }
+    }
+
+    @Test
+    fun `createAgent wraps JAgent in AgentKt`() {
+        val jClient = mockk<JLlmClient>()
+        val jAgent = mockk<JAgent>()
+        val client = LLMClientKt(jClient)
+        every { mockFactory.createAgent(jClient) } returns jAgent
+
+        val agent = Llm4s.createAgent(client)
+        assertNotNull(agent)
+    }
+
+    @Test
+    fun `DefaultClientFactory is the initial factory`() {
+        // Restore original and verify it is DefaultClientFactory
+        Llm4s.factory = originalFactory
+        assertNotNull(Llm4s.factory)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a standalone Kotlin/Gradle module (`modules/kotlin-api/`) that wraps the Java interop API (from #934, included in this branch) with idiomatic Kotlin coroutine and Flow APIs.

- `LLMClientKt` — `suspend fun complete(query: String): String` and `streamComplete(prompt: String): Flow<String>`
- `AgentKt` — `suspend fun run(query: String): AgentState`
- `Llm4s` — entry-point object to create clients/agents without Scala `Either` boilerplate
- `LLMException` — runtime exception replacing Scala `Either` for Kotlin callers

**Completely separate from the Scala/SBT codebase**: the Kotlin module is a standalone Gradle project that depends only on the published `java-api_3` artifact. No Kotlin files touch the SBT build.

**100% line coverage** enforced via JaCoCo (`jacocoTestCoverageVerification` wired to `check`). All 15 unit tests pass using mockk injectable factory and `mockkStatic` for the default factory.

**CI**: new `kotlin-api` job publishes `core` + `java-api` to local Maven, then runs `gradle check` (tests + coverage gate). `all-tests-pass` gate now requires this job to succeed.

> **Note**: This branch contains both the java-api (#934) and kotlin-api (#937) changes since the Kotlin module builds on the Java bridge.

## Test plan

- [x] `gradle check` passes locally (15/15 tests, 100% line coverage)
- [x] Existing `sbt test` unaffected (43 java-api tests still pass)
- [x] CI `kotlin-api` job added; `all-tests-pass` gate updated
- [ ] Verify CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)