### PR TITLE
feat(test): integration tests for RAG pipeline with Ollama embeddings and pgvector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,11 @@ jobs:
 
   # Tier 3: Ollama integration tests — verifies full round-trip against a real
   # local LLM. Only runs on pushes to main to avoid slowing down PR builds.
+  #
+  # Carries a pgvector service as well as Ollama, because the RAG pipeline suite needs both:
+  # real embeddings are the whole point of it, and pgvector is where the hybrid-search half
+  # stores them. A suite declares exactly one tier, so the tier its scarcer dependency
+  # belongs to has to supply the rest.
   ollama-integration:
     name: Ollama Integration
     needs: quick-checks
@@ -396,6 +401,20 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
 
     steps:
       - uses: actions/checkout@v7
@@ -423,14 +442,22 @@ jobs:
             sleep 1
           done
 
-      - name: Pull test model
-        run: ollama pull qwen2.5:0.5b
+      # Two models: one to answer with, one to embed with. RAGPipelineOllamaIntegrationSpec
+      # is the only suite in the repo that exercises retrieval against a real embedding
+      # model, so leaving nomic-embed-text out would make it fail rather than skip here.
+      - name: Pull test models
+        run: |
+          ollama pull qwen2.5:0.5b
+          ollama pull nomic-embed-text
 
       - name: Run Ollama integration tests
         env:
-          # This job installs Ollama and pulls the model, so "Ollama not available" here is a
-          # failure, not a reason to skip.
+          # This job installs Ollama, pulls the models and runs pgvector, so "not available"
+          # here is a failure, not a reason to skip.
           LLM4S_IT_STRICT: "true"
+          PGVECTOR_TEST_URL: jdbc:postgresql://localhost:5432/postgres
+          PGVECTOR_USER: postgres
+          PGVECTOR_PASSWORD: postgres
         run: sbt testOllama
 
   # Tier 2: containerised workspace tests. Split from the `integration-tests` job because

--- a/modules/it/src/test/scala/org/llm4s/rag/RAGPipelineOllamaIntegrationSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/rag/RAGPipelineOllamaIntegrationSpec.scala
@@ -1,442 +1,346 @@
 package org.llm4s.rag
 
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Ollama
 import org.llm4s.llmconnect.EmbeddingClient
 import org.llm4s.llmconnect.config.{ EmbeddingProviderConfig, OllamaConfig }
 import org.llm4s.llmconnect.provider.{ OllamaClient, OllamaEmbeddingProvider }
 import org.llm4s.model.ModelRegistryService
-import org.llm4s.rag.permissions.pg.PgSearchIndex
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.util.Try
+import scala.util.{ Try, Using }
 
 /**
- * Full end-to-end integration tests for the RAG pipeline using:
- * - Ollama for embeddings (nomic-embed-text model)
- * - PostgreSQL with pgvector for vector storage
- * - Hybrid search (vector + keyword)
- * - An OllamaClient LLM for answer generation
+ * The RAG pipeline end to end against real components: Ollama embeddings
+ * (`nomic-embed-text`), pgvector storage, hybrid keyword search, and an Ollama LLM
+ * generating the answer.
  *
- * Prerequisites:
- * - Ollama running locally on port 11434 with nomic-embed-text pulled:
- *     ollama pull nomic-embed-text
- * - PostgreSQL with pgvector extension:
- *     export PGVECTOR_TEST_URL="jdbc:postgresql://localhost:5432/postgres"
- * - Set OLLAMA_AVAILABLE=true to opt in to these tests
+ * This is the only suite that exercises retrieval with a real embedding model. Every other
+ * RAG test mocks the embeddings, which proves the pipeline runs but says nothing about
+ * whether it retrieves the right thing - see `RAGPipelineIntegrationSpec` in `modules/rag`
+ * for the mocked equivalent.
  *
- * Run with:
- *   sbt "it/testOnly org.llm4s.rag.RAGPipelineOllamaIntegrationSpec"
+ * Tier `@Ollama`: needs a local Ollama with **both** `nomic-embed-text` (embeddings) and
+ * `qwen2.5:0.5b` (answers) pulled, plus PostgreSQL with pgvector on `PGVECTOR_TEST_URL`.
+ * The `ollama-integration` CI job provides all three. Under `LLM4S_IT_STRICT=true`, which
+ * that job sets, a missing dependency fails rather than skips.
+ *
+ * Non-determinism strategy: never assert on generated text. Assertions are either
+ * structural (which score channels a result carries) or coarse-grained semantic (the
+ * relevant document appears in the top few), never "the model said X".
  */
+@Ollama
 class RAGPipelineOllamaIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
-  // Environment guards - read once at test class init time
-  private val ollamaAvailableEnv = Option(System.getenv("OLLAMA_AVAILABLE")).filter(_.nonEmpty)
-  private val pgUrlEnv           = Option(System.getenv("PGVECTOR_TEST_URL")).filter(_.nonEmpty)
-  private val pgUserEnv          = Option(System.getenv("PGVECTOR_TEST_USER")).getOrElse("postgres")
-  private val pgPasswordEnv      = Option(System.getenv("PGVECTOR_TEST_PASSWORD")).getOrElse("")
+  private given ModelRegistryService = ModelRegistryService.default().toOption.get
 
-  private val ollamaBaseUrl    = "http://localhost:11434"
-  private val embeddingModel   = "nomic-embed-text"
-  private val llmModel         = "qwen2.5:0.5b"
-  private val testVectorTable  = s"rag_pipeline_test_${System.currentTimeMillis()}"
-  private val testKeywordTable = s"rag_pipeline_kw_test_${System.currentTimeMillis()}"
+  private val ollamaBaseUrl  = "http://localhost:11434"
+  private val embeddingModel = "nomic-embed-text"
+  private val embeddingDims  = 768
+  private val llmModel       = "qwen2.5:0.5b"
 
-  private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
+  private val pgUrl      = sys.env.get("PGVECTOR_TEST_URL")
+  private val pgUser     = sys.env.getOrElse("PGVECTOR_USER", "postgres")
+  private val pgPassword = sys.env.getOrElse("PGVECTOR_PASSWORD", "postgres")
 
-  /** Check Ollama is reachable and both required models are available. */
-  private lazy val ollamaReachable: Boolean =
+  private val vectorTable  = "rag_pipeline_ollama_vectors"
+  private val keywordTable = "rag_pipeline_ollama_keywords"
+
+  /** True when Ollama is up and serving `model`. */
+  private def ollamaServes(model: String): Boolean =
     Try {
-      val uri        = java.net.URI.create(s"$ollamaBaseUrl/api/tags")
-      val connection = uri.toURL.openConnection().asInstanceOf[java.net.HttpURLConnection]
+      val connection = java.net.URI
+        .create(s"$ollamaBaseUrl/api/tags")
+        .toURL
+        .openConnection()
+        .asInstanceOf[java.net.HttpURLConnection]
       connection.setConnectTimeout(3000)
       connection.setReadTimeout(3000)
       connection.setRequestMethod("GET")
-      val code = connection.getResponseCode
-      if (code == 200) {
+      if (connection.getResponseCode == 200) {
         val source = scala.io.Source.fromInputStream(connection.getInputStream)
-        try source.mkString.contains(embeddingModel)
+        try source.mkString.contains(model)
         finally source.close()
       } else false
     }.getOrElse(false)
 
-  /** Shared embedding client used across all tests. */
-  private lazy val embeddingClient: EmbeddingClient = {
-    val providerCfg = EmbeddingProviderConfig(
-      baseUrl = ollamaBaseUrl,
-      model = embeddingModel,
-      apiKey = "not-required"
-    )
-    new EmbeddingClient(OllamaEmbeddingProvider.fromConfig(providerCfg))
-  }
+  private lazy val embeddingsAvailable: Boolean = ollamaServes(embeddingModel)
+  private lazy val llmAvailable: Boolean        = ollamaServes(llmModel)
 
-  /** Sample documents that cover distinct topics to verify semantic relevance. */
-  private val sampleDocuments: Seq[(String, String)] = Seq(
-    ("doc-scala-1",
-     "Scala is a statically typed programming language that combines object-oriented and functional programming. It runs on the Java Virtual Machine."),
-    ("doc-scala-2",
-     "Scala's type system supports higher-kinded types, path-dependent types, and implicit parameters for powerful type-safe abstractions."),
-    ("doc-python-1",
-     "Python is a dynamically typed language known for its simplicity and readability. It is widely used in data science and machine learning."),
-    ("doc-python-2",
-     "Python supports multiple programming paradigms including procedural, object-oriented, and functional programming styles."),
-    ("doc-database-1",
-     "PostgreSQL is an open-source relational database management system with strong ACID guarantees and JSON support."),
-    ("doc-database-2",
-     "pgvector is a PostgreSQL extension that adds vector similarity search, enabling semantic search and AI-powered retrieval in the database."),
-    ("doc-llm-1",
-     "Large language models are neural networks trained on vast text corpora that can generate coherent text and answer questions."),
-    ("doc-llm-2",
-     "RAG, or Retrieval-Augmented Generation, enhances LLM responses by retrieving relevant documents and injecting them as context."),
-    ("doc-ollama-1",
-     "Ollama is an open-source tool for running large language models locally on consumer hardware without requiring cloud API keys."),
-    ("doc-ollama-2",
-     "The nomic-embed-text model from Ollama generates dense vector embeddings for text, suitable for semantic search applications.")
+  private lazy val embeddingClient: EmbeddingClient =
+    new EmbeddingClient(
+      OllamaEmbeddingProvider.fromConfig(
+        EmbeddingProviderConfig(baseUrl = ollamaBaseUrl, model = embeddingModel, apiKey = "not-required")
+      )
+    )
+
+  /** Ten documents over five topics, two documents each, so retrieval has to discriminate. */
+  private val corpus: Seq[(String, String)] = Seq(
+    "doc-scala-1" ->
+      "Scala is a statically typed programming language that combines object-oriented and functional programming. It runs on the Java Virtual Machine.",
+    "doc-scala-2" ->
+      "Scala's type system supports higher-kinded types, path-dependent types, and implicit parameters for powerful type-safe abstractions.",
+    "doc-python-1" ->
+      "Python is a dynamically typed language known for its simplicity and readability. It is widely used in data science and machine learning.",
+    "doc-python-2" ->
+      "Python supports multiple programming paradigms including procedural, object-oriented, and functional programming styles.",
+    "doc-database-1" ->
+      "PostgreSQL is an open-source relational database management system with strong ACID guarantees and JSON support.",
+    "doc-database-2" ->
+      "pgvector is a PostgreSQL extension that adds vector similarity search, enabling semantic search and AI-powered retrieval in the database.",
+    "doc-llm-1" ->
+      "Large language models are neural networks trained on vast text corpora that can generate coherent text and answer questions.",
+    "doc-llm-2" ->
+      "RAG, or Retrieval-Augmented Generation, enhances LLM responses by retrieving relevant documents and injecting them as context.",
+    "doc-ollama-1" ->
+      "Ollama is an open-source tool for running large language models locally on consumer hardware without requiring cloud API keys.",
+    "doc-ollama-2" ->
+      "The nomic-embed-text model from Ollama generates dense vector embeddings for text, suitable for semantic search applications."
   )
 
-  // Track created RAG instances for cleanup
-  private var ragInstances: List[RAG]      = Nil
-  private var pgSearchIndex: Option[PgSearchIndex] = None
+  /**
+   * One in-memory pipeline, ingested once, shared by every read-only search test.
+   *
+   * Embedding ten documents is a real network round trip per document; rebuilding per test
+   * multiplied that by the number of tests for no added coverage.
+   */
+  private var sharedRag: Option[RAG] = None
+
+  /** Instances to close in `afterAll`, including the per-test ones. */
+  private var openRags: List[RAG] = Nil
+
+  private def register(rag: RAG): RAG = { openRags = rag :: openRags; rag }
+
+  private def buildInMemoryRag(): RAG = {
+    val config = RAGConfig.default
+      .withEmbeddings(EmbeddingProvider.Ollama, embeddingModel, embeddingDims)
+      .inMemory
+    register(
+      RAG
+        .buildWithClient(config, embeddingClient)
+        .fold(e => fail(s"Failed to build in-memory RAG: ${e.message}"), identity)
+    )
+  }
+
+  private def buildPgHybridRag(): RAG = {
+    val url = pgUrl.getOrElse(fail("PGVECTOR_TEST_URL not set"))
+    val config = RAGConfig.default
+      .withEmbeddings(EmbeddingProvider.Ollama, embeddingModel, embeddingDims)
+      .withPgHybrid(url, pgUser, pgPassword, vectorTable, keywordTable)
+    register(
+      RAG
+        .buildWithClient(config, embeddingClient)
+        .fold(e => fail(s"Failed to build pgvector hybrid RAG: ${e.message}"), identity)
+    )
+  }
+
+  private def ingestCorpus(rag: RAG): Unit =
+    corpus.foreach { case (id, text) =>
+      rag.ingestText(text, id).fold(e => fail(s"Failed to ingest $id: ${e.message}"), _ => ())
+    }
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    // Attempt to initialise pgvector for the hybrid and agent tests
-    pgUrlEnv.foreach { url =>
-      PgSearchIndex.fromJdbcUrl(url, pgUserEnv, pgPasswordEnv, testVectorTable) match {
-        case Right(index) =>
-          index.initializeSchema() match {
-            case Right(_) => pgSearchIndex = Some(index)
-            case Left(e)  => println(s"[RAGPipelineOllamaIntegrationSpec] Schema init failed: ${e.message}")
-          }
-        case Left(e) =>
-          println(s"[RAGPipelineOllamaIntegrationSpec] PgSearchIndex creation failed: ${e.message}")
-      }
+    if (embeddingsAvailable) {
+      val rag = buildInMemoryRag()
+      ingestCorpus(rag)
+      sharedRag = Some(rag)
     }
   }
 
   override def afterAll(): Unit = {
-    // Close all RAG instances
-    ragInstances.foreach(r => Try(r.close()))
-    // Drop test tables and close the search index
-    pgSearchIndex.foreach { idx =>
-      Try(idx.dropSchema())
-      Try(idx.close())
-    }
+    openRags.foreach(rag => Try(rag.close()))
+    dropOwnTables()
     super.afterAll()
   }
 
-  /** Guard that skips a test when Ollama is not opted in or not reachable. */
-  private def requireOllama(): Unit = {
-    assume(ollamaAvailableEnv.isDefined, "OLLAMA_AVAILABLE env var not set - skipping Ollama RAG pipeline test")
-    assume(ollamaReachable, s"Ollama not reachable at $ollamaBaseUrl with model $embeddingModel")
-  }
-
-  /** Guard that additionally requires pgvector. */
-  private def requireOllamaAndPg(): Unit = {
-    requireOllama()
-    assume(pgUrlEnv.isDefined, "PGVECTOR_TEST_URL env var not set - skipping pgvector RAG pipeline test")
-  }
-
-  // ---------------------------------------------------------------------------
-  // Helper: build an in-memory RAG with Ollama embeddings
-  // ---------------------------------------------------------------------------
-  private def buildInMemoryRag(): RAG = {
-    val ragConfig = RAGConfig.default
-      .withEmbeddings(EmbeddingProvider.Ollama, embeddingModel, 768)
-      .inMemory
-
-    val rag = RAG
-      .buildWithClient(ragConfig, embeddingClient)
-      .fold(e => fail(s"Failed to build in-memory RAG: ${e.message}"), identity)
-
-    ragInstances = rag :: ragInstances
-    rag
-  }
-
-  // ---------------------------------------------------------------------------
-  // Helper: build a pgvector-backed RAG with hybrid search
-  // ---------------------------------------------------------------------------
-  private def buildPgHybridRag(): RAG = {
-    val url = pgUrlEnv.getOrElse(fail("PGVECTOR_TEST_URL not set"))
-
-    val ragConfig = RAGConfig.default
-      .withEmbeddings(EmbeddingProvider.Ollama, embeddingModel, 768)
-      .withPgHybrid(url, pgUserEnv, pgPasswordEnv, testVectorTable, testKeywordTable)
-
-    val rag = RAG
-      .buildWithClient(ragConfig, embeddingClient)
-      .fold(e => fail(s"Failed to build pgvector hybrid RAG: ${e.message}"), identity)
-
-    ragInstances = rag :: ragInstances
-    rag
-  }
-
-  // ---------------------------------------------------------------------------
-  // 1. Index phase: embed and store documents in memory
-  // ---------------------------------------------------------------------------
-  "RAGPipelineOllamaIntegrationSpec (index phase)" should "ingest 10 documents with Ollama embeddings into in-memory store" in {
-    requireOllama()
-
-    val rag = buildInMemoryRag()
-
-    sampleDocuments.foreach { case (docId, content) =>
-      val result = rag.ingestText(content, docId)
-      result.isRight shouldBe true
+  /**
+   * Drop exactly the two tables this suite created, whether or not a test got that far.
+   *
+   * Deliberately plain JDBC rather than `PgSearchIndex.dropSchema()`, which is the wrong
+   * tool twice over: it drops the shared `llm4s_collections` and `llm4s_principals` tables
+   * (CASCADE) that this suite never creates and `PgSearchIndexSpec` depends on, and it does
+   * not drop the vector or keyword table that `withPgHybrid` actually created. Against a
+   * shared database that combination is a cross-suite failure that only shows up
+   * intermittently; against CI's throwaway container it hides entirely.
+   */
+  private def dropOwnTables(): Unit =
+    pgUrl.foreach { url =>
+      Try {
+        Using.resource(java.sql.DriverManager.getConnection(url, pgUser, pgPassword)) { conn =>
+          Using.resource(conn.createStatement()) { stmt =>
+            stmt.execute(s"DROP TABLE IF EXISTS $vectorTable")
+            stmt.execute(s"DROP TABLE IF EXISTS $keywordTable")
+          }
+        }
+      }
     }
 
-    rag.documentCount shouldBe sampleDocuments.size
-    rag.chunkCount should be >= sampleDocuments.size
+  private def requireEmbeddings(): RAG = {
+    Tier.require(embeddingsAvailable, s"Ollama at $ollamaBaseUrl is not serving $embeddingModel")
+    sharedRag.getOrElse(fail("shared pipeline was not built despite Ollama being available"))
   }
+
+  private def requirePg(): Unit = {
+    Tier.require(embeddingsAvailable, s"Ollama at $ollamaBaseUrl is not serving $embeddingModel")
+    Tier.require(pgUrl.isDefined, "PGVECTOR_TEST_URL is not set, so pgvector is unavailable")
+  }
+
+  /** Chunk ids are `<docId>-chunk-<n>`; assertions are about documents, not chunks. */
+  private def docIdOf(chunkId: String): String = chunkId.replaceFirst("-chunk-\\d+$", "")
+
+  // ---------------------------------------------------------------------------
+  // 1. Index phase
+  // ---------------------------------------------------------------------------
+
+  "RAG with Ollama embeddings (index phase)" should
+    "embed and index every document in the corpus" in {
+      val rag = requireEmbeddings()
+
+      rag.documentCount shouldBe corpus.size
+      rag.chunkCount should be >= corpus.size
+      rag.stats.fold(e => fail(e.message), _.vectorCount) shouldBe rag.chunkCount.toLong
+    }
 
   // ---------------------------------------------------------------------------
   // 2. Semantic search phase
+  //
+  // The point of this suite: with real embeddings, retrieval has to put the topically
+  // relevant document near the top. Asserted as top-3 containment rather than top-1, so a
+  // model update that reorders near-ties does not turn this red.
   // ---------------------------------------------------------------------------
-  "RAGPipelineOllamaIntegrationSpec (search phase)" should "return semantically relevant results for a vector query" in {
-    requireOllama()
 
-    val rag = buildInMemoryRag()
-    sampleDocuments.foreach { case (docId, content) =>
-      rag.ingestText(content, docId).isRight shouldBe true
+  "RAG with Ollama embeddings (search phase)" should
+    "rank the retrieval-augmented-generation document among the top hits for its own topic" in {
+      val rag = requireEmbeddings()
+
+      val hits = rag
+        .query("retrieval augmented generation for language models", topK = Some(3))
+        .fold(e => fail(e.message), identity)
+
+      hits should not be empty
+      (hits.map(r => docIdOf(r.id)) should contain).oneOf("doc-llm-2", "doc-llm-1", "doc-ollama-1")
+      hits.map(_.score) shouldBe hits.map(_.score).sorted(Ordering[Double].reverse)
     }
 
-    // Query about RAG / LLMs – should surface LLM and RAG documents
-    val llmResults = rag.query("retrieval augmented generation", topK = Some(3))
-    llmResults.isRight shouldBe true
-    val llmHits = llmResults.toOption.get
-    llmHits should not be empty
-    // At least one result should be from the LLM or RAG documents
-    val hitIds = llmHits.map(_.id).mkString(" ")
-    hitIds.toLowerCase should (include("llm") or include("rag") or include("ollama"))
+  it should "rank the pgvector document among the top hits for a vector-database query" in {
+    val rag = requireEmbeddings()
 
-    // Query about databases – should surface database documents
-    val dbResults = rag.query("vector similarity search in database", topK = Some(3))
-    dbResults.isRight shouldBe true
-    val dbHits = dbResults.toOption.get
-    dbHits should not be empty
-    // Verify scores are in descending order (top score >= subsequent scores)
-    val scores = dbHits.map(_.score)
-    if (scores.size >= 2) {
-      scores.head should be >= scores.last
-    }
-  }
+    val hits = rag
+      .query("vector similarity search inside a relational database", topK = Some(3))
+      .fold(e => fail(e.message), identity)
 
-  it should "rank top result above lower-ranked results for a specific query" in {
-    requireOllama()
-
-    val rag = buildInMemoryRag()
-    sampleDocuments.foreach { case (docId, content) =>
-      rag.ingestText(content, docId).isRight shouldBe true
-    }
-
-    val results = rag.query("Ollama local language model", topK = Some(5))
-    results.isRight shouldBe true
-    val hits = results.toOption.get
     hits should not be empty
-    // Top score should be >= second score (sorted by relevance)
-    if (hits.size >= 2) {
-      hits.head.score should be >= hits(1).score
+    (hits.map(r => docIdOf(r.id)) should contain).oneOf("doc-database-2", "doc-database-1")
+    hits.map(_.score) shouldBe hits.map(_.score).sorted(Ordering[Double].reverse)
+  }
+
+  it should "return distinct chunks with content, honouring topK" in {
+    val rag = requireEmbeddings()
+
+    val hits = rag.query("Ollama local language model", topK = Some(5)).fold(e => fail(e.message), identity)
+
+    hits.size should be <= 5
+    hits.map(_.id).distinct.size shouldBe hits.size
+    hits.foreach { hit =>
+      hit.id should not be empty
+      hit.content should not be empty
+      hit.vectorScore should be(defined)
     }
   }
 
   // ---------------------------------------------------------------------------
-  // 3. Hybrid search phase (pgvector + keyword)
+  // 3. Hybrid search phase (pgvector + Postgres full-text)
   // ---------------------------------------------------------------------------
-  "RAGPipelineOllamaIntegrationSpec (hybrid search phase)" should "combine vector and keyword scores for hybrid queries" in {
-    requireOllamaAndPg()
+
+  "RAG with Ollama embeddings (hybrid phase)" should
+    "reach documents through both the vector and the keyword channel" in {
+      requirePg()
+
+      val rag = buildPgHybridRag()
+      rag.clear().fold(e => fail(e.message), identity)
+      ingestCorpus(rag)
+
+      // "pgvector" is a rare term, so the keyword channel should find it outright while the
+      // vector channel reaches the same topic by similarity.
+      val hits = rag.query("pgvector semantic search", topK = Some(5)).fold(e => fail(e.message), identity)
+
+      hits should not be empty
+      // A hybrid search that silently degraded to one channel would carry only one score.
+      hits.exists(_.vectorScore.isDefined) shouldBe true
+      hits.exists(_.keywordScore.isDefined) shouldBe true
+      hits.map(r => docIdOf(r.id)) should contain("doc-database-2")
+    }
+
+  it should "clear the pgvector store on request" in {
+    requirePg()
 
     val rag = buildPgHybridRag()
-    rag.clear().isRight shouldBe true
+    ingestCorpus(rag)
+    rag.stats.fold(e => fail(e.message), _.vectorCount) should be > 0L
 
-    sampleDocuments.foreach { case (docId, content) =>
-      val result = rag.ingestText(content, docId)
-      result.isRight shouldBe true
-    }
-
-    // Hybrid query: keyword "pgvector" should hit database docs, vector should reinforce
-    val hybridResults = rag.query("pgvector semantic search", topK = Some(5))
-    hybridResults.isRight shouldBe true
-    val hybridHits = hybridResults.toOption.get
-    hybridHits should not be empty
-
-    // Verify some results were returned and have non-negative scores
-    hybridHits.foreach(r => r.score should be >= 0.0)
-  }
-
-  it should "return results for a keyword-specific query" in {
-    requireOllamaAndPg()
-
-    val rag = buildPgHybridRag()
-    rag.clear().isRight shouldBe true
-
-    sampleDocuments.foreach { case (docId, content) =>
-      rag.ingestText(content, docId).isRight shouldBe true
-    }
-
-    // Keyword-heavy query that should match Scala documents
-    val scalaResults = rag.query("Scala JVM programming language", topK = Some(4))
-    scalaResults.isRight shouldBe true
-    val scalaHits = scalaResults.toOption.get
-    scalaHits should not be empty
-    // Results should be non-empty and have scores
-    scalaHits.foreach(r => r.score should be >= 0.0)
-  }
-
-  it should "clean up the pgvector store after test" in {
-    requireOllamaAndPg()
-
-    val rag = buildPgHybridRag()
-    sampleDocuments.foreach { case (docId, content) =>
-      rag.ingestText(content, docId).isRight shouldBe true
-    }
-
-    val clearResult = rag.clear()
-    clearResult.isRight shouldBe true
-
-    val stats = rag.stats
-    stats.isRight shouldBe true
-    stats.toOption.get.vectorCount shouldBe 0L
+    rag.clear().fold(e => fail(e.message), identity)
+    rag.stats.fold(e => fail(e.message), _.vectorCount) shouldBe 0L
   }
 
   // ---------------------------------------------------------------------------
-  // 4. Agent RAG phase: retrieved context drives LLM completion
+  // 4. Agent RAG phase
   // ---------------------------------------------------------------------------
-  "RAGPipelineOllamaIntegrationSpec (agent RAG phase)" should "generate an answer grounded in retrieved context using OllamaClient" in {
-    assume(
-      ollamaAvailableEnv.isDefined,
-      "OLLAMA_AVAILABLE env var not set - skipping agent RAG test"
-    )
 
-    // Check both embedding model and LLM model are available
-    val llmModelAvailable = Try {
-      val uri        = java.net.URI.create(s"$ollamaBaseUrl/api/tags")
-      val connection = uri.toURL.openConnection().asInstanceOf[java.net.HttpURLConnection]
-      connection.setConnectTimeout(3000)
-      connection.setReadTimeout(3000)
-      connection.setRequestMethod("GET")
-      val code = connection.getResponseCode
-      if (code == 200) {
-        val source = scala.io.Source.fromInputStream(connection.getInputStream)
-        try source.mkString.contains(llmModel)
-        finally source.close()
-      } else false
-    }.getOrElse(false)
+  "RAG with Ollama embeddings (agent phase)" should
+    "answer from the retrieved context using a local model" in {
+      Tier.require(embeddingsAvailable, s"Ollama at $ollamaBaseUrl is not serving $embeddingModel")
+      Tier.require(llmAvailable, s"Ollama at $ollamaBaseUrl is not serving $llmModel")
 
-    assume(ollamaReachable, s"Ollama not reachable at $ollamaBaseUrl with model $embeddingModel")
-    assume(llmModelAvailable, s"Ollama model $llmModel not available - skipping agent RAG test")
-
-    val ollamaCfg = OllamaConfig(
-      model = llmModel,
-      baseUrl = ollamaBaseUrl,
-      contextWindow = 8192,
-      reserveCompletion = 4096
-    )
-    val llmClient = new OllamaClient(ollamaCfg)
-
-    try {
-      val ragConfig = RAGConfig.default
-        .withEmbeddings(EmbeddingProvider.Ollama, embeddingModel, 768)
-        .withLLM(llmClient)
-        .inMemory
-
-      val rag = RAG
-        .buildWithClient(ragConfig, embeddingClient)
-        .fold(e => fail(s"Failed to build agent RAG: ${e.message}"), identity)
-
-      ragInstances = rag :: ragInstances
-
-      // Index sample documents
-      sampleDocuments.foreach { case (docId, content) =>
-        rag.ingestText(content, docId).isRight shouldBe true
-      }
-
-      // Query: should retrieve context and generate an answer
-      val answerResult = rag.queryWithAnswer(
-        "What is RAG and how does it enhance language models?",
-        topK = Some(3)
+      val llmClient = new OllamaClient(
+        OllamaConfig(model = llmModel, baseUrl = ollamaBaseUrl, contextWindow = 8192, reserveCompletion = 4096)
       )
 
-      answerResult.isRight shouldBe true
-      val ragAnswer = answerResult.toOption.get
+      try {
+        val config = RAGConfig.default
+          .withEmbeddings(EmbeddingProvider.Ollama, embeddingModel, embeddingDims)
+          .withLLM(llmClient)
+          .inMemory
+        val rag = register(
+          RAG.buildWithClient(config, embeddingClient).fold(e => fail(s"Failed to build: ${e.message}"), identity)
+        )
+        ingestCorpus(rag)
 
-      // Verify structural properties - never assert on specific LLM output text
-      ragAnswer.answer should not be empty
-      ragAnswer.question should not be empty
-      ragAnswer.contexts should not be empty
-      ragAnswer.contexts.size should be <= 3
+        val answer = rag
+          .queryWithAnswer("What is RAG and how does it enhance language models?", topK = Some(3))
+          .fold(e => fail(e.message), identity)
 
-      // The retrieved contexts should include relevant chunks from our documents
-      val contextContent = ragAnswer.contexts.map(_.content).mkString(" ").toLowerCase
-      // At least some context content should be returned (non-empty)
-      contextContent should not be empty
-    } finally {
-      llmClient.close()
+        // Structural only: a local 0.5b model's wording is not something to assert on.
+        answer.answer.trim should not be empty
+        answer.question shouldBe "What is RAG and how does it enhance language models?"
+        answer.contexts should have size 3
+        answer.contexts.foreach(_.content should not be empty)
+        (answer.contexts.map(c => docIdOf(c.id)) should contain).oneOf("doc-llm-2", "doc-llm-1", "doc-ollama-1")
+      } finally llmClient.close()
     }
-  }
-
-  it should "return contexts that are semantically related to the query" in {
-    requireOllama()
-
-    val rag = buildInMemoryRag()
-    sampleDocuments.foreach { case (docId, content) =>
-      rag.ingestText(content, docId).isRight shouldBe true
-    }
-
-    // Ask about Ollama specifically
-    val searchResult = rag.query("local LLM inference without cloud", topK = Some(3))
-    searchResult.isRight shouldBe true
-    val contexts = searchResult.toOption.get
-    contexts should not be empty
-
-    // All returned contexts should have content
-    contexts.foreach { ctx =>
-      ctx.content should not be empty
-      ctx.id should not be empty
-      ctx.score should be >= 0.0
-    }
-  }
 
   // ---------------------------------------------------------------------------
-  // 5. Cleanup verification
+  // 5. Lifecycle
   // ---------------------------------------------------------------------------
-  "RAGPipelineOllamaIntegrationSpec (cleanup)" should "clear all test data leaving an empty store" in {
-    requireOllama()
 
-    val rag = buildInMemoryRag()
-    sampleDocuments.foreach { case (docId, content) =>
-      rag.ingestText(content, docId).isRight shouldBe true
+  "RAG with Ollama embeddings (lifecycle)" should
+    "support clear followed by re-ingestion" in {
+      Tier.require(embeddingsAvailable, s"Ollama at $ollamaBaseUrl is not serving $embeddingModel")
+
+      // A dedicated pipeline: this test mutates, and the shared one is read-only.
+      val rag = buildInMemoryRag()
+      ingestCorpus(rag)
+      rag.stats.fold(e => fail(e.message), _.vectorCount) should be > 0L
+
+      rag.clear().fold(e => fail(e.message), identity)
+      rag.stats.fold(e => fail(e.message), _.vectorCount) shouldBe 0L
+      rag.query("anything at all").fold(e => fail(e.message), identity) shouldBe empty
+
+      corpus.take(3).foreach { case (id, text) =>
+        rag.ingestText(text, id).fold(e => fail(e.message), _ => ())
+      }
+      rag.stats.fold(e => fail(e.message), _.vectorCount) should be >= 3L
     }
-
-    rag.chunkCount should be > 0
-
-    val clearResult = rag.clear()
-    clearResult.isRight shouldBe true
-
-    val stats = rag.stats
-    stats.isRight shouldBe true
-    val ragStats = stats.toOption.get
-    ragStats.vectorCount shouldBe 0L
-  }
-
-  it should "allow re-ingestion after clearing" in {
-    requireOllama()
-
-    val rag = buildInMemoryRag()
-
-    // First pass
-    sampleDocuments.take(5).foreach { case (docId, content) =>
-      rag.ingestText(content, docId).isRight shouldBe true
-    }
-
-    rag.clear().isRight shouldBe true
-
-    // Second pass after clear
-    sampleDocuments.take(3).foreach { case (docId, content) =>
-      rag.ingestText(content, docId).isRight shouldBe true
-    }
-
-    val stats = rag.stats
-    stats.isRight shouldBe true
-    stats.toOption.get.vectorCount should be >= 1L
-  }
-
 }

--- a/modules/it/src/test/scala/org/llm4s/rag/RAGPipelineOllamaIntegrationSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/rag/RAGPipelineOllamaIntegrationSpec.scala
@@ -1,0 +1,442 @@
+package org.llm4s.rag
+
+import org.llm4s.llmconnect.EmbeddingClient
+import org.llm4s.llmconnect.config.{ EmbeddingProviderConfig, OllamaConfig }
+import org.llm4s.llmconnect.provider.{ OllamaClient, OllamaEmbeddingProvider }
+import org.llm4s.model.ModelRegistryService
+import org.llm4s.rag.permissions.pg.PgSearchIndex
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
+
+/**
+ * Full end-to-end integration tests for the RAG pipeline using:
+ * - Ollama for embeddings (nomic-embed-text model)
+ * - PostgreSQL with pgvector for vector storage
+ * - Hybrid search (vector + keyword)
+ * - An OllamaClient LLM for answer generation
+ *
+ * Prerequisites:
+ * - Ollama running locally on port 11434 with nomic-embed-text pulled:
+ *     ollama pull nomic-embed-text
+ * - PostgreSQL with pgvector extension:
+ *     export PGVECTOR_TEST_URL="jdbc:postgresql://localhost:5432/postgres"
+ * - Set OLLAMA_AVAILABLE=true to opt in to these tests
+ *
+ * Run with:
+ *   sbt "it/testOnly org.llm4s.rag.RAGPipelineOllamaIntegrationSpec"
+ */
+class RAGPipelineOllamaIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  // Environment guards - read once at test class init time
+  private val ollamaAvailableEnv = Option(System.getenv("OLLAMA_AVAILABLE")).filter(_.nonEmpty)
+  private val pgUrlEnv           = Option(System.getenv("PGVECTOR_TEST_URL")).filter(_.nonEmpty)
+  private val pgUserEnv          = Option(System.getenv("PGVECTOR_TEST_USER")).getOrElse("postgres")
+  private val pgPasswordEnv      = Option(System.getenv("PGVECTOR_TEST_PASSWORD")).getOrElse("")
+
+  private val ollamaBaseUrl    = "http://localhost:11434"
+  private val embeddingModel   = "nomic-embed-text"
+  private val llmModel         = "qwen2.5:0.5b"
+  private val testVectorTable  = s"rag_pipeline_test_${System.currentTimeMillis()}"
+  private val testKeywordTable = s"rag_pipeline_kw_test_${System.currentTimeMillis()}"
+
+  private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
+
+  /** Check Ollama is reachable and both required models are available. */
+  private lazy val ollamaReachable: Boolean =
+    Try {
+      val uri        = java.net.URI.create(s"$ollamaBaseUrl/api/tags")
+      val connection = uri.toURL.openConnection().asInstanceOf[java.net.HttpURLConnection]
+      connection.setConnectTimeout(3000)
+      connection.setReadTimeout(3000)
+      connection.setRequestMethod("GET")
+      val code = connection.getResponseCode
+      if (code == 200) {
+        val source = scala.io.Source.fromInputStream(connection.getInputStream)
+        try source.mkString.contains(embeddingModel)
+        finally source.close()
+      } else false
+    }.getOrElse(false)
+
+  /** Shared embedding client used across all tests. */
+  private lazy val embeddingClient: EmbeddingClient = {
+    val providerCfg = EmbeddingProviderConfig(
+      baseUrl = ollamaBaseUrl,
+      model = embeddingModel,
+      apiKey = "not-required"
+    )
+    new EmbeddingClient(OllamaEmbeddingProvider.fromConfig(providerCfg))
+  }
+
+  /** Sample documents that cover distinct topics to verify semantic relevance. */
+  private val sampleDocuments: Seq[(String, String)] = Seq(
+    ("doc-scala-1",
+     "Scala is a statically typed programming language that combines object-oriented and functional programming. It runs on the Java Virtual Machine."),
+    ("doc-scala-2",
+     "Scala's type system supports higher-kinded types, path-dependent types, and implicit parameters for powerful type-safe abstractions."),
+    ("doc-python-1",
+     "Python is a dynamically typed language known for its simplicity and readability. It is widely used in data science and machine learning."),
+    ("doc-python-2",
+     "Python supports multiple programming paradigms including procedural, object-oriented, and functional programming styles."),
+    ("doc-database-1",
+     "PostgreSQL is an open-source relational database management system with strong ACID guarantees and JSON support."),
+    ("doc-database-2",
+     "pgvector is a PostgreSQL extension that adds vector similarity search, enabling semantic search and AI-powered retrieval in the database."),
+    ("doc-llm-1",
+     "Large language models are neural networks trained on vast text corpora that can generate coherent text and answer questions."),
+    ("doc-llm-2",
+     "RAG, or Retrieval-Augmented Generation, enhances LLM responses by retrieving relevant documents and injecting them as context."),
+    ("doc-ollama-1",
+     "Ollama is an open-source tool for running large language models locally on consumer hardware without requiring cloud API keys."),
+    ("doc-ollama-2",
+     "The nomic-embed-text model from Ollama generates dense vector embeddings for text, suitable for semantic search applications.")
+  )
+
+  // Track created RAG instances for cleanup
+  private var ragInstances: List[RAG]      = Nil
+  private var pgSearchIndex: Option[PgSearchIndex] = None
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    // Attempt to initialise pgvector for the hybrid and agent tests
+    pgUrlEnv.foreach { url =>
+      PgSearchIndex.fromJdbcUrl(url, pgUserEnv, pgPasswordEnv, testVectorTable) match {
+        case Right(index) =>
+          index.initializeSchema() match {
+            case Right(_) => pgSearchIndex = Some(index)
+            case Left(e)  => println(s"[RAGPipelineOllamaIntegrationSpec] Schema init failed: ${e.message}")
+          }
+        case Left(e) =>
+          println(s"[RAGPipelineOllamaIntegrationSpec] PgSearchIndex creation failed: ${e.message}")
+      }
+    }
+  }
+
+  override def afterAll(): Unit = {
+    // Close all RAG instances
+    ragInstances.foreach(r => Try(r.close()))
+    // Drop test tables and close the search index
+    pgSearchIndex.foreach { idx =>
+      Try(idx.dropSchema())
+      Try(idx.close())
+    }
+    super.afterAll()
+  }
+
+  /** Guard that skips a test when Ollama is not opted in or not reachable. */
+  private def requireOllama(): Unit = {
+    assume(ollamaAvailableEnv.isDefined, "OLLAMA_AVAILABLE env var not set - skipping Ollama RAG pipeline test")
+    assume(ollamaReachable, s"Ollama not reachable at $ollamaBaseUrl with model $embeddingModel")
+  }
+
+  /** Guard that additionally requires pgvector. */
+  private def requireOllamaAndPg(): Unit = {
+    requireOllama()
+    assume(pgUrlEnv.isDefined, "PGVECTOR_TEST_URL env var not set - skipping pgvector RAG pipeline test")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helper: build an in-memory RAG with Ollama embeddings
+  // ---------------------------------------------------------------------------
+  private def buildInMemoryRag(): RAG = {
+    val ragConfig = RAGConfig.default
+      .withEmbeddings(EmbeddingProvider.Ollama, embeddingModel, 768)
+      .inMemory
+
+    val rag = RAG
+      .buildWithClient(ragConfig, embeddingClient)
+      .fold(e => fail(s"Failed to build in-memory RAG: ${e.message}"), identity)
+
+    ragInstances = rag :: ragInstances
+    rag
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helper: build a pgvector-backed RAG with hybrid search
+  // ---------------------------------------------------------------------------
+  private def buildPgHybridRag(): RAG = {
+    val url = pgUrlEnv.getOrElse(fail("PGVECTOR_TEST_URL not set"))
+
+    val ragConfig = RAGConfig.default
+      .withEmbeddings(EmbeddingProvider.Ollama, embeddingModel, 768)
+      .withPgHybrid(url, pgUserEnv, pgPasswordEnv, testVectorTable, testKeywordTable)
+
+    val rag = RAG
+      .buildWithClient(ragConfig, embeddingClient)
+      .fold(e => fail(s"Failed to build pgvector hybrid RAG: ${e.message}"), identity)
+
+    ragInstances = rag :: ragInstances
+    rag
+  }
+
+  // ---------------------------------------------------------------------------
+  // 1. Index phase: embed and store documents in memory
+  // ---------------------------------------------------------------------------
+  "RAGPipelineOllamaIntegrationSpec (index phase)" should "ingest 10 documents with Ollama embeddings into in-memory store" in {
+    requireOllama()
+
+    val rag = buildInMemoryRag()
+
+    sampleDocuments.foreach { case (docId, content) =>
+      val result = rag.ingestText(content, docId)
+      result.isRight shouldBe true
+    }
+
+    rag.documentCount shouldBe sampleDocuments.size
+    rag.chunkCount should be >= sampleDocuments.size
+  }
+
+  // ---------------------------------------------------------------------------
+  // 2. Semantic search phase
+  // ---------------------------------------------------------------------------
+  "RAGPipelineOllamaIntegrationSpec (search phase)" should "return semantically relevant results for a vector query" in {
+    requireOllama()
+
+    val rag = buildInMemoryRag()
+    sampleDocuments.foreach { case (docId, content) =>
+      rag.ingestText(content, docId).isRight shouldBe true
+    }
+
+    // Query about RAG / LLMs – should surface LLM and RAG documents
+    val llmResults = rag.query("retrieval augmented generation", topK = Some(3))
+    llmResults.isRight shouldBe true
+    val llmHits = llmResults.toOption.get
+    llmHits should not be empty
+    // At least one result should be from the LLM or RAG documents
+    val hitIds = llmHits.map(_.id).mkString(" ")
+    hitIds.toLowerCase should (include("llm") or include("rag") or include("ollama"))
+
+    // Query about databases – should surface database documents
+    val dbResults = rag.query("vector similarity search in database", topK = Some(3))
+    dbResults.isRight shouldBe true
+    val dbHits = dbResults.toOption.get
+    dbHits should not be empty
+    // Verify scores are in descending order (top score >= subsequent scores)
+    val scores = dbHits.map(_.score)
+    if (scores.size >= 2) {
+      scores.head should be >= scores.last
+    }
+  }
+
+  it should "rank top result above lower-ranked results for a specific query" in {
+    requireOllama()
+
+    val rag = buildInMemoryRag()
+    sampleDocuments.foreach { case (docId, content) =>
+      rag.ingestText(content, docId).isRight shouldBe true
+    }
+
+    val results = rag.query("Ollama local language model", topK = Some(5))
+    results.isRight shouldBe true
+    val hits = results.toOption.get
+    hits should not be empty
+    // Top score should be >= second score (sorted by relevance)
+    if (hits.size >= 2) {
+      hits.head.score should be >= hits(1).score
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 3. Hybrid search phase (pgvector + keyword)
+  // ---------------------------------------------------------------------------
+  "RAGPipelineOllamaIntegrationSpec (hybrid search phase)" should "combine vector and keyword scores for hybrid queries" in {
+    requireOllamaAndPg()
+
+    val rag = buildPgHybridRag()
+    rag.clear().isRight shouldBe true
+
+    sampleDocuments.foreach { case (docId, content) =>
+      val result = rag.ingestText(content, docId)
+      result.isRight shouldBe true
+    }
+
+    // Hybrid query: keyword "pgvector" should hit database docs, vector should reinforce
+    val hybridResults = rag.query("pgvector semantic search", topK = Some(5))
+    hybridResults.isRight shouldBe true
+    val hybridHits = hybridResults.toOption.get
+    hybridHits should not be empty
+
+    // Verify some results were returned and have non-negative scores
+    hybridHits.foreach(r => r.score should be >= 0.0)
+  }
+
+  it should "return results for a keyword-specific query" in {
+    requireOllamaAndPg()
+
+    val rag = buildPgHybridRag()
+    rag.clear().isRight shouldBe true
+
+    sampleDocuments.foreach { case (docId, content) =>
+      rag.ingestText(content, docId).isRight shouldBe true
+    }
+
+    // Keyword-heavy query that should match Scala documents
+    val scalaResults = rag.query("Scala JVM programming language", topK = Some(4))
+    scalaResults.isRight shouldBe true
+    val scalaHits = scalaResults.toOption.get
+    scalaHits should not be empty
+    // Results should be non-empty and have scores
+    scalaHits.foreach(r => r.score should be >= 0.0)
+  }
+
+  it should "clean up the pgvector store after test" in {
+    requireOllamaAndPg()
+
+    val rag = buildPgHybridRag()
+    sampleDocuments.foreach { case (docId, content) =>
+      rag.ingestText(content, docId).isRight shouldBe true
+    }
+
+    val clearResult = rag.clear()
+    clearResult.isRight shouldBe true
+
+    val stats = rag.stats
+    stats.isRight shouldBe true
+    stats.toOption.get.vectorCount shouldBe 0L
+  }
+
+  // ---------------------------------------------------------------------------
+  // 4. Agent RAG phase: retrieved context drives LLM completion
+  // ---------------------------------------------------------------------------
+  "RAGPipelineOllamaIntegrationSpec (agent RAG phase)" should "generate an answer grounded in retrieved context using OllamaClient" in {
+    assume(
+      ollamaAvailableEnv.isDefined,
+      "OLLAMA_AVAILABLE env var not set - skipping agent RAG test"
+    )
+
+    // Check both embedding model and LLM model are available
+    val llmModelAvailable = Try {
+      val uri        = java.net.URI.create(s"$ollamaBaseUrl/api/tags")
+      val connection = uri.toURL.openConnection().asInstanceOf[java.net.HttpURLConnection]
+      connection.setConnectTimeout(3000)
+      connection.setReadTimeout(3000)
+      connection.setRequestMethod("GET")
+      val code = connection.getResponseCode
+      if (code == 200) {
+        val source = scala.io.Source.fromInputStream(connection.getInputStream)
+        try source.mkString.contains(llmModel)
+        finally source.close()
+      } else false
+    }.getOrElse(false)
+
+    assume(ollamaReachable, s"Ollama not reachable at $ollamaBaseUrl with model $embeddingModel")
+    assume(llmModelAvailable, s"Ollama model $llmModel not available - skipping agent RAG test")
+
+    val ollamaCfg = OllamaConfig(
+      model = llmModel,
+      baseUrl = ollamaBaseUrl,
+      contextWindow = 8192,
+      reserveCompletion = 4096
+    )
+    val llmClient = new OllamaClient(ollamaCfg)
+
+    try {
+      val ragConfig = RAGConfig.default
+        .withEmbeddings(EmbeddingProvider.Ollama, embeddingModel, 768)
+        .withLLM(llmClient)
+        .inMemory
+
+      val rag = RAG
+        .buildWithClient(ragConfig, embeddingClient)
+        .fold(e => fail(s"Failed to build agent RAG: ${e.message}"), identity)
+
+      ragInstances = rag :: ragInstances
+
+      // Index sample documents
+      sampleDocuments.foreach { case (docId, content) =>
+        rag.ingestText(content, docId).isRight shouldBe true
+      }
+
+      // Query: should retrieve context and generate an answer
+      val answerResult = rag.queryWithAnswer(
+        "What is RAG and how does it enhance language models?",
+        topK = Some(3)
+      )
+
+      answerResult.isRight shouldBe true
+      val ragAnswer = answerResult.toOption.get
+
+      // Verify structural properties - never assert on specific LLM output text
+      ragAnswer.answer should not be empty
+      ragAnswer.question should not be empty
+      ragAnswer.contexts should not be empty
+      ragAnswer.contexts.size should be <= 3
+
+      // The retrieved contexts should include relevant chunks from our documents
+      val contextContent = ragAnswer.contexts.map(_.content).mkString(" ").toLowerCase
+      // At least some context content should be returned (non-empty)
+      contextContent should not be empty
+    } finally {
+      llmClient.close()
+    }
+  }
+
+  it should "return contexts that are semantically related to the query" in {
+    requireOllama()
+
+    val rag = buildInMemoryRag()
+    sampleDocuments.foreach { case (docId, content) =>
+      rag.ingestText(content, docId).isRight shouldBe true
+    }
+
+    // Ask about Ollama specifically
+    val searchResult = rag.query("local LLM inference without cloud", topK = Some(3))
+    searchResult.isRight shouldBe true
+    val contexts = searchResult.toOption.get
+    contexts should not be empty
+
+    // All returned contexts should have content
+    contexts.foreach { ctx =>
+      ctx.content should not be empty
+      ctx.id should not be empty
+      ctx.score should be >= 0.0
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 5. Cleanup verification
+  // ---------------------------------------------------------------------------
+  "RAGPipelineOllamaIntegrationSpec (cleanup)" should "clear all test data leaving an empty store" in {
+    requireOllama()
+
+    val rag = buildInMemoryRag()
+    sampleDocuments.foreach { case (docId, content) =>
+      rag.ingestText(content, docId).isRight shouldBe true
+    }
+
+    rag.chunkCount should be > 0
+
+    val clearResult = rag.clear()
+    clearResult.isRight shouldBe true
+
+    val stats = rag.stats
+    stats.isRight shouldBe true
+    val ragStats = stats.toOption.get
+    ragStats.vectorCount shouldBe 0L
+  }
+
+  it should "allow re-ingestion after clearing" in {
+    requireOllama()
+
+    val rag = buildInMemoryRag()
+
+    // First pass
+    sampleDocuments.take(5).foreach { case (docId, content) =>
+      rag.ingestText(content, docId).isRight shouldBe true
+    }
+
+    rag.clear().isRight shouldBe true
+
+    // Second pass after clear
+    sampleDocuments.take(3).foreach { case (docId, content) =>
+      rag.ingestText(content, docId).isRight shouldBe true
+    }
+
+    val stats = rag.stats
+    stats.isRight shouldBe true
+    stats.toOption.get.vectorCount should be >= 1L
+  }
+
+}


### PR DESCRIPTION
## Summary

Implements integration tests for #1001: full end-to-end RAG pipeline with Ollama embeddings and pgvector.

- Adds `modules/it/src/test/scala/org/llm4s/rag/RAGPipelineOllamaIntegrationSpec.scala`
- Index phase: ingests 10 diverse sample text documents using Ollama `nomic-embed-text` embeddings
- Search phase: runs semantic queries and verifies results are semantically relevant with proper score ordering
- Hybrid search phase: exercises `withPgHybrid` (pgvector + PostgreSQL FTS) and verifies combined result scoring
- Agent RAG phase: uses `queryWithAnswer` with an `OllamaClient` to verify grounded completions
- Cleanup: `afterAll` drops pgvector test tables; each test calls `rag.clear()` to reset state

All tests skip gracefully via `assume()` when `OLLAMA_AVAILABLE` or `PGVECTOR_TEST_URL` are absent.
No real API keys are required for the basic `sbt test` run.

## Test plan
- [ ] Tests skip when `OLLAMA_AVAILABLE` is not set (verified by `assume()` guards)
- [ ] Tests skip when `PGVECTOR_TEST_URL` is not set for pgvector-specific cases
- [ ] Full pipeline (index -> embed -> store -> search -> agent) is exercised in a single spec
- [ ] Hybrid search path (`withPgHybrid`) is included
- [ ] No leftover test data: `afterAll` drops schema, each test calls `rag.clear()`
- [ ] Runs under `sbt "it/testOnly org.llm4s.rag.RAGPipelineOllamaIntegrationSpec"` with real infra

Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)