### PR TITLE
feat(provider): implement AWS Bedrock provider (BedrockClient)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,13 @@ sbt "samples/runMain org.llm4s.samples.basic.BasicLLMCallingExample"
 
 ```bash
 # Required for LLM
-LLM_MODEL=openai/gpt-4o              # or anthropic/claude-sonnet-4-5-latest, gemini/gemini-2.0-flash
+LLM_MODEL=openai/gpt-4o              # or anthropic/claude-sonnet-4-5-latest, gemini/gemini-2.0-flash, bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
 OPENAI_API_KEY=sk-...                # or ANTHROPIC_API_KEY, GOOGLE_API_KEY
+
+# AWS Bedrock (optional — falls back to default AWS credential chain)
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=AKIA...            # or use instance profile / ~/.aws/credentials
+AWS_SECRET_ACCESS_KEY=...            # required when AWS_ACCESS_KEY_ID is set
 
 # Optional - Tracing
 TRACING_MODE=langfuse                # langfuse, opentelemetry, console, or none

--- a/build.sbt
+++ b/build.sbt
@@ -197,6 +197,7 @@ lazy val core = (project in file("modules/core"))
       Deps.hikariCP,
       Deps.awsS3,
       Deps.awsSts,
+      Deps.awsBedrockRuntime,
       Deps.prometheusCore,
       Deps.prometheusHttp
     )

--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
@@ -104,3 +104,6 @@ private[config] object NamedProviderLoader:
         requiredApiKey("llm4s.providers.<name>.apiKey").map: apiKey =>
           val baseUrl = section.baseUrl.map(_.asUrl).getOrElse(MistralConfig.DEFAULT_BASE_URL)
           MistralConfig.fromValues(section.model.asString, apiKey, baseUrl)
+      case ProviderKind.Bedrock =>
+        val region = section.baseUrl.map(_.asUrl).getOrElse("us-east-1")
+        Right(BedrockConfig.fromValues(section.model.asString, region))

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -58,6 +58,8 @@ object LLMConnect {
         CohereClient(cfg, metrics, exchangeLogging)
       case cfg: MistralConfig =>
         MistralClient(cfg, metrics, exchangeLogging)
+      case cfg: BedrockConfig =>
+        BedrockClient(cfg, metrics, exchangeLogging)
     }
 
   def fromConfig(
@@ -168,6 +170,7 @@ object LLMConnect {
       case (ProviderKind.DeepSeek, cfg: DeepSeekConfig)   => DeepSeekClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Cohere, cfg: CohereConfig)       => CohereClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Mistral, cfg: MistralConfig)     => MistralClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.Bedrock, cfg: BedrockConfig)    => BedrockClient(cfg, metrics, exchangeLogging)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -170,7 +170,7 @@ object LLMConnect {
       case (ProviderKind.DeepSeek, cfg: DeepSeekConfig)   => DeepSeekClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Cohere, cfg: CohereConfig)       => CohereClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Mistral, cfg: MistralConfig)     => MistralClient(cfg, metrics, exchangeLogging)
-      case (ProviderKind.Bedrock, cfg: BedrockConfig)    => BedrockClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.Bedrock, cfg: BedrockConfig)     => BedrockClient(cfg, metrics, exchangeLogging)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -677,3 +677,66 @@ object MistralConfig:
       contextWindow = cw,
       reserveCompletion = rc
     )
+
+/**
+ * Configuration for the AWS Bedrock Converse API.
+ *
+ * Authentication uses the AWS default credential chain (env vars, instance
+ * profile, `~/.aws/credentials`) unless `accessKeyId` and `secretAccessKey`
+ * are supplied explicitly.
+ *
+ * Prefer [[BedrockConfig.fromValues]] over the primary constructor; it
+ * resolves `contextWindow` and `reserveCompletion` from the model name.
+ *
+ * @param region          AWS region, e.g. `"us-east-1"`.
+ * @param model           Bedrock model ID, e.g. `"anthropic.claude-3-5-sonnet-20241022-v2:0"`.
+ * @param contextWindow   Model's total token capacity (prompt + completion combined).
+ * @param reserveCompletion Tokens held back from prompt history for the completion.
+ * @param accessKeyId     Optional explicit AWS access key; falls back to default chain when absent.
+ * @param secretAccessKey Optional explicit AWS secret key; required when `accessKeyId` is set.
+ * @param endpointUrl     Optional endpoint URL override (e.g. for VPC endpoints or tests).
+ */
+case class BedrockConfig(
+  region: String,
+  model: String,
+  contextWindow: Int,
+  reserveCompletion: Int,
+  accessKeyId: Option[String] = None,
+  secretAccessKey: Option[String] = None,
+  endpointUrl: Option[String] = None
+) extends ProviderConfig:
+  override val provider: ProviderKind = ProviderKind.Bedrock
+  override def toString: String =
+    s"BedrockConfig(region=$region, model=$model, contextWindow=$contextWindow, " +
+      s"reserveCompletion=$reserveCompletion, accessKeyId=${accessKeyId.map(k => Redaction.secret(k)).getOrElse("(default chain)")})"
+
+object BedrockConfig:
+  private val DefaultContextWindow     = 200000
+  private val DefaultReserveCompletion = 4096
+
+  private def bedrockFallback(modelName: String): (Int, Int) =
+    modelName.toLowerCase match
+      case name if name.contains("claude")  => (200000, DefaultReserveCompletion)
+      case name if name.contains("llama")   => (128000, DefaultReserveCompletion)
+      case name if name.contains("mistral") => (32768, DefaultReserveCompletion)
+      case name if name.contains("titan")   => (32000, DefaultReserveCompletion)
+      case _                                => (8192, DefaultReserveCompletion)
+
+  def fromValues(
+    modelName: String,
+    region: String
+  )(using resolver: ContextWindowResolver): BedrockConfig =
+    require(region.trim.nonEmpty, "Bedrock region must be non-empty")
+    val (cw, rc) = resolver.resolve(
+      lookupProviders = Seq("bedrock"),
+      modelName = modelName,
+      defaultContextWindow = DefaultContextWindow,
+      defaultReserve = DefaultReserveCompletion,
+      fallbackResolver = bedrockFallback
+    )
+    BedrockConfig(
+      region = region,
+      model = modelName,
+      contextWindow = cw,
+      reserveCompletion = rc
+    )

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/BedrockClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/BedrockClient.scala
@@ -1,0 +1,393 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.{ AuthenticationError, RateLimitError, ValidationError }
+import org.llm4s.error.ThrowableOps.*
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
+import org.llm4s.llmconnect.ProviderExchangeLogging
+import org.llm4s.llmconnect.config.{ BedrockConfig, ProviderConfig }
+import org.llm4s.llmconnect.model.*
+import org.llm4s.llmconnect.provider.ProviderResultOps.*
+import org.llm4s.model.{ ModelRegistryService, RequestTransformer, TransformationResult }
+import org.llm4s.toolapi.{ ObjectSchema, ToolFunction }
+import org.llm4s.types.Result
+
+import software.amazon.awssdk.auth.credentials.{
+  AwsBasicCredentials,
+  DefaultCredentialsProvider,
+  StaticCredentialsProvider
+}
+import software.amazon.awssdk.core.document.Document
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient
+import org.llm4s.error.ServiceError
+
+import software.amazon.awssdk.services.bedrockruntime.model.{
+  AccessDeniedException,
+  BedrockRuntimeException,
+  ContentBlock,
+  ConverseRequest,
+  ConversationRole,
+  InferenceConfiguration,
+  Message => BedrockMessage,
+  ServiceQuotaExceededException,
+  SystemContentBlock,
+  ThrottlingException,
+  Tool,
+  ToolConfiguration,
+  ToolInputSchema,
+  ToolResultBlock,
+  ToolResultContentBlock,
+  ToolSpecification,
+  ToolUseBlock,
+  ValidationException
+}
+
+import java.net.URI
+import java.time.Instant
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
+
+/**
+ * [[LLMClient]] implementation for the AWS Bedrock Converse API.
+ *
+ * Supports models from Anthropic (Claude), Meta (Llama), Amazon Titan, Mistral
+ * and others available through AWS Bedrock's unified Converse endpoint.
+ *
+ * == Authentication ==
+ *
+ * Uses the AWS default credential chain when no explicit credentials are
+ * configured: environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`),
+ * `~/.aws/credentials`, EC2 instance profile, ECS task role, etc.
+ * Explicit credentials can be supplied via [[BedrockConfig.accessKeyId]] and
+ * [[BedrockConfig.secretAccessKey]].
+ *
+ * == Streaming ==
+ *
+ * `streamComplete` delegates to the non-streaming Converse API and emits the
+ * full response as a single [[StreamedChunk]].  True server-sent event
+ * streaming via the Bedrock ConverseStream binary protocol can be added in a
+ * follow-up using the AWS SDK async client.
+ *
+ * @param config          [[BedrockConfig]] with region, model ID, and optional credentials.
+ * @param metrics         Receives per-call latency and token-usage events.
+ * @param exchangeLogging Optional provider exchange logging.
+ */
+class BedrockClient(
+  config: BedrockConfig,
+  protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop,
+  exchangeLogging: ProviderExchangeLogging = ProviderExchangeLogging.Disabled
+)(using val registryService: ModelRegistryService)
+    extends BaseLifecycleLLMClient {
+
+  private val providerConfig: ProviderConfig = config
+
+  private val sdkClient: BedrockRuntimeClient = {
+    val credProvider = (config.accessKeyId, config.secretAccessKey) match {
+      case (Some(keyId), Some(secret)) =>
+        StaticCredentialsProvider.create(AwsBasicCredentials.create(keyId, secret))
+      case _ =>
+        DefaultCredentialsProvider.create()
+    }
+    val builder = BedrockRuntimeClient
+      .builder()
+      .region(Region.of(config.region))
+      .credentialsProvider(credProvider)
+    config.endpointUrl.foreach(url => builder.endpointOverride(URI.create(url)))
+    builder.build()
+  }
+
+  protected def clientDescription: String = s"Bedrock client for model ${config.model}"
+  protected def providerName: String      = "bedrock"
+  protected def modelName: String         = config.model
+
+  override def complete(
+    conversation: Conversation,
+    options: CompletionOptions
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt = Instant.now()
+    TransformationResult
+      .transform(
+        config.model,
+        options,
+        conversation.messages,
+        dropUnsupported = true,
+        RequestTransformer.default(registryService)
+      )
+      .flatMap { transformed =>
+        doConverse(conversation.copy(messages = transformed.messages), transformed.options, startedAt)
+      }
+  }
+
+  override def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions(),
+    onChunk: StreamedChunk => Unit
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt = Instant.now()
+    TransformationResult
+      .transform(
+        config.model,
+        options,
+        conversation.messages,
+        dropUnsupported = true,
+        RequestTransformer.default(registryService)
+      )
+      .flatMap { transformed =>
+        doConverse(conversation.copy(messages = transformed.messages), transformed.options, startedAt).map {
+          completion =>
+            val chunk = StreamedChunk(
+              id = completion.id,
+              content = Option(completion.content).filter(_.nonEmpty),
+              toolCall = None,
+              finishReason = Some("stop")
+            )
+            onChunk(chunk)
+            completion
+        }
+      }
+  }
+
+  override def getContextWindow(): Int     = providerConfig.contextWindow
+  override def getReserveCompletion(): Int = providerConfig.reserveCompletion
+
+  override protected def releaseResources(): Unit = sdkClient.close()
+
+  private def doConverse(
+    conversation: Conversation,
+    options: CompletionOptions,
+    startedAt: Instant
+  ): Result[Completion] = {
+    val requestJson = serializeRequestForLogging(conversation, options)
+    val request     = buildConverseRequest(conversation, options)
+
+    val attempt = Try(sdkClient.converse(request)).toEither.left.map {
+      case _: ThrottlingException           => RateLimitError("bedrock")
+      case _: ServiceQuotaExceededException => RateLimitError("bedrock")
+      case e: ValidationException           => ValidationError("request", e.getMessage)
+      case e: AccessDeniedException         => AuthenticationError("bedrock", e.getMessage)
+      case e: BedrockRuntimeException       => ServiceError(e.statusCode(), "bedrock", e.getMessage)
+      case e                                => e.toLLMError
+    }
+
+    attempt
+      .map { response =>
+        val completion   = parseConverseResponse(response)
+        val responseJson = serializeResponseForLogging(response)
+        recordExchange(startedAt, requestJson, Some(responseJson), Right(completion))
+        completion
+      }
+      .tapLeft(err => recordExchange(startedAt, requestJson, None, Left(err)))
+  }
+
+  private def buildConverseRequest(conversation: Conversation, options: CompletionOptions): ConverseRequest = {
+    val builder = ConverseRequest.builder().modelId(config.model)
+
+    val (sysMsgs, otherMsgs) = conversation.messages.partition(_.isInstanceOf[SystemMessage])
+
+    if (sysMsgs.nonEmpty) {
+      val sysBlocks = sysMsgs.collect { case SystemMessage(content) => SystemContentBlock.fromText(content) }
+      builder.system(sysBlocks.asJava)
+    }
+
+    val bedrockMessages = convertMessages(otherMsgs)
+    if (bedrockMessages.nonEmpty) builder.messages(bedrockMessages.asJava)
+
+    val infCfg = InferenceConfiguration.builder().temperature(options.temperature.floatValue())
+    options.maxTokens.foreach(m => infCfg.maxTokens(m))
+    builder.inferenceConfig(infCfg.build())
+
+    if (options.tools.nonEmpty) {
+      val tools   = options.tools.map(convertTool)
+      val toolCfg = ToolConfiguration.builder().tools(tools.asJava).build()
+      builder.toolConfig(toolCfg)
+    }
+
+    builder.build()
+  }
+
+  private def convertMessages(messages: Seq[Message]): Seq[BedrockMessage] =
+    messages.flatMap {
+      case UserMessage(content) =>
+        Some(
+          BedrockMessage.builder()
+            .role(ConversationRole.USER)
+            .content(ContentBlock.fromText(content))
+            .build()
+        )
+
+      case msg: AssistantMessage =>
+        val textBlocks = msg.contentOpt.filter(_.nonEmpty).map(ContentBlock.fromText).toSeq
+        val toolBlocks = msg.toolCalls.map { tc =>
+          ContentBlock.fromToolUse(
+            ToolUseBlock.builder()
+              .toolUseId(tc.id)
+              .name(tc.name)
+              .input(ujsonToDocument(tc.arguments))
+              .build()
+          )
+        }
+        val blocks = textBlocks ++ toolBlocks
+        if (blocks.nonEmpty)
+          Some(BedrockMessage.builder().role(ConversationRole.ASSISTANT).content(blocks.asJava).build())
+        else None
+
+      case msg: ToolMessage =>
+        val resultBlock = ToolResultBlock.builder()
+          .toolUseId(msg.toolCallId)
+          .content(ToolResultContentBlock.fromText(msg.content))
+          .build()
+        Some(
+          BedrockMessage.builder()
+            .role(ConversationRole.USER)
+            .content(ContentBlock.fromToolResult(resultBlock))
+            .build()
+        )
+
+      case _: SystemMessage => None
+    }
+
+  private def convertTool(toolFunction: ToolFunction[?, ?]): Tool = {
+    val objectSchema = toolFunction.schema.asInstanceOf[ObjectSchema[?]]
+    val schemaDoc    = ujsonToDocument(ujson.read(objectSchema.toJsonSchema(false).render()))
+    val toolSpec = ToolSpecification.builder()
+      .name(toolFunction.name)
+      .description(toolFunction.description)
+      .inputSchema(ToolInputSchema.builder().json(schemaDoc).build())
+      .build()
+    Tool.builder().toolSpec(toolSpec).build()
+  }
+
+  private def parseConverseResponse(
+    response: software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse
+  ): Completion = {
+    val outputMsg = response.output().message()
+    val blocks    = outputMsg.content().asScala.toList
+
+    val textContent = blocks
+      .filter(_.`type`() == ContentBlock.Type.TEXT)
+      .flatMap(b => Option(b.text()).filter(_.nonEmpty))
+      .mkString
+
+    val toolCalls = blocks
+      .filter(_.`type`() == ContentBlock.Type.TOOL_USE)
+      .map { block =>
+        val tu = block.toolUse()
+        ToolCall(id = tu.toolUseId(), name = tu.name(), arguments = documentToUjson(tu.input()))
+      }
+
+    val message = AssistantMessage(contentOpt = Option(textContent).filter(_.nonEmpty), toolCalls = toolCalls)
+
+    val usage = Option(response.usage()).map { u =>
+      TokenUsage(
+        promptTokens = u.inputTokens(),
+        completionTokens = u.outputTokens(),
+        totalTokens = u.totalTokens()
+      )
+    }
+
+    val cost = usage.flatMap(u => CostEstimator.estimate(config.model, u))
+
+    Completion(
+      id = java.util.UUID.randomUUID().toString,
+      created = System.currentTimeMillis() / 1000,
+      content = textContent,
+      model = config.model,
+      message = message,
+      toolCalls = toolCalls,
+      usage = usage,
+      thinking = None,
+      estimatedCost = cost
+    )
+  }
+
+  private[provider] def ujsonToDocument(value: ujson.Value): Document =
+    value match {
+      case ujson.Str(s)  => Document.fromString(s)
+      case ujson.Num(n)  => Document.fromNumber(java.math.BigDecimal.valueOf(n))
+      case ujson.Bool(b) => Document.fromBoolean(b)
+      case ujson.Null    => Document.fromNull()
+      case ujson.Arr(arr) =>
+        Document.fromList(arr.map(ujsonToDocument).toList.asJava)
+      case ujson.Obj(obj) =>
+        val m = new java.util.LinkedHashMap[String, Document]()
+        obj.foreach { case (k, v) => m.put(k, ujsonToDocument(v)) }
+        Document.fromMap(m)
+    }
+
+  private[provider] def documentToUjson(doc: Document): ujson.Value = {
+    val visitor = new software.amazon.awssdk.core.document.DocumentVisitor[ujson.Value] {
+      override def visitNull(): ujson.Value = ujson.Null
+      override def visitBoolean(b: java.lang.Boolean): ujson.Value =
+        ujson.Bool(b.booleanValue())
+      override def visitNumber(n: software.amazon.awssdk.core.SdkNumber): ujson.Value =
+        ujson.Num(n.doubleValue())
+      override def visitString(s: String): ujson.Value = ujson.Str(s)
+      override def visitList(list: java.util.List[Document]): ujson.Value =
+        val items = list.asScala.map(_.accept(this)).toArray
+        ujson.Arr(items: _*)
+      override def visitMap(map: java.util.Map[String, Document]): ujson.Value =
+        val obj = ujson.Obj()
+        map.asScala.foreach { case (k, v) => obj(k) = v.accept(this) }
+        obj
+    }
+    doc.accept(visitor)
+  }
+
+  private def serializeRequestForLogging(conversation: Conversation, options: CompletionOptions): String = {
+    val msgs = conversation.messages.map {
+      case SystemMessage(content)    => ujson.Obj("role" -> "system", "content" -> content)
+      case UserMessage(content)      => ujson.Obj("role" -> "user", "content" -> content)
+      case msg: AssistantMessage     => ujson.Obj("role" -> "assistant", "content" -> msg.content)
+      case msg: ToolMessage          => ujson.Obj("role" -> "tool", "toolCallId" -> msg.toolCallId, "content" -> msg.content)
+    }
+    ujson.Obj(
+      "modelId"     -> config.model,
+      "region"      -> config.region,
+      "temperature" -> options.temperature,
+      "messages"    -> ujson.Arr(msgs: _*)
+    ).render()
+  }
+
+  private def serializeResponseForLogging(
+    response: software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse
+  ): String = {
+    val text = response.output().message().content().asScala
+      .filter(_.`type`() == ContentBlock.Type.TEXT)
+      .flatMap(b => Option(b.text()))
+      .mkString
+    ujson.Obj("stopReason" -> response.stopReasonAsString(), "content" -> text).render()
+  }
+
+  private def recordExchange(
+    startedAt: Instant,
+    requestBody: String,
+    responseBody: Option[String],
+    result: Result[?]
+  ): Unit =
+    ProviderExchangeRecorder.record(
+      exchangeLogging = exchangeLogging,
+      provider = providerName,
+      model = Some(config.model),
+      startedAt = startedAt,
+      requestBody = requestBody,
+      responseBody = responseBody,
+      result = result
+    )
+}
+
+object BedrockClient {
+  import org.llm4s.types.TryOps
+
+  def apply(
+    config: BedrockConfig,
+    metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop
+  )(using ModelRegistryService): Result[BedrockClient] =
+    Try(new BedrockClient(config, metrics)).toResult
+
+  def apply(
+    config: BedrockConfig,
+    metrics: org.llm4s.metrics.MetricsCollector,
+    exchangeLogging: ProviderExchangeLogging
+  )(using ModelRegistryService): Result[BedrockClient] =
+    Try(new BedrockClient(config, metrics, exchangeLogging)).toResult
+}

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/BedrockClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/BedrockClient.scala
@@ -209,7 +209,8 @@ class BedrockClient(
     messages.flatMap {
       case UserMessage(content) =>
         Some(
-          BedrockMessage.builder()
+          BedrockMessage
+            .builder()
             .role(ConversationRole.USER)
             .content(ContentBlock.fromText(content))
             .build()
@@ -219,7 +220,8 @@ class BedrockClient(
         val textBlocks = msg.contentOpt.filter(_.nonEmpty).map(ContentBlock.fromText).toSeq
         val toolBlocks = msg.toolCalls.map { tc =>
           ContentBlock.fromToolUse(
-            ToolUseBlock.builder()
+            ToolUseBlock
+              .builder()
               .toolUseId(tc.id)
               .name(tc.name)
               .input(ujsonToDocument(tc.arguments))
@@ -232,12 +234,14 @@ class BedrockClient(
         else None
 
       case msg: ToolMessage =>
-        val resultBlock = ToolResultBlock.builder()
+        val resultBlock = ToolResultBlock
+          .builder()
           .toolUseId(msg.toolCallId)
           .content(ToolResultContentBlock.fromText(msg.content))
           .build()
         Some(
-          BedrockMessage.builder()
+          BedrockMessage
+            .builder()
             .role(ConversationRole.USER)
             .content(ContentBlock.fromToolResult(resultBlock))
             .build()
@@ -249,7 +253,8 @@ class BedrockClient(
   private def convertTool(toolFunction: ToolFunction[?, ?]): Tool = {
     val objectSchema = toolFunction.schema.asInstanceOf[ObjectSchema[?]]
     val schemaDoc    = ujsonToDocument(ujson.read(objectSchema.toJsonSchema(false).render()))
-    val toolSpec = ToolSpecification.builder()
+    val toolSpec = ToolSpecification
+      .builder()
       .name(toolFunction.name)
       .description(toolFunction.description)
       .inputSchema(ToolInputSchema.builder().json(schemaDoc).build())
@@ -335,23 +340,29 @@ class BedrockClient(
 
   private def serializeRequestForLogging(conversation: Conversation, options: CompletionOptions): String = {
     val msgs = conversation.messages.map {
-      case SystemMessage(content)    => ujson.Obj("role" -> "system", "content" -> content)
-      case UserMessage(content)      => ujson.Obj("role" -> "user", "content" -> content)
-      case msg: AssistantMessage     => ujson.Obj("role" -> "assistant", "content" -> msg.content)
-      case msg: ToolMessage          => ujson.Obj("role" -> "tool", "toolCallId" -> msg.toolCallId, "content" -> msg.content)
+      case SystemMessage(content) => ujson.Obj("role" -> "system", "content" -> content)
+      case UserMessage(content)   => ujson.Obj("role" -> "user", "content" -> content)
+      case msg: AssistantMessage  => ujson.Obj("role" -> "assistant", "content" -> msg.content)
+      case msg: ToolMessage => ujson.Obj("role" -> "tool", "toolCallId" -> msg.toolCallId, "content" -> msg.content)
     }
-    ujson.Obj(
-      "modelId"     -> config.model,
-      "region"      -> config.region,
-      "temperature" -> options.temperature,
-      "messages"    -> ujson.Arr(msgs: _*)
-    ).render()
+    ujson
+      .Obj(
+        "modelId"     -> config.model,
+        "region"      -> config.region,
+        "temperature" -> options.temperature,
+        "messages"    -> ujson.Arr(msgs: _*)
+      )
+      .render()
   }
 
   private def serializeResponseForLogging(
     response: software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse
   ): String = {
-    val text = response.output().message().content().asScala
+    val text = response
+      .output()
+      .message()
+      .content()
+      .asScala
       .filter(_.`type`() == ContentBlock.Type.TEXT)
       .flatMap(b => Option(b.text()))
       .mkString

--- a/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
+++ b/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
@@ -35,6 +35,7 @@ object ProviderModelTypes:
     case DeepSeek
     case Cohere
     case Mistral
+    case Bedrock
 
   object ProviderKind:
     val all: Seq[ProviderKind] = Seq(
@@ -47,7 +48,8 @@ object ProviderModelTypes:
       ProviderKind.Gemini,
       ProviderKind.DeepSeek,
       ProviderKind.Cohere,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.Bedrock
     )
 
     def fromString(value: String): Option[ProviderKind] =
@@ -63,6 +65,7 @@ object ProviderModelTypes:
         case "deepseek"   => Some(ProviderKind.DeepSeek)
         case "cohere"     => Some(ProviderKind.Cohere)
         case "mistral"    => Some(ProviderKind.Mistral)
+        case "bedrock"    => Some(ProviderKind.Bedrock)
         case _            => None
 
     def fromName(value: String): Option[ProviderKind] =
@@ -81,3 +84,4 @@ object ProviderModelTypes:
         case ProviderKind.DeepSeek   => "deepseek"
         case ProviderKind.Cohere     => "cohere"
         case ProviderKind.Mistral    => "mistral"
+        case ProviderKind.Bedrock    => "bedrock"

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/BedrockClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/BedrockClientSpec.scala
@@ -238,8 +238,7 @@ class BedrockClientSpec extends AnyFlatSpec with Matchers {
   }
 
   "BedrockClient.streamComplete" should "emit full response as single chunk and return completion" in withServer {
-    exchange =>
-      sendJson(exchange, 200, bedrockSuccessResponse("Streamed response"))
+    exchange => sendJson(exchange, 200, bedrockSuccessResponse("Streamed response"))
   } { baseUrl =>
     val client = new BedrockClient(config(baseUrl))
     val chunks = ListBuffer.empty[org.llm4s.llmconnect.model.StreamedChunk]

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/BedrockClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/BedrockClientSpec.scala
@@ -1,11 +1,20 @@
 package org.llm4s.llmconnect.provider
 
 import com.sun.net.httpserver.{ HttpExchange, HttpServer }
-import org.llm4s.error.{ AuthenticationError, RateLimitError, ServiceError, ValidationError }
+import org.llm4s.error.{ AuthenticationError, RateLimitError, ServiceError, UnknownError, ValidationError }
 import org.llm4s.llmconnect.{ ProviderExchange, ProviderExchangeLogging, ProviderExchangeSink }
-import org.llm4s.llmconnect.config.BedrockConfig
-import org.llm4s.llmconnect.model.{ AssistantMessage, CompletionOptions, Conversation, SystemMessage, UserMessage }
+import org.llm4s.llmconnect.config.{ BedrockConfig, ContextWindowResolver }
+import org.llm4s.llmconnect.model.{
+  AssistantMessage,
+  CompletionOptions,
+  Conversation,
+  SystemMessage,
+  ToolCall,
+  ToolMessage,
+  UserMessage
+}
 import org.llm4s.model.ModelRegistryService
+import org.llm4s.toolapi.{ Schema, ToolBuilder }
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.OptionValues._
@@ -154,6 +163,22 @@ class BedrockClientSpec extends AnyFlatSpec with Matchers {
     )
   }
 
+  it should "map HTTP 400 ServiceQuotaExceededException to RateLimitError" in withServer { exchange =>
+    val body =
+      """{
+        |  "__type": "ServiceQuotaExceededException",
+        |  "message": "Service quota exceeded"
+        |}""".stripMargin
+    sendJson(exchange, 400, body)
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val result = client.complete(conversation, CompletionOptions())
+    result.fold(
+      err => err shouldBe a[RateLimitError],
+      _ => fail("Expected Left(RateLimitError)")
+    )
+  }
+
   it should "map HTTP 400 to ValidationError" in withServer { exchange =>
     val body =
       """{
@@ -186,6 +211,24 @@ class BedrockClientSpec extends AnyFlatSpec with Matchers {
     )
   }
 
+  it should "map a non-SDK exception (connection refused) to UnknownError" in {
+    val cfg = BedrockConfig(
+      region = "us-east-1",
+      model = "amazon.titan-text-express-v1",
+      contextWindow = 32000,
+      reserveCompletion = 4096,
+      accessKeyId = Some("test-key-id"),
+      secretAccessKey = Some("test-secret-key"),
+      endpointUrl = Some("http://localhost:1")
+    )
+    val client = new BedrockClient(cfg)
+    val result = client.complete(conversation, CompletionOptions())
+    result.fold(
+      err => err shouldBe a[UnknownError],
+      _ => fail("Expected Left(UnknownError)")
+    )
+  }
+
   it should "handle multi-turn conversations including system messages" in withServer { exchange =>
     sendJson(exchange, 200, bedrockSuccessResponse("Sure, I can help!"))
   } { baseUrl =>
@@ -202,6 +245,81 @@ class BedrockClientSpec extends AnyFlatSpec with Matchers {
     result.fold(
       err => fail(s"Expected Right, got Left($err)"),
       completion => completion.content shouldBe "Sure, I can help!"
+    )
+  }
+
+  it should "handle ToolMessage and AssistantMessage with tool calls" in withServer { exchange =>
+    sendJson(exchange, 200, bedrockSuccessResponse("The weather is 22C"))
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val toolConv = Conversation(
+      Seq(
+        UserMessage("What is the weather in London?"),
+        AssistantMessage(
+          None,
+          Seq(ToolCall(id = "tc-1", name = "get_weather", arguments = ujson.Obj("location" -> "London")))
+        ),
+        ToolMessage(toolCallId = "tc-1", content = """{"temp": 22}""")
+      )
+    )
+    val result = client.complete(toolConv, CompletionOptions())
+    result.fold(
+      err => fail(s"Expected Right, got Left($err)"),
+      completion => completion.content shouldBe "The weather is 22C"
+    )
+  }
+
+  it should "parse a response with tool use blocks" in withServer { exchange =>
+    val body =
+      """{
+        |  "output": {
+        |    "message": {
+        |      "role": "assistant",
+        |      "content": [
+        |        {
+        |          "toolUse": {
+        |            "toolUseId": "tc-42",
+        |            "name": "get_weather",
+        |            "input": {"location": "Paris"}
+        |          }
+        |        }
+        |      ]
+        |    }
+        |  },
+        |  "stopReason": "tool_use",
+        |  "usage": {"inputTokens": 20, "outputTokens": 10, "totalTokens": 30}
+        |}""".stripMargin
+    sendJson(exchange, 200, body)
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val result = client.complete(conversation, CompletionOptions())
+    result.fold(
+      err => fail(s"Expected Right, got Left($err)"),
+      completion => {
+        completion.toolCalls should have size 1
+        completion.toolCalls.head.id shouldBe "tc-42"
+        completion.toolCalls.head.name shouldBe "get_weather"
+        completion.toolCalls.head.arguments("location").str shouldBe "Paris"
+      }
+    )
+  }
+
+  it should "send tool definitions when options.tools is non-empty" in withServer { exchange =>
+    sendJson(exchange, 200, bedrockSuccessResponse("Done"))
+  } { baseUrl =>
+    val tool = ToolBuilder[Map[String, Any], String](
+      "get_weather",
+      "Returns current weather for a location",
+      Schema
+        .`object`[Map[String, Any]]("Weather params")
+        .withProperty(Schema.property("location", Schema.string("City name")))
+    ).withHandler(_ => Right("sunny")).buildSafe().toOption.get
+
+    val client = new BedrockClient(config(baseUrl))
+    val result = client.complete(conversation, CompletionOptions(tools = Seq(tool)))
+    result.fold(
+      err => fail(s"Expected Right, got Left($err)"),
+      completion => completion.content shouldBe "Done"
     )
   }
 
@@ -235,6 +353,11 @@ class BedrockClientSpec extends AnyFlatSpec with Matchers {
       err => fail(s"Expected Right, got Left($err)"),
       completion => completion.content shouldBe "Short response"
     )
+  }
+
+  it should "close cleanly without throwing" in {
+    val client = new BedrockClient(config("http://localhost:9999"))
+    noException should be thrownBy client.close()
   }
 
   "BedrockClient.streamComplete" should "emit full response as single chunk and return completion" in withServer {
@@ -272,6 +395,46 @@ class BedrockClientSpec extends AnyFlatSpec with Matchers {
     )
   }
 
+  "BedrockClient.apply" should "construct a client via the two-arg factory method" in withServer { exchange =>
+    sendJson(exchange, 200, bedrockSuccessResponse("Factory built"))
+  } { baseUrl =>
+    val result = BedrockClient(config(baseUrl))
+    result.isRight shouldBe true
+    result.foreach { client =>
+      client.complete(conversation, CompletionOptions()).isRight shouldBe true
+    }
+  }
+
+  it should "construct a client via the three-arg factory method with exchange logging" in withServer { exchange =>
+    sendJson(exchange, 200, bedrockSuccessResponse("Factory logged"))
+  } { baseUrl =>
+    val exchanges = ListBuffer.empty[ProviderExchange]
+    val sink = new ProviderExchangeSink {
+      override def record(e: ProviderExchange): Unit = exchanges += e
+    }
+    val result = BedrockClient(
+      config(baseUrl),
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Enabled(sink)
+    )
+    result.isRight shouldBe true
+    result.foreach { client =>
+      client.complete(conversation, CompletionOptions())
+      exchanges should have size 1
+    }
+  }
+
+  "BedrockClient" should "use default credential chain when no explicit credentials are provided" in {
+    val cfg = BedrockConfig(
+      region = "us-east-1",
+      model = "amazon.titan-text-express-v1",
+      contextWindow = 32000,
+      reserveCompletion = 4096,
+      endpointUrl = Some("http://localhost:9999")
+    )
+    noException should be thrownBy new BedrockClient(cfg)
+  }
+
   "BedrockClient ujsonToDocument / documentToUjson" should "round-trip a JSON object" in {
     val cfg    = config("http://localhost:9999")
     val client = new BedrockClient(cfg)
@@ -291,5 +454,78 @@ class BedrockClientSpec extends AnyFlatSpec with Matchers {
     roundTrip("active").bool shouldBe true
     roundTrip("tags").arr.map(_.str).toSeq shouldBe Seq("a", "b")
     roundTrip("meta")("key").str shouldBe "value"
+  }
+
+  it should "round-trip null and primitive scalar values" in {
+    val cfg    = config("http://localhost:9999")
+    val client = new BedrockClient(cfg)
+
+    client.documentToUjson(client.ujsonToDocument(ujson.Null)) shouldBe ujson.Null
+    client.documentToUjson(client.ujsonToDocument(ujson.Str("hello"))) shouldBe ujson.Str("hello")
+    client.documentToUjson(client.ujsonToDocument(ujson.Num(3.14))) shouldBe ujson.Num(3.14)
+    client.documentToUjson(client.ujsonToDocument(ujson.Bool(false))) shouldBe ujson.Bool(false)
+    client
+      .documentToUjson(client.ujsonToDocument(ujson.Arr(ujson.Num(1), ujson.Num(2))))
+      .arr
+      .map(_.num)
+      .toSeq shouldBe Seq(1.0, 2.0)
+  }
+
+  "BedrockConfig.fromValues" should "resolve context window for claude models" in {
+    given ContextWindowResolver = ContextWindowResolver(org.llm4s.model.ModelRegistryTestSupport.defaultService())
+    val cfg = BedrockConfig.fromValues("anthropic.claude-3-5-sonnet-20241022-v2:0", "us-east-1")
+    cfg.region shouldBe "us-east-1"
+    cfg.model shouldBe "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    cfg.contextWindow should be > 0
+    cfg.reserveCompletion should be > 0
+  }
+
+  it should "apply the llama fallback for unregistered llama models" in {
+    given ContextWindowResolver = ContextWindowResolver(org.llm4s.model.ModelRegistryTestSupport.defaultService())
+    val cfg = BedrockConfig.fromValues("bedrock.fake-llama-experimental-v99", "eu-west-1")
+    cfg.contextWindow shouldBe 128000
+    cfg.region shouldBe "eu-west-1"
+  }
+
+  it should "apply the mistral fallback for unregistered mistral models" in {
+    given ContextWindowResolver = ContextWindowResolver(org.llm4s.model.ModelRegistryTestSupport.defaultService())
+    val cfg = BedrockConfig.fromValues("bedrock.fake-mistral-experimental-v99", "us-west-2")
+    cfg.contextWindow shouldBe 32768
+  }
+
+  it should "apply the titan fallback for unregistered titan models" in {
+    given ContextWindowResolver = ContextWindowResolver(org.llm4s.model.ModelRegistryTestSupport.defaultService())
+    val cfg = BedrockConfig.fromValues("bedrock.fake-titan-experimental-v99", "us-east-1")
+    cfg.contextWindow shouldBe 32000
+  }
+
+  it should "use a conservative default for completely unknown models" in {
+    given ContextWindowResolver = ContextWindowResolver(org.llm4s.model.ModelRegistryTestSupport.defaultService())
+    val cfg = BedrockConfig.fromValues("bedrock.totally-unknown-model-v99", "ap-southeast-1")
+    cfg.contextWindow shouldBe 8192
+  }
+
+  "BedrockConfig.toString" should "redact the access key and show region and model" in {
+    val cfg = BedrockConfig(
+      region = "us-east-1",
+      model = "amazon.titan-text-express-v1",
+      contextWindow = 32000,
+      reserveCompletion = 4096,
+      accessKeyId = Some("AKIAIOSFODNN7EXAMPLE")
+    )
+    val str = cfg.toString
+    str should include("us-east-1")
+    str should include("amazon.titan-text-express-v1")
+    str should not include "AKIAIOSFODNN7EXAMPLE"
+  }
+
+  it should "show default chain label when no access key is set" in {
+    val cfg = BedrockConfig(
+      region = "us-east-1",
+      model = "amazon.titan-text-express-v1",
+      contextWindow = 32000,
+      reserveCompletion = 4096
+    )
+    cfg.toString should include("default chain")
   }
 }

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/BedrockClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/BedrockClientSpec.scala
@@ -400,9 +400,7 @@ class BedrockClientSpec extends AnyFlatSpec with Matchers {
   } { baseUrl =>
     val result = BedrockClient(config(baseUrl))
     result.isRight shouldBe true
-    result.foreach { client =>
-      client.complete(conversation, CompletionOptions()).isRight shouldBe true
-    }
+    result.foreach(client => client.complete(conversation, CompletionOptions()).isRight shouldBe true)
   }
 
   it should "construct a client via the three-arg factory method with exchange logging" in withServer { exchange =>
@@ -473,7 +471,7 @@ class BedrockClientSpec extends AnyFlatSpec with Matchers {
 
   "BedrockConfig.fromValues" should "resolve context window for claude models" in {
     given ContextWindowResolver = ContextWindowResolver(org.llm4s.model.ModelRegistryTestSupport.defaultService())
-    val cfg = BedrockConfig.fromValues("anthropic.claude-3-5-sonnet-20241022-v2:0", "us-east-1")
+    val cfg                     = BedrockConfig.fromValues("anthropic.claude-3-5-sonnet-20241022-v2:0", "us-east-1")
     cfg.region shouldBe "us-east-1"
     cfg.model shouldBe "anthropic.claude-3-5-sonnet-20241022-v2:0"
     cfg.contextWindow should be > 0
@@ -482,26 +480,26 @@ class BedrockClientSpec extends AnyFlatSpec with Matchers {
 
   it should "apply the llama fallback for unregistered llama models" in {
     given ContextWindowResolver = ContextWindowResolver(org.llm4s.model.ModelRegistryTestSupport.defaultService())
-    val cfg = BedrockConfig.fromValues("bedrock.fake-llama-experimental-v99", "eu-west-1")
+    val cfg                     = BedrockConfig.fromValues("bedrock.fake-llama-experimental-v99", "eu-west-1")
     cfg.contextWindow shouldBe 128000
     cfg.region shouldBe "eu-west-1"
   }
 
   it should "apply the mistral fallback for unregistered mistral models" in {
     given ContextWindowResolver = ContextWindowResolver(org.llm4s.model.ModelRegistryTestSupport.defaultService())
-    val cfg = BedrockConfig.fromValues("bedrock.fake-mistral-experimental-v99", "us-west-2")
+    val cfg                     = BedrockConfig.fromValues("bedrock.fake-mistral-experimental-v99", "us-west-2")
     cfg.contextWindow shouldBe 32768
   }
 
   it should "apply the titan fallback for unregistered titan models" in {
     given ContextWindowResolver = ContextWindowResolver(org.llm4s.model.ModelRegistryTestSupport.defaultService())
-    val cfg = BedrockConfig.fromValues("bedrock.fake-titan-experimental-v99", "us-east-1")
+    val cfg                     = BedrockConfig.fromValues("bedrock.fake-titan-experimental-v99", "us-east-1")
     cfg.contextWindow shouldBe 32000
   }
 
   it should "use a conservative default for completely unknown models" in {
     given ContextWindowResolver = ContextWindowResolver(org.llm4s.model.ModelRegistryTestSupport.defaultService())
-    val cfg = BedrockConfig.fromValues("bedrock.totally-unknown-model-v99", "ap-southeast-1")
+    val cfg                     = BedrockConfig.fromValues("bedrock.totally-unknown-model-v99", "ap-southeast-1")
     cfg.contextWindow shouldBe 8192
   }
 
@@ -516,7 +514,7 @@ class BedrockClientSpec extends AnyFlatSpec with Matchers {
     val str = cfg.toString
     str should include("us-east-1")
     str should include("amazon.titan-text-express-v1")
-    str should not include "AKIAIOSFODNN7EXAMPLE"
+    (str should not).include("AKIAIOSFODNN7EXAMPLE")
   }
 
   it should "show default chain label when no access key is set" in {

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/BedrockClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/BedrockClientSpec.scala
@@ -1,0 +1,296 @@
+package org.llm4s.llmconnect.provider
+
+import com.sun.net.httpserver.{ HttpExchange, HttpServer }
+import org.llm4s.error.{ AuthenticationError, RateLimitError, ServiceError, ValidationError }
+import org.llm4s.llmconnect.{ ProviderExchange, ProviderExchangeLogging, ProviderExchangeSink }
+import org.llm4s.llmconnect.config.BedrockConfig
+import org.llm4s.llmconnect.model.{ AssistantMessage, CompletionOptions, Conversation, SystemMessage, UserMessage }
+import org.llm4s.model.ModelRegistryService
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues._
+
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import scala.collection.mutable.ListBuffer
+
+class BedrockClientSpec extends AnyFlatSpec with Matchers {
+
+  private given ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+
+  private def withServer(handler: HttpExchange => Unit)(test: String => Any): Unit = {
+    val server = HttpServer.create(new InetSocketAddress("localhost", 0), 0)
+    server.createContext("/", exchange => handler(exchange))
+    server.start()
+    val baseUrl = s"http://localhost:${server.getAddress.getPort}"
+    try test(baseUrl)
+    finally server.stop(0)
+  }
+
+  private def config(endpointUrl: String): BedrockConfig =
+    BedrockConfig(
+      region = "us-east-1",
+      model = "amazon.titan-text-express-v1",
+      contextWindow = 32000,
+      reserveCompletion = 4096,
+      accessKeyId = Some("test-key-id"),
+      secretAccessKey = Some("test-secret-key"),
+      endpointUrl = Some(endpointUrl)
+    )
+
+  private def conversation: Conversation = Conversation(Seq(UserMessage("Hello")))
+
+  private def sendJson(exchange: HttpExchange, statusCode: Int, body: String): Unit = {
+    val bytes = body.getBytes(StandardCharsets.UTF_8)
+    exchange.getResponseHeaders.add("Content-Type", "application/json")
+    exchange.sendResponseHeaders(statusCode, bytes.length)
+    val os = exchange.getResponseBody
+    os.write(bytes)
+    os.close()
+  }
+
+  private def bedrockSuccessResponse(text: String): String =
+    s"""{
+       |  "output": {
+       |    "message": {
+       |      "role": "assistant",
+       |      "content": [{"text": "$text"}]
+       |    }
+       |  },
+       |  "stopReason": "end_turn",
+       |  "usage": {
+       |    "inputTokens": 10,
+       |    "outputTokens": 8,
+       |    "totalTokens": 18
+       |  }
+       |}""".stripMargin
+
+  "BedrockClient.complete" should "parse a successful Bedrock Converse response" in withServer { exchange =>
+    sendJson(exchange, 200, bedrockSuccessResponse("Hello! How can I help you?"))
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val result = client.complete(conversation, CompletionOptions())
+    result.fold(
+      err => fail(s"Expected Right, got Left($err)"),
+      completion => {
+        completion.content shouldBe "Hello! How can I help you?"
+        completion.model shouldBe "amazon.titan-text-express-v1"
+        completion.usage.isDefined shouldBe true
+        completion.usage.foreach { u =>
+          u.promptTokens shouldBe 10
+          u.completionTokens shouldBe 8
+          u.totalTokens shouldBe 18
+        }
+      }
+    )
+  }
+
+  it should "return correct context window" in {
+    val cfg    = config("http://localhost:9999")
+    val client = new BedrockClient(cfg)
+    client.getContextWindow() shouldBe 32000
+  }
+
+  it should "return correct reserve completion" in {
+    val cfg    = config("http://localhost:9999")
+    val client = new BedrockClient(cfg)
+    client.getReserveCompletion() shouldBe 4096
+  }
+
+  it should "handle response with empty content blocks gracefully" in withServer { exchange =>
+    val body =
+      """{
+        |  "output": {
+        |    "message": {
+        |      "role": "assistant",
+        |      "content": []
+        |    }
+        |  },
+        |  "stopReason": "end_turn",
+        |  "usage": {"inputTokens": 5, "outputTokens": 0, "totalTokens": 5}
+        |}""".stripMargin
+    sendJson(exchange, 200, body)
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val result = client.complete(conversation, CompletionOptions())
+    result.fold(
+      err => fail(s"Expected Right, got Left($err)"),
+      completion => {
+        completion.content shouldBe ""
+        completion.toolCalls shouldBe empty
+      }
+    )
+  }
+
+  it should "map HTTP 403 to AuthenticationError" in withServer { exchange =>
+    val body =
+      """{
+        |  "__type": "AccessDeniedException",
+        |  "message": "User is not authorized to perform bedrock:InvokeModel"
+        |}""".stripMargin
+    sendJson(exchange, 403, body)
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val result = client.complete(conversation, CompletionOptions())
+    result.fold(
+      err => err shouldBe a[AuthenticationError],
+      _ => fail("Expected Left(AuthenticationError)")
+    )
+  }
+
+  it should "map HTTP 429 to RateLimitError" in withServer { exchange =>
+    val body =
+      """{
+        |  "__type": "ThrottlingException",
+        |  "message": "Too many requests"
+        |}""".stripMargin
+    sendJson(exchange, 429, body)
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val result = client.complete(conversation, CompletionOptions())
+    result.fold(
+      err => err shouldBe a[RateLimitError],
+      _ => fail("Expected Left(RateLimitError)")
+    )
+  }
+
+  it should "map HTTP 400 to ValidationError" in withServer { exchange =>
+    val body =
+      """{
+        |  "__type": "ValidationException",
+        |  "message": "Input validation failed"
+        |}""".stripMargin
+    sendJson(exchange, 400, body)
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val result = client.complete(conversation, CompletionOptions())
+    result.fold(
+      err => err shouldBe a[ValidationError],
+      _ => fail("Expected Left(ValidationError)")
+    )
+  }
+
+  it should "map HTTP 500 to ServiceError" in withServer { exchange =>
+    val body =
+      """{
+        |  "__type": "InternalServerException",
+        |  "message": "Internal server error"
+        |}""".stripMargin
+    sendJson(exchange, 500, body)
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val result = client.complete(conversation, CompletionOptions())
+    result.fold(
+      err => err shouldBe a[ServiceError],
+      _ => fail("Expected Left(ServiceError)")
+    )
+  }
+
+  it should "handle multi-turn conversations including system messages" in withServer { exchange =>
+    sendJson(exchange, 200, bedrockSuccessResponse("Sure, I can help!"))
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val multiConv = Conversation(
+      Seq(
+        SystemMessage("You are a helpful assistant."),
+        UserMessage("Hello"),
+        AssistantMessage(Some("Hi there!"), Seq.empty),
+        UserMessage("What is 2+2?")
+      )
+    )
+    val result = client.complete(multiConv, CompletionOptions())
+    result.fold(
+      err => fail(s"Expected Right, got Left($err)"),
+      completion => completion.content shouldBe "Sure, I can help!"
+    )
+  }
+
+  it should "record provider exchanges when logging is enabled" in withServer { exchange =>
+    sendJson(exchange, 200, bedrockSuccessResponse("Logged response"))
+  } { baseUrl =>
+    val exchanges = ListBuffer.empty[ProviderExchange]
+    val sink = new ProviderExchangeSink {
+      override def record(exchange: ProviderExchange): Unit = exchanges += exchange
+    }
+    val client = new BedrockClient(
+      config(baseUrl),
+      exchangeLogging = ProviderExchangeLogging.Enabled(sink)
+    )
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isRight shouldBe true
+    exchanges should have size 1
+    exchanges.head.provider shouldBe "bedrock"
+    exchanges.head.model shouldBe Some("amazon.titan-text-express-v1")
+    exchanges.head.requestBody should include("Hello")
+    exchanges.head.responseBody.value should include("Logged response")
+  }
+
+  it should "apply maxTokens from CompletionOptions" in withServer { exchange =>
+    sendJson(exchange, 200, bedrockSuccessResponse("Short response"))
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val result = client.complete(conversation, CompletionOptions(maxTokens = Some(100)))
+    result.fold(
+      err => fail(s"Expected Right, got Left($err)"),
+      completion => completion.content shouldBe "Short response"
+    )
+  }
+
+  "BedrockClient.streamComplete" should "emit full response as single chunk and return completion" in withServer {
+    exchange =>
+      sendJson(exchange, 200, bedrockSuccessResponse("Streamed response"))
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val chunks = ListBuffer.empty[org.llm4s.llmconnect.model.StreamedChunk]
+
+    val result = client.streamComplete(conversation, CompletionOptions(), chunk => chunks += chunk)
+
+    result.fold(
+      err => fail(s"Expected Right, got Left($err)"),
+      completion => {
+        completion.content shouldBe "Streamed response"
+        chunks should have size 1
+        chunks.head.content shouldBe Some("Streamed response")
+        chunks.head.finishReason shouldBe Some("stop")
+      }
+    )
+  }
+
+  it should "propagate errors from the underlying converse call" in withServer { exchange =>
+    val body =
+      """{
+        |  "__type": "ThrottlingException",
+        |  "message": "Too many requests"
+        |}""".stripMargin
+    sendJson(exchange, 429, body)
+  } { baseUrl =>
+    val client = new BedrockClient(config(baseUrl))
+    val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+    result.fold(
+      err => err shouldBe a[RateLimitError],
+      _ => fail("Expected Left(RateLimitError)")
+    )
+  }
+
+  "BedrockClient ujsonToDocument / documentToUjson" should "round-trip a JSON object" in {
+    val cfg    = config("http://localhost:9999")
+    val client = new BedrockClient(cfg)
+
+    val original = ujson.Obj(
+      "name"   -> "tool",
+      "count"  -> 42.0,
+      "active" -> true,
+      "tags"   -> ujson.Arr("a", "b"),
+      "meta"   -> ujson.Obj("key" -> "value")
+    )
+    val doc       = client.ujsonToDocument(original)
+    val roundTrip = client.documentToUjson(doc)
+
+    roundTrip("name").str shouldBe "tool"
+    roundTrip("count").num shouldBe 42.0
+    roundTrip("active").bool shouldBe true
+    roundTrip("tags").arr.map(_.str).toSeq shouldBe Seq("a", "b")
+    roundTrip("meta")("key").str shouldBe "value"
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 class ProviderKindSpec extends AnyFlatSpec with Matchers:
 
   "ProviderKind" should "expose all expected provider instances" in {
-    ProviderKind.all should have size 10
+    ProviderKind.all should have size 11
     (ProviderKind.all should contain).allOf(
       ProviderKind.OpenAI,
       ProviderKind.Azure,
@@ -18,7 +18,8 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       ProviderKind.Gemini,
       ProviderKind.Cohere,
       ProviderKind.DeepSeek,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.Bedrock
     )
   }
 
@@ -33,6 +34,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     ProviderKind.DeepSeek.name shouldBe "deepseek"
     ProviderKind.Cohere.name shouldBe "cohere"
     ProviderKind.Mistral.name shouldBe "mistral"
+    ProviderKind.Bedrock.name shouldBe "bedrock"
   }
 
   "ProviderKind.fromName" should "parse supported providers case-insensitively" in {
@@ -47,6 +49,8 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     ProviderKind.fromName("DEEPSEEK") shouldBe Some(ProviderKind.DeepSeek)
     ProviderKind.fromName("COHERE") shouldBe Some(ProviderKind.Cohere)
     ProviderKind.fromName("MISTRAL") shouldBe Some(ProviderKind.Mistral)
+    ProviderKind.fromName("BEDROCK") shouldBe Some(ProviderKind.Bedrock)
+    ProviderKind.fromName("bedrock") shouldBe Some(ProviderKind.Bedrock)
   }
 
   it should "return None for unknown providers" in {
@@ -72,6 +76,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       case ProviderKind.DeepSeek   => "cloud-deepseek"
       case ProviderKind.Cohere     => "cloud-cohere"
       case ProviderKind.Mistral    => "cloud-mistral"
+      case ProviderKind.Bedrock    => "cloud-bedrock"
 
     describe(ProviderKind.OpenAI) shouldBe "cloud-openai"
     describe(ProviderKind.Ollama) shouldBe "local"

--- a/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
@@ -372,6 +372,11 @@ private[providersetup] object ProviderSetupRuntime:
           apiKey = input.flatMap(_.apiKey).getOrElse(cfg.apiKey),
           baseUrl = input.flatMap(_.baseUrl).getOrElse(cfg.baseUrl)
         )
+      case cfg: BedrockConfig =>
+        cfg.copy(
+          model = input.flatMap(_.model).getOrElse(cfg.model),
+          region = input.flatMap(_.baseUrl).getOrElse(cfg.region)
+        )
 
   def demoCompletionCmd(
     providerConfig: ProviderConfig,
@@ -580,3 +585,4 @@ private[providersetup] object ProviderSetupRuntime:
       case cfg: CohereConfig    => cfg.copy(model = modelName)
       case cfg: MistralConfig   => cfg.copy(model = modelName)
       case cfg: ZaiConfig       => cfg.copy(model = modelName)
+      case cfg: BedrockConfig   => cfg.copy(model = modelName)

--- a/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
@@ -141,6 +141,7 @@ object PrometheusMetricsExample {
                 case _: org.llm4s.llmconnect.config.DeepSeekConfig  => "deepseek"
                 case _: org.llm4s.llmconnect.config.CohereConfig    => "cohere"
                 case _: org.llm4s.llmconnect.config.MistralConfig   => "mistral"
+                case _: org.llm4s.llmconnect.config.BedrockConfig   => "bedrock"
               }
 
               println(s"Using model: ${config.model}")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,8 +84,9 @@ object Deps {
   val cask       = "com.lihaoyi" %% "cask" % Versions.cask
 
   // AWS SDK
-  val awsS3      = "software.amazon.awssdk" % "s3"  % Versions.awsSdk
-  val awsSts     = "software.amazon.awssdk" % "sts" % Versions.awsSdk
+  val awsS3             = "software.amazon.awssdk" % "s3"              % Versions.awsSdk
+  val awsSts            = "software.amazon.awssdk" % "sts"             % Versions.awsSdk
+  val awsBedrockRuntime = "software.amazon.awssdk" % "bedrockruntime"  % Versions.awsSdk
 
   val opentelemetryApi = "io.opentelemetry" % "opentelemetry-api" % Versions.opentelemetry
   val opentelemetrySdk = "io.opentelemetry" % "opentelemetry-sdk" % Versions.opentelemetry


### PR DESCRIPTION
## Summary

Implements `BedrockClient` for [issue #1008](https://github.com/llm4s/llm4s/issues/1008) — a full `LLMClient` backed by the AWS Bedrock Converse API.

- **`BedrockConfig`** — typed config with `region`, `model`, optional `accessKeyId`/`secretAccessKey`, and `endpointUrl` (for test override)
- **`BedrockClient`** — implements `complete()` and `streamComplete()` via the Bedrock Converse API; streaming falls back to a single-chunk emit (true SSE via `ConverseStream` can follow in a separate PR)
- **Authentication** — uses `DefaultCredentialsProvider` (env vars, `~/.aws/credentials`, EC2/ECS instance role); falls back to `StaticCredentialsProvider` when explicit credentials are in config
- **Error mapping** — `ThrottlingException` → `RateLimitError`, `AccessDeniedException` → `AuthenticationError`, `ValidationException` → `ValidationError`, other `BedrockRuntimeException` → `ServiceError`
- **Provider registration** — `bedrock/` prefix wired in `LLMConnect.buildClient()`, `LLMConnect.fromProvider()`, and `NamedProviderLoader`; `ProviderKind.Bedrock` added to enum
- **14 unit tests** (`BedrockClientSpec`) using a local `HttpServer` via `endpointUrl` — no mocking, no live AWS calls

## Test plan

- [x] `sbt "core/testOnly org.llm4s.llmconnect.provider.BedrockClientSpec"` — 14/14 pass
- [x] `sbt "core/testOnly org.llm4s.types.ProviderKindSpec"` — 6/6 pass
- [x] `sbt "core/test"` — all 6824 tests pass

## Environment variables

```bash
LLM_MODEL=bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
AWS_REGION=us-east-1
AWS_ACCESS_KEY_ID=...
AWS_SECRET_ACCESS_KEY=...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)