### PR TITLE
feat(test): smoke test for Cohere provider

### DIFF
--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/CohereSmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/CohereSmokeSpec.scala
@@ -1,0 +1,81 @@
+package org.llm4s.llmconnect.smoke
+
+import org.llm4s.error.{ AuthenticationError, ConfigurationError }
+import org.llm4s.llmconnect.config.{ CohereConfig, ContextWindowResolver }
+import org.llm4s.llmconnect.model.{ CompletionOptions, Conversation, UserMessage }
+import org.llm4s.llmconnect.provider.CohereClient
+import org.llm4s.model.ModelRegistryService
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Cloud smoke tests for Cohere.
+ *
+ * These tests live in the dedicated integration-test module so default `sbt test`
+ * stays fast. Run them with `sbt "it/testOnly org.llm4s.llmconnect.smoke.*"`
+ * or the `sbt testSmoke` alias.
+ *
+ * Requires: `COHERE_API_KEY` environment variable.
+ * Tag: CloudSmoke
+ *
+ * Note: The current CohereClient implementation (v2 scope) does not support
+ * streaming. The `streamComplete` test verifies that calling it returns a
+ * `Left(ConfigurationError)` rather than throwing an exception, in accordance
+ * with the project's `Result[A]` error handling contract.
+ */
+class CohereSmokeSpec extends AnyFlatSpec with Matchers {
+
+  private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
+  private given ContextWindowResolver = ContextWindowResolver(mrs)
+
+  private val apiKey: Option[String] = Option(System.getenv("COHERE_API_KEY")).filter(_.nonEmpty)
+
+  private def config(key: String): CohereConfig =
+    CohereConfig.fromValues(
+      modelName = "command-r",
+      apiKey = key,
+      baseUrl = CohereConfig.DEFAULT_BASE_URL
+    )
+
+  private def conversation: Conversation = Conversation(Seq(UserMessage("Say hi in one word")))
+
+  "Cohere" should "complete a basic request" in {
+    assume(apiKey.isDefined, "COHERE_API_KEY not set")
+
+    val clientResult = CohereClient(config(apiKey.get))
+    withClue(s"Client creation failed: ${clientResult.swap.toOption}") {
+      clientResult.isRight shouldBe true
+    }
+
+    val client     = clientResult.toOption.get
+    val completion = client.complete(conversation, CompletionOptions())
+
+    withClue(s"Completion failed: ${completion.swap.toOption}") {
+      completion.isRight shouldBe true
+    }
+    val result = completion.toOption.get
+    result.content should not be empty
+    result.usage should not be empty
+    result.usage.get.promptTokens should be > 0
+    result.usage.get.completionTokens should be > 0
+  }
+
+  it should "return a Left(ConfigurationError) for streamComplete (not yet implemented)" in {
+    // streamComplete returns an error immediately without contacting the API,
+    // so no COHERE_API_KEY is required for this test.
+    val client = CohereClient(config("placeholder-key")).toOption.get
+    val chunks = scala.collection.mutable.ListBuffer.empty[String]
+    val result = client.streamComplete(conversation, CompletionOptions(), _ => chunks += "chunk")
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe an[ConfigurationError]
+  }
+
+  it should "return AuthenticationError for invalid key" in {
+    val client = CohereClient(config("invalid-key-for-testing")).toOption.get
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe an[AuthenticationError]
+  }
+}


### PR DESCRIPTION
## Summary

Implements #1012: adds `CohereSmokeSpec` in `modules/it/` to match the pattern of existing smoke tests for Anthropic, DeepSeek, Gemini, OpenAI, and OpenRouter.

- Skips gracefully when `COHERE_API_KEY` is absent (uses `assume()`)
- Tagged `CloudSmoke` in the scaladoc comment; excluded from default `sbt test` by the existing test filter
- Tests `complete()` against `command-r`: verifies `isRight`, response text non-empty, token usage populated
- Tests `streamComplete()`: verifies the result is `Left(ConfigurationError)` — the current CohereClient v2 implementation explicitly does not support streaming and returns a typed error rather than throwing
- Tests error path: invalid API key returns `Left(AuthenticationError)` (not an exception)
- Runs under `sbt testSmoke` alias

## Notes on streaming test

The CohereClient implementation contains an explicit comment that streaming is intentionally not supported in the v2 scope. The smoke test documents this by verifying the typed error (`Left(ConfigurationError)`) is returned without throwing an exception, satisfying the project's `Result[A]` error handling contract.

## Test plan
- [ ] `COHERE_API_KEY` not set: all tests that require the key are skipped via `assume()`
- [ ] `COHERE_API_KEY` set: `complete` succeeds with non-empty content and token usage
- [ ] `COHERE_API_KEY` set: `streamComplete` returns `Left(ConfigurationError)` (no network call needed)
- [ ] Invalid key: `complete` returns `Left(AuthenticationError)`
- [ ] `sbt testSmoke` runs the new spec alongside existing smoke tests

Closes #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)