### PR TITLE
feat(test): smoke test for Zai provider

### DIFF
--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/ZaiSmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/ZaiSmokeSpec.scala
@@ -1,0 +1,75 @@
+package org.llm4s.llmconnect.smoke
+
+import org.llm4s.error.AuthenticationError
+import org.llm4s.llmconnect.config.{ ContextWindowResolver, ZaiConfig }
+import org.llm4s.llmconnect.model.{ CompletionOptions, Conversation, StreamedChunk, UserMessage }
+import org.llm4s.llmconnect.provider.ZaiClient
+import org.llm4s.model.ModelRegistryService
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Cloud smoke tests for Z.ai (Zai).
+ *
+ * These tests live in the dedicated integration-test module so default `sbt test`
+ * stays fast. Run them with `sbt "it/testOnly org.llm4s.llmconnect.smoke.*"`
+ * or the `sbt testSmoke` alias.
+ *
+ * Requires: `ZAI_API_KEY` environment variable.
+ */
+class ZaiSmokeSpec extends AnyFlatSpec with Matchers {
+
+  private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
+  private given ContextWindowResolver    = ContextWindowResolver(mrs)
+
+  private val apiKey: Option[String] = Option(System.getenv("ZAI_API_KEY")).filter(_.nonEmpty)
+
+  private def config(key: String): ZaiConfig =
+    ZaiConfig.fromValues(
+      modelName = "GLM-4-Flash",
+      apiKey = key,
+      baseUrl = ZaiConfig.DEFAULT_BASE_URL
+    )
+
+  private def conversation: Conversation = Conversation(Seq(UserMessage("Say hi in one word")))
+
+  "Zai" should "complete a basic request" in {
+    assume(apiKey.isDefined, "ZAI_API_KEY not set")
+
+    val clientResult = ZaiClient(config(apiKey.get))
+    withClue(s"Client creation failed: ${clientResult.swap.toOption}") {
+      clientResult.isRight shouldBe true
+    }
+
+    val client     = clientResult.toOption.get
+    val completion = client.complete(conversation, CompletionOptions())
+
+    withClue(s"Completion failed: ${completion.swap.toOption}") {
+      completion.isRight shouldBe true
+    }
+    completion.toOption.get.content should not be empty
+    completion.toOption.get.usage shouldBe defined
+  }
+
+  it should "stream a response" in {
+    assume(apiKey.isDefined, "ZAI_API_KEY not set")
+
+    val client = ZaiClient(config(apiKey.get)).toOption.get
+    val chunks = scala.collection.mutable.ListBuffer.empty[StreamedChunk]
+    val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+    withClue(s"Streaming failed: ${result.swap.toOption}") {
+      result.isRight shouldBe true
+    }
+    result.toOption.get.content should not be empty
+    chunks should not be empty
+  }
+
+  it should "return AuthenticationError for invalid key" in {
+    val client = ZaiClient(config("invalid-zai-key-for-testing")).toOption.get
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe an[AuthenticationError]
+  }
+}


### PR DESCRIPTION
## Summary

Implements #1014: adds `ZaiSmokeSpec` to `modules/it/src/test/scala/org/llm4s/llmconnect/smoke/` following the established pattern of `AnthropicSmokeSpec` and `DeepSeekSmokeSpec`.

- Requires `ZAI_API_KEY`; skips gracefully when absent via `assume()`
- Tests `complete()` with a simple prompt, verifies `isRight`, non-empty content, and token usage populated
- Tests `streamComplete()`: verifies at least one chunk emitted and final response non-empty
- Tests error path: invalid API key returns `Left(AuthenticationError)` (not an exception)
- Runs under `sbt testSmoke` (i.e. `it/testOnly org.llm4s.llmconnect.smoke.*`)
- Excluded from default `sbt test` (tests live in the `it` module, separate from `core`)

## Test Coverage

This is a smoke/integration test file targeting the real Z.ai API. No new source files were added (ZaiClient already exists). The smoke test itself does not require unit-test coverage — it is an integration test that exercises the live endpoint.

## Smoke Tests

`modules/it/src/test/scala/org/llm4s/llmconnect/smoke/ZaiSmokeSpec.scala` — three tests:
1. `complete a basic request` — skipped if `ZAI_API_KEY` absent
2. `stream a response` — skipped if `ZAI_API_KEY` absent
3. `return AuthenticationError for invalid key` — always runs (no real key needed to test error path)

Closes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)