### PR TITLE
feat: integration and smoke tests for Google Vertex AI provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,3 +234,31 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
         run: sbt testSmoke
+
+  # Vertex AI smoke tests — requires a GCP service account with Vertex AI access.
+  # Triggered manually (workflow_dispatch) or as part of pre-release checks.
+  vertex-smoke:
+    name: Vertex AI Smoke Tests
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+
+      - name: Run Vertex AI smoke tests
+        env:
+          GOOGLE_CLOUD_PROJECT: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
+          GOOGLE_CLOUD_LOCATION: ${{ secrets.GOOGLE_CLOUD_LOCATION }}
+          VERTEX_ACCESS_TOKEN: ${{ secrets.VERTEX_ACCESS_TOKEN }}
+          VERTEX_ANTHROPIC_MODEL: ${{ secrets.VERTEX_ANTHROPIC_MODEL }}
+        run: sbt "it/testOnly org.llm4s.llmconnect.smoke.VertexAISmokeSpec"

--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
@@ -104,3 +104,15 @@ private[config] object NamedProviderLoader:
         requiredApiKey("llm4s.providers.<name>.apiKey").map: apiKey =>
           val baseUrl = section.baseUrl.map(_.asUrl).getOrElse(MistralConfig.DEFAULT_BASE_URL)
           MistralConfig.fromValues(section.model.asString, apiKey, baseUrl)
+      case ProviderKind.VertexAI =>
+        for
+          project     <- required("project", section.organization, "llm4s.providers.<name>.organization")
+          location    <- required("location", section.endpoint, "llm4s.providers.<name>.endpoint")
+          accessToken <- requiredApiKey("llm4s.providers.<name>.apiKey")
+        yield VertexAIConfig.fromValues(
+          project = project,
+          location = location,
+          modelName = section.model.asString,
+          accessToken = accessToken,
+          baseUrl = section.baseUrl.map(_.asUrl).getOrElse(""),
+        )

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -58,6 +58,8 @@ object LLMConnect {
         CohereClient(cfg, metrics, exchangeLogging)
       case cfg: MistralConfig =>
         MistralClient(cfg, metrics, exchangeLogging)
+      case cfg: VertexAIConfig =>
+        VertexAIClient(cfg, metrics, exchangeLogging)
     }
 
   def fromConfig(
@@ -168,6 +170,7 @@ object LLMConnect {
       case (ProviderKind.DeepSeek, cfg: DeepSeekConfig)   => DeepSeekClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Cohere, cfg: CohereConfig)       => CohereClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Mistral, cfg: MistralConfig)     => MistralClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.VertexAI, cfg: VertexAIConfig)   => VertexAIClient(cfg, metrics, exchangeLogging)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -677,3 +677,95 @@ object MistralConfig:
       contextWindow = cw,
       reserveCompletion = rc
     )
+
+/**
+ * Configuration for Google Vertex AI.
+ *
+ * Vertex AI exposes Gemini models (and optionally Claude models via Anthropic
+ * on Vertex) through regional REST endpoints. Authentication uses a bearer token
+ * obtained from Application Default Credentials (ADC) rather than an API key.
+ *
+ * Prefer [[VertexAIConfig.fromValues]] over the primary constructor; it resolves
+ * `contextWindow` and `reserveCompletion` automatically from the model name.
+ *
+ * @param project         GCP project ID (e.g. `"my-gcp-project"`).
+ * @param location        GCP region (e.g. `"us-central1"`, `"europe-west1"`).
+ * @param model           Model identifier (e.g. `"gemini-1.5-flash"`, `"claude-3-haiku@20240307"`).
+ * @param accessToken     Bearer token for authentication; typically obtained from ADC.
+ *                        Pass an empty string to trigger a [[org.llm4s.error.ConfigurationError]]
+ *                        on the first request.
+ * @param baseUrl         API base URL override; defaults to the standard Vertex AI endpoint.
+ * @param contextWindow   Model's total token capacity (prompt + completion combined).
+ * @param reserveCompletion Tokens held back from prompt history for the completion.
+ */
+case class VertexAIConfig(
+  project: String,
+  location: String,
+  model: String,
+  accessToken: String,
+  baseUrl: String,
+  contextWindow: Int,
+  reserveCompletion: Int,
+) extends ProviderConfig:
+  override val provider: ProviderKind = ProviderKind.VertexAI
+  override def toString: String =
+    s"VertexAIConfig(project=$project, location=$location, model=$model, " +
+      s"accessToken=${Redaction.secret(accessToken)}, baseUrl=$baseUrl, " +
+      s"contextWindow=$contextWindow, reserveCompletion=$reserveCompletion)"
+
+object VertexAIConfig:
+  private val DefaultContextWindow     = 1048576
+  private val DefaultReserveCompletion = 8192
+
+  /** Base URL template; `{location}` is substituted at construction time. */
+  val DEFAULT_BASE_URL_TEMPLATE: String =
+    "https://{location}-aiplatform.googleapis.com/v1"
+
+  private def vertexFallback(modelName: String): (Int, Int) =
+    modelName match
+      case name if name.contains("gemini-2")   => (1048576, DefaultReserveCompletion)
+      case name if name.contains("gemini-1.5") => (1048576, DefaultReserveCompletion)
+      case name if name.contains("gemini-1.0") => (32768, DefaultReserveCompletion)
+      case name if name.contains("claude-3")   => (200000, DefaultReserveCompletion)
+      case _                                   => (DefaultContextWindow, DefaultReserveCompletion)
+
+  /**
+   * Constructs a [[VertexAIConfig]], resolving `contextWindow` and
+   * `reserveCompletion` from the model name automatically.
+   *
+   * @param project      GCP project ID; must be non-empty.
+   * @param location     GCP region (e.g. `"us-central1"`); must be non-empty.
+   * @param modelName    Model identifier (e.g. `"gemini-1.5-flash"`).
+   * @param accessToken  Bearer token for authentication; must be non-empty.
+   * @param baseUrl      API base URL; defaults to the regional Vertex AI endpoint
+   *                     derived from `location`.
+   */
+  def fromValues(
+    project: String,
+    location: String,
+    modelName: String,
+    accessToken: String,
+    baseUrl: String = "",
+  )(using resolver: ContextWindowResolver): VertexAIConfig =
+    require(project.trim.nonEmpty, "VertexAI project must be non-empty")
+    require(location.trim.nonEmpty, "VertexAI location must be non-empty")
+    require(accessToken.trim.nonEmpty, "VertexAI accessToken must be non-empty")
+    val resolvedBaseUrl =
+      if baseUrl.trim.nonEmpty then baseUrl.trim
+      else DEFAULT_BASE_URL_TEMPLATE.replace("{location}", location.trim)
+    val (cw, rc) = resolver.resolve(
+      lookupProviders = Seq("vertex", "gemini", "google", "anthropic"),
+      modelName = modelName,
+      defaultContextWindow = DefaultContextWindow,
+      defaultReserve = DefaultReserveCompletion,
+      fallbackResolver = vertexFallback
+    )
+    VertexAIConfig(
+      project = project.trim,
+      location = location.trim,
+      model = modelName,
+      accessToken = accessToken,
+      baseUrl = resolvedBaseUrl,
+      contextWindow = cw,
+      reserveCompletion = rc,
+    )

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VertexAIClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VertexAIClient.scala
@@ -1,0 +1,611 @@
+// scalafix:off DisableSyntax.NoKeywordTry, DisableSyntax.NoKeywordFinally
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.{ AuthenticationError, ConfigurationError }
+import org.llm4s.error.ThrowableOps._
+import org.llm4s.http.Llm4sHttpClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
+import org.llm4s.llmconnect.ProviderExchangeLogging
+import org.llm4s.llmconnect.config.VertexAIConfig
+import org.llm4s.llmconnect.model._
+import org.llm4s.llmconnect.provider.ProviderResultOps._
+import org.llm4s.llmconnect.streaming._
+import org.llm4s.model.{ ModelRegistryService, TransformationResult }
+import org.llm4s.toolapi.ToolFunction
+import org.llm4s.types.Result
+import org.slf4j.LoggerFactory
+
+import java.io.{ BufferedReader, InputStreamReader }
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.UUID
+import scala.util.Try
+
+/**
+ * [[LLMClient]] implementation for Google Vertex AI.
+ *
+ * Calls the Vertex AI REST API (Gemini-on-Vertex and Claude-on-Vertex) using
+ * [[org.llm4s.http.Llm4sHttpClient]].
+ *
+ * == Authentication ==
+ *
+ * Vertex AI uses bearer-token authentication. The access token must be obtained
+ * externally (e.g. via Application Default Credentials or a service account key)
+ * and supplied in [[VertexAIConfig.accessToken]]. An empty access token results
+ * in a [[org.llm4s.error.ConfigurationError]] on the first request.
+ *
+ * == Regional endpoints ==
+ *
+ * The endpoint URL includes the GCP region. For example, `us-central1` and
+ * `europe-west1` produce different base URLs. Supply a custom `baseUrl` in
+ * [[VertexAIConfig]] to override the default regional endpoint.
+ *
+ * == Response format ==
+ *
+ * Gemini-on-Vertex returns the same JSON structure as the public Gemini API
+ * (candidates array with content parts). Claude-on-Vertex returns Anthropic's
+ * messages format (content blocks with type and text fields).
+ *
+ * == Streaming ==
+ *
+ * Streaming uses the same SSE format as the public Gemini API.
+ *
+ * @param config         [[VertexAIConfig]] with project, location, model, and access token.
+ * @param metrics        Receives per-call latency and token-usage events.
+ * @param exchangeLogging Controls provider exchange recording.
+ * @param httpClient     HTTP client used for all requests; injectable for testing.
+ */
+class VertexAIClient(
+  config: VertexAIConfig,
+  protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop,
+  exchangeLogging: ProviderExchangeLogging = ProviderExchangeLogging.Disabled,
+  private[provider] val httpClient: Llm4sHttpClient = Llm4sHttpClient.create(),
+)(using val registryService: ModelRegistryService)
+    extends BaseLifecycleLLMClient {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  protected def clientDescription: String = s"VertexAI client for model ${config.model}"
+  protected def providerName: String      = "vertex"
+  protected def modelName: String         = config.model
+
+  /** True when the model is a Claude model served via Anthropic on Vertex. */
+  private def isClaudeModel: Boolean = config.model.toLowerCase.contains("claude")
+
+  /**
+   * Builds the Vertex AI endpoint URL for a non-streaming request.
+   * Gemini-on-Vertex uses `generateContent`; Claude-on-Vertex uses `rawPredict`.
+   */
+  private def endpointUrl: String = {
+    val base = config.baseUrl.stripSuffix("/")
+    if (isClaudeModel) {
+      s"$base/projects/${config.project}/locations/${config.location}/publishers/anthropic/models/${config.model}:rawPredict"
+    } else {
+      s"$base/projects/${config.project}/locations/${config.location}/publishers/google/models/${config.model}:generateContent"
+    }
+  }
+
+  /**
+   * Builds the Vertex AI endpoint URL for a streaming request.
+   */
+  private def streamingEndpointUrl: String = {
+    val base = config.baseUrl.stripSuffix("/")
+    if (isClaudeModel) {
+      s"$base/projects/${config.project}/locations/${config.location}/publishers/anthropic/models/${config.model}:streamRawPredict"
+    } else {
+      s"$base/projects/${config.project}/locations/${config.location}/publishers/google/models/${config.model}:streamGenerateContent?alt=sse"
+    }
+  }
+
+  private def authHeaders: Map[String, String] = Map(
+    "Content-Type"  -> "application/json",
+    "Authorization" -> s"Bearer ${config.accessToken}",
+  )
+
+  override def complete(
+    conversation: Conversation,
+    options: CompletionOptions,
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt = Instant.now()
+    if (config.accessToken.trim.isEmpty) {
+      Left(ConfigurationError("VertexAI accessToken is required but was empty"))
+    } else TransformationResult
+      .transform(
+        config.model,
+        options,
+        conversation.messages,
+        dropUnsupported = true,
+        org.llm4s.model.RequestTransformer.default(registryService),
+      )
+      .flatMap { transformed =>
+        val transformedConversation = conversation.copy(messages = transformed.messages)
+        val requestBody =
+          if (isClaudeModel) buildClaudeRequestBody(transformedConversation, transformed.options)
+          else buildGeminiRequestBody(transformedConversation, transformed.options)
+        val requestText = requestBody.render()
+        val url         = endpointUrl
+
+        logger.debug(s"[VertexAI] Sending request to $url")
+
+        val attempt = Try {
+          val response = httpClient.post(url, authHeaders, requestText, timeout = 120000)
+          if (response.statusCode >= 200 && response.statusCode < 300) {
+            val completionResult =
+              if (isClaudeModel) parseClaudeCompletionResponse(response.body)
+              else parseGeminiCompletionResponse(response.body)
+            recordExchange(startedAt, requestText, Some(response.body), completionResult)
+            completionResult
+          } else {
+            val errorResult = handleErrorResponse(response.statusCode, response.body)
+            recordExchange(startedAt, requestText, Some(response.body), errorResult)
+            errorResult
+          }
+        }.toEither.left
+          .map(e => e.toLLMError)
+          .flatten
+
+        attempt
+      }
+  }
+
+  override def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions(),
+    onChunk: StreamedChunk => Unit,
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt = Instant.now()
+    if (config.accessToken.trim.isEmpty) {
+      Left(ConfigurationError("VertexAI accessToken is required but was empty"))
+    } else
+      TransformationResult
+        .transform(
+          config.model,
+          options,
+          conversation.messages,
+          dropUnsupported = true,
+          org.llm4s.model.RequestTransformer.default(registryService),
+        )
+        .flatMap { transformed =>
+          val transformedConversation = conversation.copy(messages = transformed.messages)
+          val requestBody =
+            if (isClaudeModel) buildClaudeRequestBody(transformedConversation, transformed.options)
+            else buildGeminiRequestBody(transformedConversation, transformed.options)
+          val requestText = requestBody.render()
+          val url         = streamingEndpointUrl
+
+          logger.debug(s"[VertexAI] Starting stream to $url")
+
+          val response = httpClient.postStream(url, authHeaders, requestText, timeout = 600000)
+
+          if (response.statusCode < 200 || response.statusCode >= 300) {
+            val err = new String(response.body.readAllBytes(), StandardCharsets.UTF_8)
+            response.body.close()
+            val errorResult = handleErrorResponse(response.statusCode, err)
+            recordExchange(startedAt, requestText, Some(err), errorResult)
+            errorResult
+          } else {
+            val accumulator = StreamingAccumulator.create()
+            val messageId   = UUID.randomUUID().toString
+            val reader      = new BufferedReader(new InputStreamReader(response.body, StandardCharsets.UTF_8))
+            val rawStream   = new StringBuilder()
+
+            Try {
+              try {
+                var line: String = null
+                while ({ line = reader.readLine(); line != null }) {
+                  rawStream.append(line).append('\n')
+                  val trimmed = line.trim
+                  if (trimmed.startsWith("data: ")) {
+                    val jsonStr = trimmed.stripPrefix("data: ").trim
+                    if (jsonStr.nonEmpty) {
+                      Try(ujson.read(jsonStr)).foreach { json =>
+                        parseGeminiStreamChunk(json, messageId).foreach { chunk =>
+                          accumulator.addChunk(chunk)
+                          onChunk(chunk)
+                        }
+                        for {
+                          usage      <- Try(json("usageMetadata")).toOption
+                          prompt     <- Try(usage("promptTokenCount").num.toInt).toOption
+                          completion <- Try(usage("candidatesTokenCount").num.toInt).toOption
+                        } accumulator.updateTokens(prompt, completion)
+                      }
+                    }
+                  }
+                }
+              } finally {
+                Try(reader.close())
+                Try(response.body.close())
+              }
+            }.toEither.left
+              .map(_.toLLMError)
+              .flatMap(_ =>
+                accumulator.toCompletion.map { c =>
+                  val cost       = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
+                  val completion = c.copy(model = config.model, estimatedCost = cost)
+                  recordExchange(startedAt, requestText, Some(rawStream.result()), Right(completion))
+                  completion
+                }
+              )
+              .tapLeft(error =>
+                recordExchange(
+                  startedAt,
+                  requestText,
+                  Option.when(rawStream.nonEmpty)(rawStream.result()),
+                  Left(error),
+                )
+              )
+          }
+        }
+  }
+
+  override def getContextWindow(): Int = config.contextWindow
+
+  override def getReserveCompletion(): Int = config.reserveCompletion
+
+  /**
+   * Builds the Gemini-on-Vertex API request body.
+   *
+   * Uses the same format as the public Gemini API (contents array,
+   * systemInstruction, generationConfig).
+   */
+  private def buildGeminiRequestBody(
+    conversation: Conversation,
+    options: CompletionOptions,
+  ): ujson.Value = {
+    val contents    = scala.collection.mutable.ArrayBuffer[ujson.Value]()
+    var systemInstr = Option.empty[String]
+    val toolCallIdToName = scala.collection.mutable.Map[String, String]()
+
+    conversation.messages.foreach {
+      case SystemMessage(content) =>
+        systemInstr = Some(content)
+
+      case UserMessage(content) =>
+        contents += ujson.Obj(
+          "role"  -> "user",
+          "parts" -> ujson.Arr(ujson.Obj("text" -> content)),
+        )
+
+      case AssistantMessage(contentOpt, toolCalls) =>
+        if (toolCalls.nonEmpty) {
+          val parts = scala.collection.mutable.ArrayBuffer[ujson.Value]()
+          contentOpt.foreach(c => parts += ujson.Obj("text" -> c))
+          toolCalls.foreach { tc =>
+            toolCallIdToName(tc.id) = tc.name
+            parts += ujson.Obj(
+              "functionCall" -> ujson.Obj(
+                "name" -> tc.name,
+                "args" -> tc.arguments,
+              )
+            )
+          }
+          contents += ujson.Obj("role" -> "model", "parts" -> ujson.Arr(parts.toSeq: _*))
+        } else {
+          contentOpt.foreach { content =>
+            contents += ujson.Obj(
+              "role"  -> "model",
+              "parts" -> ujson.Arr(ujson.Obj("text" -> content)),
+            )
+          }
+        }
+
+      case ToolMessage(content, toolCallId) =>
+        val functionName = toolCallIdToName.getOrElse(toolCallId, toolCallId)
+        contents += ujson.Obj(
+          "role" -> "user",
+          "parts" -> ujson.Arr(
+            ujson.Obj(
+              "functionResponse" -> ujson.Obj(
+                "name"     -> functionName,
+                "response" -> ujson.Obj("result" -> content),
+              )
+            )
+          ),
+        )
+    }
+
+    val generationConfig = ujson.Obj(
+      "temperature" -> options.temperature,
+      "topP"        -> options.topP,
+    )
+    options.maxTokens.foreach(mt => generationConfig("maxOutputTokens") = mt)
+
+    options.responseFormat.foreach {
+      case ResponseFormat.Json =>
+        generationConfig("responseMimeType") = "application/json"
+      case js: ResponseFormat.JsonSchema =>
+        generationConfig("responseMimeType") = "application/json"
+        generationConfig("responseSchema") = js.schema
+    }
+
+    val request = ujson.Obj(
+      "contents"         -> ujson.Arr(contents.toSeq: _*),
+      "generationConfig" -> generationConfig,
+    )
+
+    systemInstr.foreach { sysContent =>
+      request("systemInstruction") = ujson.Obj(
+        "parts" -> ujson.Arr(ujson.Obj("text" -> sysContent))
+      )
+    }
+
+    if (options.tools.nonEmpty) {
+      val functionDeclarations = options.tools.map(convertToolToGeminiFormat)
+      request("tools") = ujson.Arr(
+        ujson.Obj("functionDeclarations" -> ujson.Arr(functionDeclarations: _*))
+      )
+    }
+
+    request
+  }
+
+  /**
+   * Builds the Claude-on-Vertex (Anthropic Messages API) request body.
+   *
+   * Claude served via Vertex AI uses the same JSON request format as the
+   * direct Anthropic API, minus the API key header.
+   */
+  private def buildClaudeRequestBody(
+    conversation: Conversation,
+    options: CompletionOptions,
+  ): ujson.Value = {
+    val messages    = scala.collection.mutable.ArrayBuffer[ujson.Value]()
+    var systemInstr = Option.empty[String]
+
+    conversation.messages.foreach {
+      case SystemMessage(content) =>
+        systemInstr = Some(content)
+      case UserMessage(content) =>
+        messages += ujson.Obj("role" -> "user", "content" -> content)
+      case AssistantMessage(contentOpt, _) =>
+        contentOpt.foreach { c =>
+          messages += ujson.Obj("role" -> "assistant", "content" -> c)
+        }
+      case ToolMessage(content, toolCallId) =>
+        messages += ujson.Obj(
+          "role"    -> "user",
+          "content" -> s"[Tool result for $toolCallId]: $content",
+        )
+    }
+
+    val request = ujson.Obj(
+      "model"      -> config.model,
+      "max_tokens" -> options.maxTokens.getOrElse(2048),
+      "messages"   -> ujson.Arr(messages.toSeq: _*),
+    )
+
+    systemInstr.foreach(s => request("system") = s)
+
+    request
+  }
+
+  /** Convert a tool to Gemini's function declaration format. */
+  private[provider] def convertToolToGeminiFormat(tool: ToolFunction[_, _]): ujson.Value = {
+    val schema = ujson.read(tool.schema.toJsonSchema(false).render())
+    schema.obj.remove("strict")
+    schema.obj.remove("additionalProperties")
+    stripAdditionalProperties(schema)
+    ujson.Obj(
+      "name"        -> tool.name,
+      "description" -> tool.description,
+      "parameters"  -> schema,
+    )
+  }
+
+  /** Recursively strip `additionalProperties` from a JSON schema. */
+  private[provider] def stripAdditionalProperties(json: ujson.Value): Unit =
+    json match {
+      case obj: ujson.Obj =>
+        obj.value.remove("additionalProperties")
+        obj.value.get("properties").foreach(props => props.obj.values.foreach(stripAdditionalProperties))
+        obj.value.get("items").foreach(stripAdditionalProperties)
+        Seq("anyOf", "oneOf", "allOf").foreach { key =>
+          obj.value.get(key).foreach(arr => arr.arr.foreach(stripAdditionalProperties))
+        }
+      case _ => ()
+    }
+
+  /** Parse a Gemini-on-Vertex completion response. */
+  private def parseGeminiCompletionResponse(responseText: String): Result[Completion] =
+    Try {
+      val json       = ujson.read(responseText)
+      val candidates = json("candidates").arr
+
+      if (candidates.isEmpty) {
+        Left(org.llm4s.error.ValidationError("response", "No candidates in Vertex AI Gemini response"))
+      } else {
+        val candidate = candidates.head
+        val content   = candidate("content")
+        val parts     = content("parts").arr
+
+        val textContent = parts
+          .filter(p => p.obj.contains("text"))
+          .map(_("text").str)
+          .mkString
+
+        val toolCalls = parts
+          .filter(p => p.obj.contains("functionCall"))
+          .map { p =>
+            val fc = p("functionCall")
+            ToolCall(
+              id = UUID.randomUUID().toString,
+              name = fc("name").str,
+              arguments = fc("args"),
+            )
+          }
+          .toSeq
+
+        val usageOpt = Try {
+          val usage = json("usageMetadata")
+          TokenUsage(
+            promptTokens = usage("promptTokenCount").num.toInt,
+            completionTokens = usage("candidatesTokenCount").num.toInt,
+            totalTokens = usage("totalTokenCount").num.toInt,
+          )
+        }.toOption
+
+        val message = AssistantMessage(
+          contentOpt = if (textContent.nonEmpty) Some(textContent) else None,
+          toolCalls = toolCalls,
+        )
+        val cost = usageOpt.flatMap(u => CostEstimator.estimate(config.model, u))
+
+        Right(
+          Completion(
+            id = UUID.randomUUID().toString,
+            content = textContent,
+            model = config.model,
+            toolCalls = toolCalls.toList,
+            created = System.currentTimeMillis() / 1000,
+            message = message,
+            usage = usageOpt,
+            estimatedCost = cost,
+          )
+        )
+      }
+    }.toEither.left.map(e => e.toLLMError).flatten
+
+  /** Parse a Claude-on-Vertex (Anthropic messages format) completion response. */
+  private def parseClaudeCompletionResponse(responseText: String): Result[Completion] =
+    Try {
+      val json    = ujson.read(responseText)
+      val content = json("content").arr
+
+      val textContent = content
+        .filter(b => b.obj.get("type").flatMap(_.strOpt).contains("text"))
+        .map(_("text").str)
+        .mkString
+
+      val usageOpt = Try {
+        val usage = json("usage")
+        val input  = usage("input_tokens").num.toInt
+        val output = usage("output_tokens").num.toInt
+        TokenUsage(promptTokens = input, completionTokens = output, totalTokens = input + output)
+      }.toOption
+
+      val message = AssistantMessage(
+        contentOpt = if (textContent.nonEmpty) Some(textContent) else None,
+        toolCalls = Seq.empty,
+      )
+      val id   = Try(json("id").str).getOrElse(UUID.randomUUID().toString)
+      val cost = usageOpt.flatMap(u => CostEstimator.estimate(config.model, u))
+
+      Right(
+        Completion(
+          id = id,
+          content = textContent,
+          model = config.model,
+          toolCalls = List.empty,
+          created = System.currentTimeMillis() / 1000,
+          message = message,
+          usage = usageOpt,
+          estimatedCost = cost,
+        )
+      )
+    }.toEither.left.map(e => e.toLLMError).flatten
+
+  /** Parse a streaming chunk from Vertex AI (Gemini format). */
+  private def parseGeminiStreamChunk(json: ujson.Value, messageId: String): Option[StreamedChunk] =
+    Try {
+      val candidates = json("candidates").arr
+      if (candidates.nonEmpty) {
+        val candidate = candidates.head
+        val content   = candidate("content")
+        val parts     = content("parts").arr
+
+        val textContent = parts
+          .filter(p => p.obj.contains("text"))
+          .map(_("text").str)
+          .mkString
+
+        val finishReason = Try(candidate("finishReason").str).toOption
+
+        val toolCallOpt = parts
+          .filter(p => p.obj.contains("functionCall"))
+          .headOption
+          .map { p =>
+            val fc = p("functionCall")
+            ToolCall(
+              id = UUID.randomUUID().toString,
+              name = fc("name").str,
+              arguments = fc("args"),
+            )
+          }
+
+        Some(
+          StreamedChunk(
+            id = messageId,
+            content = if (textContent.nonEmpty) Some(textContent) else None,
+            toolCall = toolCallOpt,
+            finishReason = finishReason,
+          )
+        )
+      } else {
+        None
+      }
+    }.toOption.flatten
+
+  private def handleErrorResponse(statusCode: Int, body: String): Result[Nothing] = {
+    logger.error(s"[VertexAI] Error response: $statusCode")
+    val details = HttpErrorMapper.extractErrorDetails(body, statusCode, providerName)
+    if (statusCode == 401 || statusCode == 403 || isAdcAuthFailure(details)) {
+      Left(AuthenticationError(providerName, details))
+    } else {
+      HttpErrorMapper.mapHttpError(statusCode, body, providerName)
+    }
+  }
+
+  private def isAdcAuthFailure(details: String): Boolean = {
+    val lower = details.toLowerCase
+    lower.contains("unauthenticated") || lower.contains("invalid credentials") ||
+    lower.contains("permission denied") || lower.contains("access token")
+  }
+
+  private def recordExchange(
+    startedAt: Instant,
+    requestBody: String,
+    responseBody: Option[String],
+    result: Result[?],
+  ): Unit =
+    ProviderExchangeRecorder.record(
+      exchangeLogging = exchangeLogging,
+      provider = providerName,
+      model = Some(config.model),
+      startedAt = startedAt,
+      requestBody = requestBody,
+      responseBody = responseBody,
+      result = result,
+    )
+
+  override protected def releaseResources(): Unit =
+    (httpClient: Any) match {
+      case c: AutoCloseable => c.close()
+      case _                => ()
+    }
+}
+
+object VertexAIClient {
+  import org.llm4s.types.TryOps
+
+  def apply(config: VertexAIConfig)(using ModelRegistryService): Result[VertexAIClient] =
+    Try(new VertexAIClient(config)).toResult
+
+  def apply(config: VertexAIConfig, metrics: org.llm4s.metrics.MetricsCollector)(using
+    ModelRegistryService
+  ): Result[VertexAIClient] =
+    Try(new VertexAIClient(config, metrics)).toResult
+
+  def apply(
+    config: VertexAIConfig,
+    metrics: org.llm4s.metrics.MetricsCollector,
+    exchangeLogging: ProviderExchangeLogging,
+  )(using ModelRegistryService): Result[VertexAIClient] =
+    Try(new VertexAIClient(config, metrics, exchangeLogging)).toResult
+
+  /** Test seam — injects a custom HTTP client without going through Try-wrapping. */
+  private[provider] def forTest(
+    config: VertexAIConfig,
+    httpClient: Llm4sHttpClient,
+  )(using ModelRegistryService): VertexAIClient =
+    new VertexAIClient(config, org.llm4s.metrics.MetricsCollector.noop, ProviderExchangeLogging.Disabled, httpClient)
+}

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VertexAIClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/VertexAIClient.scala
@@ -109,43 +109,44 @@ class VertexAIClient(
     val startedAt = Instant.now()
     if (config.accessToken.trim.isEmpty) {
       Left(ConfigurationError("VertexAI accessToken is required but was empty"))
-    } else TransformationResult
-      .transform(
-        config.model,
-        options,
-        conversation.messages,
-        dropUnsupported = true,
-        org.llm4s.model.RequestTransformer.default(registryService),
-      )
-      .flatMap { transformed =>
-        val transformedConversation = conversation.copy(messages = transformed.messages)
-        val requestBody =
-          if (isClaudeModel) buildClaudeRequestBody(transformedConversation, transformed.options)
-          else buildGeminiRequestBody(transformedConversation, transformed.options)
-        val requestText = requestBody.render()
-        val url         = endpointUrl
+    } else
+      TransformationResult
+        .transform(
+          config.model,
+          options,
+          conversation.messages,
+          dropUnsupported = true,
+          org.llm4s.model.RequestTransformer.default(registryService),
+        )
+        .flatMap { transformed =>
+          val transformedConversation = conversation.copy(messages = transformed.messages)
+          val requestBody =
+            if (isClaudeModel) buildClaudeRequestBody(transformedConversation, transformed.options)
+            else buildGeminiRequestBody(transformedConversation, transformed.options)
+          val requestText = requestBody.render()
+          val url         = endpointUrl
 
-        logger.debug(s"[VertexAI] Sending request to $url")
+          logger.debug(s"[VertexAI] Sending request to $url")
 
-        val attempt = Try {
-          val response = httpClient.post(url, authHeaders, requestText, timeout = 120000)
-          if (response.statusCode >= 200 && response.statusCode < 300) {
-            val completionResult =
-              if (isClaudeModel) parseClaudeCompletionResponse(response.body)
-              else parseGeminiCompletionResponse(response.body)
-            recordExchange(startedAt, requestText, Some(response.body), completionResult)
-            completionResult
-          } else {
-            val errorResult = handleErrorResponse(response.statusCode, response.body)
-            recordExchange(startedAt, requestText, Some(response.body), errorResult)
-            errorResult
-          }
-        }.toEither.left
-          .map(e => e.toLLMError)
-          .flatten
+          val attempt = Try {
+            val response = httpClient.post(url, authHeaders, requestText, timeout = 120000)
+            if (response.statusCode >= 200 && response.statusCode < 300) {
+              val completionResult =
+                if (isClaudeModel) parseClaudeCompletionResponse(response.body)
+                else parseGeminiCompletionResponse(response.body)
+              recordExchange(startedAt, requestText, Some(response.body), completionResult)
+              completionResult
+            } else {
+              val errorResult = handleErrorResponse(response.statusCode, response.body)
+              recordExchange(startedAt, requestText, Some(response.body), errorResult)
+              errorResult
+            }
+          }.toEither.left
+            .map(e => e.toLLMError)
+            .flatten
 
-        attempt
-      }
+          attempt
+        }
   }
 
   override def streamComplete(
@@ -252,8 +253,8 @@ class VertexAIClient(
     conversation: Conversation,
     options: CompletionOptions,
   ): ujson.Value = {
-    val contents    = scala.collection.mutable.ArrayBuffer[ujson.Value]()
-    var systemInstr = Option.empty[String]
+    val contents         = scala.collection.mutable.ArrayBuffer[ujson.Value]()
+    var systemInstr      = Option.empty[String]
     val toolCallIdToName = scala.collection.mutable.Map[String, String]()
 
     conversation.messages.foreach {
@@ -358,9 +359,7 @@ class VertexAIClient(
       case UserMessage(content) =>
         messages += ujson.Obj("role" -> "user", "content" -> content)
       case AssistantMessage(contentOpt, _) =>
-        contentOpt.foreach { c =>
-          messages += ujson.Obj("role" -> "assistant", "content" -> c)
-        }
+        contentOpt.foreach(c => messages += ujson.Obj("role" -> "assistant", "content" -> c))
       case ToolMessage(content, toolCallId) =>
         messages += ujson.Obj(
           "role"    -> "user",
@@ -477,7 +476,7 @@ class VertexAIClient(
         .mkString
 
       val usageOpt = Try {
-        val usage = json("usage")
+        val usage  = json("usage")
         val input  = usage("input_tokens").num.toInt
         val output = usage("output_tokens").num.toInt
         TokenUsage(promptTokens = input, completionTokens = output, totalTokens = input + output)

--- a/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
+++ b/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
@@ -54,19 +54,19 @@ object ProviderModelTypes:
 
     def fromString(value: String): Option[ProviderKind] =
       value.trim.toLowerCase match
-        case "openai"    => Some(ProviderKind.OpenAI)
-        case "openrouter" => Some(ProviderKind.OpenRouter)
-        case "azure"     => Some(ProviderKind.Azure)
-        case "anthropic" => Some(ProviderKind.Anthropic)
-        case "ollama"    => Some(ProviderKind.Ollama)
-        case "zai"       => Some(ProviderKind.Zai)
-        case "gemini"    => Some(ProviderKind.Gemini)
-        case "google"    => Some(ProviderKind.Gemini)
-        case "deepseek"  => Some(ProviderKind.DeepSeek)
-        case "cohere"    => Some(ProviderKind.Cohere)
-        case "mistral"   => Some(ProviderKind.Mistral)
+        case "openai"                            => Some(ProviderKind.OpenAI)
+        case "openrouter"                        => Some(ProviderKind.OpenRouter)
+        case "azure"                             => Some(ProviderKind.Azure)
+        case "anthropic"                         => Some(ProviderKind.Anthropic)
+        case "ollama"                            => Some(ProviderKind.Ollama)
+        case "zai"                               => Some(ProviderKind.Zai)
+        case "gemini"                            => Some(ProviderKind.Gemini)
+        case "google"                            => Some(ProviderKind.Gemini)
+        case "deepseek"                          => Some(ProviderKind.DeepSeek)
+        case "cohere"                            => Some(ProviderKind.Cohere)
+        case "mistral"                           => Some(ProviderKind.Mistral)
         case "vertex" | "vertexai" | "vertex_ai" => Some(ProviderKind.VertexAI)
-        case _           => None
+        case _                                   => None
 
     def fromName(value: String): Option[ProviderKind] =
       fromString(value)

--- a/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
+++ b/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
@@ -35,6 +35,7 @@ object ProviderModelTypes:
     case DeepSeek
     case Cohere
     case Mistral
+    case VertexAI
 
   object ProviderKind:
     val all: Seq[ProviderKind] = Seq(
@@ -47,23 +48,25 @@ object ProviderModelTypes:
       ProviderKind.Gemini,
       ProviderKind.DeepSeek,
       ProviderKind.Cohere,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.VertexAI
     )
 
     def fromString(value: String): Option[ProviderKind] =
       value.trim.toLowerCase match
-        case "openai"     => Some(ProviderKind.OpenAI)
+        case "openai"    => Some(ProviderKind.OpenAI)
         case "openrouter" => Some(ProviderKind.OpenRouter)
-        case "azure"      => Some(ProviderKind.Azure)
-        case "anthropic"  => Some(ProviderKind.Anthropic)
-        case "ollama"     => Some(ProviderKind.Ollama)
-        case "zai"        => Some(ProviderKind.Zai)
-        case "gemini"     => Some(ProviderKind.Gemini)
-        case "google"     => Some(ProviderKind.Gemini)
-        case "deepseek"   => Some(ProviderKind.DeepSeek)
-        case "cohere"     => Some(ProviderKind.Cohere)
-        case "mistral"    => Some(ProviderKind.Mistral)
-        case _            => None
+        case "azure"     => Some(ProviderKind.Azure)
+        case "anthropic" => Some(ProviderKind.Anthropic)
+        case "ollama"    => Some(ProviderKind.Ollama)
+        case "zai"       => Some(ProviderKind.Zai)
+        case "gemini"    => Some(ProviderKind.Gemini)
+        case "google"    => Some(ProviderKind.Gemini)
+        case "deepseek"  => Some(ProviderKind.DeepSeek)
+        case "cohere"    => Some(ProviderKind.Cohere)
+        case "mistral"   => Some(ProviderKind.Mistral)
+        case "vertex" | "vertexai" | "vertex_ai" => Some(ProviderKind.VertexAI)
+        case _           => None
 
     def fromName(value: String): Option[ProviderKind] =
       fromString(value)
@@ -81,3 +84,4 @@ object ProviderModelTypes:
         case ProviderKind.DeepSeek   => "deepseek"
         case ProviderKind.Cohere     => "cohere"
         case ProviderKind.Mistral    => "mistral"
+        case ProviderKind.VertexAI   => "vertex"

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientClosedStateTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientClosedStateTest.scala
@@ -1,0 +1,81 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.ConfigurationError
+import org.llm4s.llmconnect.config.VertexAIConfig
+import org.llm4s.llmconnect.model.{ CompletionOptions, Conversation, UserMessage }
+import org.llm4s.model.ModelRegistryService
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Tests for [[VertexAIClient]] closed-state handling.
+ *
+ * Verifies that:
+ *  - Operations fail with [[ConfigurationError]] after `close()` is called.
+ *  - `close()` is idempotent (can be called multiple times safely).
+ */
+class VertexAIClientClosedStateTest extends AnyFlatSpec with Matchers {
+
+  private given ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+
+  private def testConfig: VertexAIConfig = VertexAIConfig(
+    project = "test-project",
+    location = "us-central1",
+    model = "gemini-1.5-flash",
+    accessToken = "test-token",
+    baseUrl = "https://example.invalid/v1",
+    contextWindow = 1048576,
+    reserveCompletion = 8192,
+  )
+
+  private def conversation: Conversation = Conversation(Seq(UserMessage("Hello")))
+
+  "VertexAIClient" should "return ConfigurationError when complete() is called after close()" in {
+    val client = new VertexAIClient(testConfig)
+    client.close()
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[ConfigurationError]
+    result.left.toOption.get.message should include("already closed")
+  }
+
+  it should "return ConfigurationError when streamComplete() is called after close()" in {
+    val client         = new VertexAIClient(testConfig)
+    var chunksReceived = 0
+    client.close()
+
+    val result = client.streamComplete(conversation, CompletionOptions(), _ => chunksReceived += 1)
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[ConfigurationError]
+    result.left.toOption.get.message should include("already closed")
+    chunksReceived shouldBe 0
+  }
+
+  it should "allow close() to be called multiple times (idempotent)" in {
+    val client = new VertexAIClient(testConfig)
+
+    noException should be thrownBy {
+      client.close()
+      client.close()
+      client.close()
+    }
+
+    val result = client.complete(conversation, CompletionOptions())
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[ConfigurationError]
+  }
+
+  it should "include the model name in the closed error message" in {
+    val config = testConfig.copy(model = "gemini-2.0-flash")
+    val client = new VertexAIClient(config)
+    client.close()
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get.message should include("gemini-2.0-flash")
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientSpec.scala
@@ -101,7 +101,8 @@ class VertexAIClientSpec extends AnyFlatSpec with Matchers {
        |}""".stripMargin
 
   private def ok(body: String): HttpResponse = HttpResponse(200, body, Map.empty)
-  private def err(status: Int): HttpResponse = HttpResponse(status, s"""{"error":{"message":"Error $status"}}""", Map.empty)
+  private def err(status: Int): HttpResponse =
+    HttpResponse(status, s"""{"error":{"message":"Error $status"}}""", Map.empty)
 
   // -----------------------------------------------------------------------
   // complete() — Gemini-on-Vertex response format
@@ -471,7 +472,7 @@ class VertexAIClientSpec extends AnyFlatSpec with Matchers {
 
   "VertexAIConfig" should "redact the access token in toString" in {
     val config = geminiConfig(token = "super-secret-token")
-    config.toString should not include "super-secret-token"
+    (config.toString should not).include("super-secret-token")
     config.toString should include("project=my-project")
     config.toString should include("location=us-central1")
   }

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/VertexAIClientSpec.scala
@@ -1,0 +1,534 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.http.{ FailingHttpClient, HttpResponse, MockHttpClient }
+import org.llm4s.llmconnect.{ ProviderExchange, ProviderExchangeLogging, ProviderExchangeSink }
+import org.llm4s.llmconnect.config.VertexAIConfig
+import org.llm4s.llmconnect.model._
+import org.llm4s.model.ModelRegistryService
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues._
+
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Mock-based integration tests for [[VertexAIClient]].
+ *
+ * Uses [[MockHttpClient]] / [[FailingHttpClient]] — no GCP credentials needed.
+ *
+ * Covers:
+ *  - Gemini-on-Vertex response format parsing
+ *  - Claude-on-Vertex response format parsing
+ *  - streamComplete() chunks assembled correctly
+ *  - ADC auth failure (empty access token) → ConfigurationError
+ *  - 401/403 responses → AuthenticationError
+ *  - Quota exceeded (429) → RateLimitError
+ *  - Regional endpoint routing (us-central1, europe-west1)
+ *  - Network failure → wrapped error
+ *  - Provider exchange logging
+ */
+class VertexAIClientSpec extends AnyFlatSpec with Matchers {
+
+  private given ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+
+  // -----------------------------------------------------------------------
+  // Helpers
+  // -----------------------------------------------------------------------
+
+  private def geminiConfig(
+    project: String = "my-project",
+    location: String = "us-central1",
+    model: String = "gemini-1.5-flash",
+    token: String = "test-token",
+    baseUrl: String = "https://us-central1-aiplatform.googleapis.com/v1",
+  ): VertexAIConfig =
+    VertexAIConfig(
+      project = project,
+      location = location,
+      model = model,
+      accessToken = token,
+      baseUrl = baseUrl,
+      contextWindow = 1048576,
+      reserveCompletion = 8192,
+    )
+
+  private def claudeConfig(
+    project: String = "my-project",
+    location: String = "us-central1",
+    model: String = "claude-3-haiku@20240307",
+    token: String = "test-token",
+    baseUrl: String = "https://us-central1-aiplatform.googleapis.com/v1",
+  ): VertexAIConfig =
+    VertexAIConfig(
+      project = project,
+      location = location,
+      model = model,
+      accessToken = token,
+      baseUrl = baseUrl,
+      contextWindow = 200000,
+      reserveCompletion = 8192,
+    )
+
+  private def mkGeminiClient(mockHttp: MockHttpClient, config: VertexAIConfig = geminiConfig()): VertexAIClient =
+    VertexAIClient.forTest(config, mockHttp)
+
+  private def conversation(text: String = "Hello"): Conversation =
+    Conversation(messages = Seq(UserMessage(text)))
+
+  private def geminiSuccessBody: String =
+    """|{
+       |  "candidates": [{
+       |    "content": {
+       |      "parts": [{"text": "Hello from Vertex!"}],
+       |      "role": "model"
+       |    },
+       |    "finishReason": "STOP"
+       |  }],
+       |  "usageMetadata": {
+       |    "promptTokenCount": 10,
+       |    "candidatesTokenCount": 5,
+       |    "totalTokenCount": 15
+       |  }
+       |}""".stripMargin
+
+  private def claudeSuccessBody: String =
+    """|{
+       |  "id": "msg-vertex-001",
+       |  "type": "message",
+       |  "role": "assistant",
+       |  "content": [{"type": "text", "text": "Hello from Claude on Vertex!"}],
+       |  "usage": {"input_tokens": 12, "output_tokens": 7}
+       |}""".stripMargin
+
+  private def ok(body: String): HttpResponse = HttpResponse(200, body, Map.empty)
+  private def err(status: Int): HttpResponse = HttpResponse(status, s"""{"error":{"message":"Error $status"}}""", Map.empty)
+
+  // -----------------------------------------------------------------------
+  // complete() — Gemini-on-Vertex response format
+  // -----------------------------------------------------------------------
+
+  "VertexAIClient.complete() with Gemini model" should "parse text content from a 200 response" in {
+    val mock   = new MockHttpClient(ok(geminiSuccessBody))
+    val client = mkGeminiClient(mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.content shouldBe "Hello from Vertex!"
+  }
+
+  it should "parse token usage from the Gemini response" in {
+    val mock   = new MockHttpClient(ok(geminiSuccessBody))
+    val client = mkGeminiClient(mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isRight shouldBe true
+    val usage = result.toOption.get.usage.value
+    usage.promptTokens shouldBe 10
+    usage.completionTokens shouldBe 5
+    usage.totalTokens shouldBe 15
+  }
+
+  it should "set the model name in the Completion from config" in {
+    val mock   = new MockHttpClient(ok(geminiSuccessBody))
+    val client = mkGeminiClient(mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.model shouldBe "gemini-1.5-flash"
+  }
+
+  it should "parse a Gemini tool-call response" in {
+    val toolCallBody =
+      """{
+        |  "candidates": [{
+        |    "content": {
+        |      "parts": [{"functionCall": {"name": "get_weather", "args": {"city": "London"}}}],
+        |      "role": "model"
+        |    }
+        |  }]
+        |}""".stripMargin
+    val mock   = new MockHttpClient(ok(toolCallBody))
+    val client = mkGeminiClient(mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isRight shouldBe true
+    val completion = result.toOption.get
+    completion.toolCalls should have size 1
+    completion.toolCalls.head.name shouldBe "get_weather"
+  }
+
+  it should "return an error when candidates array is empty" in {
+    val emptyBody = """{"candidates": []}"""
+    val mock      = new MockHttpClient(ok(emptyBody))
+    val client    = mkGeminiClient(mock)
+    val result    = client.complete(conversation(), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.ValidationError]
+  }
+
+  // -----------------------------------------------------------------------
+  // complete() — Claude-on-Vertex response format
+  // -----------------------------------------------------------------------
+
+  "VertexAIClient.complete() with Claude model" should "parse text content from an Anthropic-format response" in {
+    val mock   = new MockHttpClient(ok(claudeSuccessBody))
+    val client = VertexAIClient.forTest(claudeConfig(), mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.content shouldBe "Hello from Claude on Vertex!"
+  }
+
+  it should "parse token usage from the Claude response" in {
+    val mock   = new MockHttpClient(ok(claudeSuccessBody))
+    val client = VertexAIClient.forTest(claudeConfig(), mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isRight shouldBe true
+    val usage = result.toOption.get.usage.value
+    usage.promptTokens shouldBe 12
+    usage.completionTokens shouldBe 7
+  }
+
+  it should "preserve the response id from the Claude response" in {
+    val mock   = new MockHttpClient(ok(claudeSuccessBody))
+    val client = VertexAIClient.forTest(claudeConfig(), mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.id shouldBe "msg-vertex-001"
+  }
+
+  it should "set the model name in the Completion from config" in {
+    val mock   = new MockHttpClient(ok(claudeSuccessBody))
+    val client = VertexAIClient.forTest(claudeConfig(), mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.model shouldBe "claude-3-haiku@20240307"
+  }
+
+  // -----------------------------------------------------------------------
+  // Error handling — HTTP status codes
+  // -----------------------------------------------------------------------
+
+  "VertexAIClient.complete() error handling" should "return AuthenticationError on HTTP 401" in {
+    val mock   = new MockHttpClient(err(401))
+    val client = mkGeminiClient(mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.AuthenticationError]
+  }
+
+  it should "return AuthenticationError on HTTP 403" in {
+    val mock   = new MockHttpClient(err(403))
+    val client = mkGeminiClient(mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.AuthenticationError]
+  }
+
+  it should "return RateLimitError on HTTP 429 (quota exceeded)" in {
+    val quotaBody = """{"error":{"code":429,"message":"Quota exceeded","status":"RESOURCE_EXHAUSTED"}}"""
+    val mock      = new MockHttpClient(HttpResponse(429, quotaBody, Map.empty))
+    val client    = mkGeminiClient(mock)
+    val result    = client.complete(conversation(), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.RateLimitError]
+  }
+
+  it should "return ValidationError on HTTP 400" in {
+    val mock   = new MockHttpClient(err(400))
+    val client = mkGeminiClient(mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.ValidationError]
+  }
+
+  it should "return ServiceError on HTTP 500" in {
+    val mock   = new MockHttpClient(err(500))
+    val client = mkGeminiClient(mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.ServiceError]
+  }
+
+  it should "return ConfigurationError when accessToken is empty (ADC auth failure)" in {
+    val config = geminiConfig(token = "")
+    val mock   = new MockHttpClient(ok(geminiSuccessBody))
+    val client = VertexAIClient.forTest(config, mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.ConfigurationError]
+  }
+
+  it should "return ConfigurationError when accessToken is blank (ADC auth failure)" in {
+    val config = geminiConfig(token = "   ")
+    val mock   = new MockHttpClient(ok(geminiSuccessBody))
+    val client = VertexAIClient.forTest(config, mock)
+    val result = client.complete(conversation(), CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.ConfigurationError]
+  }
+
+  it should "return a wrapped error on network failure" in {
+    val failing = new FailingHttpClient(new java.io.IOException("connection refused"))
+    val client  = VertexAIClient.forTest(geminiConfig(), failing)
+    val result  = client.complete(conversation(), CompletionOptions())
+
+    result.isLeft shouldBe true
+  }
+
+  // -----------------------------------------------------------------------
+  // Regional endpoint routing
+  // -----------------------------------------------------------------------
+
+  "VertexAIClient endpoint routing" should "use us-central1 regional endpoint" in {
+    val config = geminiConfig(
+      location = "us-central1",
+      baseUrl = "https://us-central1-aiplatform.googleapis.com/v1",
+    )
+    val mock   = new MockHttpClient(ok(geminiSuccessBody))
+    val client = VertexAIClient.forTest(config, mock)
+    val _      = client.complete(conversation(), CompletionOptions())
+
+    mock.lastUrl.value should include("us-central1-aiplatform.googleapis.com")
+    mock.lastUrl.value should include("us-central1")
+  }
+
+  it should "use europe-west1 regional endpoint" in {
+    val config = geminiConfig(
+      location = "europe-west1",
+      baseUrl = "https://europe-west1-aiplatform.googleapis.com/v1",
+    )
+    val mock   = new MockHttpClient(ok(geminiSuccessBody))
+    val client = VertexAIClient.forTest(config, mock)
+    val _      = client.complete(conversation(), CompletionOptions())
+
+    mock.lastUrl.value should include("europe-west1-aiplatform.googleapis.com")
+    mock.lastUrl.value should include("europe-west1")
+  }
+
+  it should "include project and location in Gemini endpoint URL" in {
+    val config = geminiConfig(project = "test-project", location = "us-central1")
+    val mock   = new MockHttpClient(ok(geminiSuccessBody))
+    val client = VertexAIClient.forTest(config, mock)
+    val _      = client.complete(conversation(), CompletionOptions())
+
+    mock.lastUrl.value should include("test-project")
+    mock.lastUrl.value should include("us-central1")
+    mock.lastUrl.value should include("generateContent")
+  }
+
+  it should "use rawPredict endpoint for Claude models" in {
+    val config = claudeConfig()
+    val mock   = new MockHttpClient(ok(claudeSuccessBody))
+    val client = VertexAIClient.forTest(config, mock)
+    val _      = client.complete(conversation(), CompletionOptions())
+
+    mock.lastUrl.value should include("rawPredict")
+    mock.lastUrl.value should include("anthropic")
+  }
+
+  it should "use generateContent endpoint for Gemini models" in {
+    val config = geminiConfig()
+    val mock   = new MockHttpClient(ok(geminiSuccessBody))
+    val client = VertexAIClient.forTest(config, mock)
+    val _      = client.complete(conversation(), CompletionOptions())
+
+    mock.lastUrl.value should include("generateContent")
+    mock.lastUrl.value should include("google")
+  }
+
+  it should "include Authorization header with Bearer token" in {
+    val config = geminiConfig(token = "my-access-token")
+    val mock   = new MockHttpClient(ok(geminiSuccessBody))
+    val client = VertexAIClient.forTest(config, mock)
+    val _      = client.complete(conversation(), CompletionOptions())
+
+    mock.lastHeaders.value.get("Authorization") shouldBe Some("Bearer my-access-token")
+  }
+
+  // -----------------------------------------------------------------------
+  // streamComplete() — Gemini SSE chunks
+  // -----------------------------------------------------------------------
+
+  "VertexAIClient.streamComplete()" should "parse SSE lines and accumulate into a Completion" in {
+    val sseData =
+      "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}]}}]}\n" +
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" world\"}]}}]," +
+        "\"usageMetadata\":{\"promptTokenCount\":5,\"candidatesTokenCount\":2,\"totalTokenCount\":7}}\n"
+
+    val mock   = new MockHttpClient(HttpResponse(200, sseData, Map.empty))
+    val chunks = ListBuffer.empty[StreamedChunk]
+    val client = VertexAIClient.forTest(geminiConfig(), mock)
+    val result = client.streamComplete(conversation(), CompletionOptions(), c => chunks += c)
+
+    result.isRight shouldBe true
+    result.toOption.get.content should include("Hello")
+    result.toOption.get.content should include("world")
+    chunks should have size 2
+  }
+
+  it should "parse token usage from the final SSE chunk" in {
+    val sseData =
+      "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Done\"}]}}]," +
+        "\"usageMetadata\":{\"promptTokenCount\":5,\"candidatesTokenCount\":2,\"totalTokenCount\":7}}\n"
+
+    val mock   = new MockHttpClient(HttpResponse(200, sseData, Map.empty))
+    val client = VertexAIClient.forTest(geminiConfig(), mock)
+    val result = client.streamComplete(conversation(), CompletionOptions(), _ => ())
+
+    result.isRight shouldBe true
+    val usage = result.toOption.get.usage.value
+    usage.promptTokens shouldBe 5
+    usage.completionTokens shouldBe 2
+  }
+
+  it should "return AuthenticationError on non-200 streaming status" in {
+    val errorBody = """{"error":{"message":"API key missing","status":"UNAUTHENTICATED"}}"""
+    val mock      = new MockHttpClient(HttpResponse(401, errorBody, Map.empty))
+    val client    = VertexAIClient.forTest(geminiConfig(), mock)
+    val result    = client.streamComplete(conversation(), CompletionOptions(), _ => ())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.AuthenticationError]
+  }
+
+  it should "return ConfigurationError when accessToken is empty during streaming" in {
+    val config = geminiConfig(token = "")
+    val mock   = new MockHttpClient(HttpResponse(200, "", Map.empty))
+    val client = VertexAIClient.forTest(config, mock)
+    val result = client.streamComplete(conversation(), CompletionOptions(), _ => ())
+
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[org.llm4s.error.ConfigurationError]
+  }
+
+  it should "use streamGenerateContent endpoint for Gemini streaming" in {
+    val sseData = "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hi\"}]}}]}\n"
+    val mock    = new MockHttpClient(HttpResponse(200, sseData, Map.empty))
+    val client  = VertexAIClient.forTest(geminiConfig(), mock)
+    val _       = client.streamComplete(conversation(), CompletionOptions(), _ => ())
+
+    mock.lastUrl.value should include("streamGenerateContent")
+  }
+
+  // -----------------------------------------------------------------------
+  // Provider exchange logging
+  // -----------------------------------------------------------------------
+
+  "VertexAIClient exchange logging" should "record exchanges when logging is enabled" in {
+    val exchanges = ListBuffer.empty[ProviderExchange]
+    val sink = new ProviderExchangeSink {
+      override def record(exchange: ProviderExchange): Unit = exchanges += exchange
+    }
+
+    val mock = new MockHttpClient(ok(geminiSuccessBody))
+    val client = new VertexAIClient(
+      geminiConfig(),
+      org.llm4s.metrics.MetricsCollector.noop,
+      ProviderExchangeLogging.Enabled(sink),
+      mock,
+    )
+    val result = client.complete(conversation("test message"), CompletionOptions())
+
+    result.isRight shouldBe true
+    exchanges should have size 1
+    exchanges.head.provider shouldBe "vertex"
+    exchanges.head.model shouldBe Some("gemini-1.5-flash")
+    exchanges.head.requestBody should include("test message")
+    exchanges.head.responseBody.value should include("Hello from Vertex!")
+  }
+
+  // -----------------------------------------------------------------------
+  // Config accessors
+  // -----------------------------------------------------------------------
+
+  "VertexAIClient config accessors" should "return correct context window" in {
+    val mock   = new MockHttpClient(ok(geminiSuccessBody))
+    val client = mkGeminiClient(mock)
+    client.getContextWindow() shouldBe 1048576
+  }
+
+  it should "return correct reserve completion" in {
+    val mock   = new MockHttpClient(ok(geminiSuccessBody))
+    val client = mkGeminiClient(mock)
+    client.getReserveCompletion() shouldBe 8192
+  }
+
+  // -----------------------------------------------------------------------
+  // VertexAIConfig tests
+  // -----------------------------------------------------------------------
+
+  "VertexAIConfig" should "redact the access token in toString" in {
+    val config = geminiConfig(token = "super-secret-token")
+    config.toString should not include "super-secret-token"
+    config.toString should include("project=my-project")
+    config.toString should include("location=us-central1")
+  }
+
+  it should "expose the correct ProviderKind" in {
+    val config = geminiConfig()
+    config.provider shouldBe org.llm4s.types.ProviderModelTypes.ProviderKind.VertexAI
+  }
+
+  it should "derive the correct regional base URL from location using fromValues" in {
+    import org.llm4s.llmconnect.config.ContextWindowResolver
+    given ContextWindowResolver = ContextWindowResolver(
+      org.llm4s.model.ModelRegistryTestSupport.defaultService()
+    )
+    val config = VertexAIConfig.fromValues(
+      project = "my-project",
+      location = "europe-west1",
+      modelName = "gemini-1.5-flash",
+      accessToken = "tok",
+    )
+    config.baseUrl should include("europe-west1")
+    config.baseUrl should include("aiplatform.googleapis.com")
+  }
+
+  it should "use custom baseUrl when provided via fromValues" in {
+    import org.llm4s.llmconnect.config.ContextWindowResolver
+    given ContextWindowResolver = ContextWindowResolver(
+      org.llm4s.model.ModelRegistryTestSupport.defaultService()
+    )
+    val config = VertexAIConfig.fromValues(
+      project = "my-project",
+      location = "us-central1",
+      modelName = "gemini-1.5-flash",
+      accessToken = "tok",
+      baseUrl = "http://localhost:9999",
+    )
+    config.baseUrl shouldBe "http://localhost:9999"
+  }
+
+  // -----------------------------------------------------------------------
+  // LLMConnect routing
+  // -----------------------------------------------------------------------
+
+  "LLMConnect" should "route VertexAIConfig to VertexAIClient" in {
+    import org.llm4s.llmconnect.LLMConnect
+    val config = geminiConfig()
+    val result = LLMConnect.getClient(config)
+    result.isRight shouldBe true
+    result.toOption.get shouldBe a[VertexAIClient]
+  }
+
+  it should "route ProviderKind.VertexAI with VertexAIConfig correctly" in {
+    import org.llm4s.llmconnect.LLMConnect
+    import org.llm4s.types.ProviderModelTypes.ProviderKind
+    val config = geminiConfig()
+    val result = LLMConnect.getClient(ProviderKind.VertexAI, config)
+    result.isRight shouldBe true
+    result.toOption.get shouldBe a[VertexAIClient]
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
@@ -72,6 +72,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       case ProviderKind.DeepSeek   => "cloud-deepseek"
       case ProviderKind.Cohere     => "cloud-cohere"
       case ProviderKind.Mistral    => "cloud-mistral"
+      case ProviderKind.VertexAI   => "cloud-vertex"
 
     describe(ProviderKind.OpenAI) shouldBe "cloud-openai"
     describe(ProviderKind.Ollama) shouldBe "local"

--- a/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 class ProviderKindSpec extends AnyFlatSpec with Matchers:
 
   "ProviderKind" should "expose all expected provider instances" in {
-    ProviderKind.all should have size 10
+    ProviderKind.all should have size 11
     (ProviderKind.all should contain).allOf(
       ProviderKind.OpenAI,
       ProviderKind.Azure,
@@ -18,7 +18,8 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       ProviderKind.Gemini,
       ProviderKind.Cohere,
       ProviderKind.DeepSeek,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.VertexAI
     )
   }
 
@@ -33,6 +34,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     ProviderKind.DeepSeek.name shouldBe "deepseek"
     ProviderKind.Cohere.name shouldBe "cohere"
     ProviderKind.Mistral.name shouldBe "mistral"
+    ProviderKind.VertexAI.name shouldBe "vertex"
   }
 
   "ProviderKind.fromName" should "parse supported providers case-insensitively" in {
@@ -47,6 +49,9 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     ProviderKind.fromName("DEEPSEEK") shouldBe Some(ProviderKind.DeepSeek)
     ProviderKind.fromName("COHERE") shouldBe Some(ProviderKind.Cohere)
     ProviderKind.fromName("MISTRAL") shouldBe Some(ProviderKind.Mistral)
+    ProviderKind.fromName("vertex") shouldBe Some(ProviderKind.VertexAI)
+    ProviderKind.fromName("vertexai") shouldBe Some(ProviderKind.VertexAI)
+    ProviderKind.fromName("vertex_ai") shouldBe Some(ProviderKind.VertexAI)
   }
 
   it should "return None for unknown providers" in {

--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/VertexAISmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/VertexAISmokeSpec.scala
@@ -1,0 +1,179 @@
+package org.llm4s.llmconnect.smoke
+
+import org.llm4s.llmconnect.config.{ ContextWindowResolver, VertexAIConfig }
+import org.llm4s.llmconnect.model.{ CompletionOptions, Conversation, StreamedChunk, UserMessage }
+import org.llm4s.llmconnect.provider.VertexAIClient
+import org.llm4s.model.ModelRegistryService
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Real-endpoint smoke tests for the Vertex AI provider.
+ *
+ * These tests live in the dedicated integration-test module so default `sbt test`
+ * stays fast. Run them with `sbt "it/testOnly org.llm4s.llmconnect.smoke.*"`
+ * or the `sbt testSmoke` alias.
+ *
+ * == Required environment variables ==
+ *
+ *  - `GOOGLE_CLOUD_PROJECT`            — GCP project ID
+ *  - `GOOGLE_CLOUD_LOCATION`           — GCP region (e.g. `us-central1`)
+ *  - `VERTEX_ACCESS_TOKEN`             — OAuth2 bearer token obtained from ADC
+ *                                        (`gcloud auth print-access-token`)
+ *
+ * All tests are skipped gracefully when any of these variables is absent.
+ *
+ * == Optional: Anthropic on Vertex ==
+ *
+ * Tests against `claude-3-haiku@20240307` are also skipped unless
+ * `VERTEX_ANTHROPIC_MODEL` is set (e.g. `claude-3-haiku@20240307`).
+ * Claude access on Vertex requires explicit model enablement in your GCP
+ * project.
+ *
+ * @see [[org.llm4s.llmconnect.provider.VertexAIClient]]
+ * @see [[org.llm4s.llmconnect.smoke.GeminiSmokeSpec]] for the public Gemini API smoke tests
+ */
+class VertexAISmokeSpec extends AnyFlatSpec with Matchers {
+
+  private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
+  private given ContextWindowResolver    = ContextWindowResolver(mrs)
+
+  // Environment variables
+  private val project: Option[String]  = Option(System.getenv("GOOGLE_CLOUD_PROJECT")).filter(_.nonEmpty)
+  private val location: Option[String] = Option(System.getenv("GOOGLE_CLOUD_LOCATION")).filter(_.nonEmpty)
+  private val token: Option[String]    = Option(System.getenv("VERTEX_ACCESS_TOKEN")).filter(_.nonEmpty)
+
+  // Optional Anthropic model (Claude on Vertex)
+  private val anthropicModel: Option[String] =
+    Option(System.getenv("VERTEX_ANTHROPIC_MODEL")).filter(_.nonEmpty)
+
+  /** True only when all required GCP env vars are present. */
+  private def gcpCredentialsPresent: Boolean =
+    project.isDefined && location.isDefined && token.isDefined
+
+  private def geminiConfig: VertexAIConfig =
+    VertexAIConfig.fromValues(
+      project = project.get,
+      location = location.get,
+      modelName = "gemini-1.5-flash",
+      accessToken = token.get,
+    )
+
+  private def claudeConfig(model: String): VertexAIConfig =
+    VertexAIConfig.fromValues(
+      project = project.get,
+      location = location.get,
+      modelName = model,
+      accessToken = token.get,
+    )
+
+  private def conversation: Conversation = Conversation(Seq(UserMessage("Say hi in one word")))
+
+  // -----------------------------------------------------------------------
+  // Gemini-on-Vertex smoke tests
+  // -----------------------------------------------------------------------
+
+  "Vertex AI Gemini" should "complete a basic request" in {
+    assume(gcpCredentialsPresent, "GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_LOCATION, or VERTEX_ACCESS_TOKEN not set")
+
+    val clientResult = VertexAIClient(geminiConfig)
+    withClue(s"Client creation failed: ${clientResult.swap.toOption}") {
+      clientResult.isRight shouldBe true
+    }
+
+    val client     = clientResult.toOption.get
+    val completion = client.complete(conversation, CompletionOptions())
+
+    withClue(s"Completion failed: ${completion.swap.toOption}") {
+      completion.isRight shouldBe true
+    }
+    completion.toOption.get.content should not be empty
+  }
+
+  it should "populate token usage in the response" in {
+    assume(gcpCredentialsPresent, "GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_LOCATION, or VERTEX_ACCESS_TOKEN not set")
+
+    val client     = VertexAIClient(geminiConfig).toOption.get
+    val completion = client.complete(conversation, CompletionOptions())
+
+    withClue(s"Completion failed: ${completion.swap.toOption}") {
+      completion.isRight shouldBe true
+    }
+    val usage = completion.toOption.get.usage
+    usage shouldBe defined
+    usage.foreach { u =>
+      u.promptTokens should be > 0
+      u.completionTokens should be > 0
+    }
+  }
+
+  it should "stream a response and emit at least one chunk" in {
+    assume(gcpCredentialsPresent, "GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_LOCATION, or VERTEX_ACCESS_TOKEN not set")
+
+    val client = VertexAIClient(geminiConfig).toOption.get
+    val chunks = scala.collection.mutable.ListBuffer.empty[StreamedChunk]
+    val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+    withClue(s"Streaming failed: ${result.swap.toOption}") {
+      result.isRight shouldBe true
+    }
+    result.toOption.get.content should not be empty
+    chunks should not be empty
+  }
+
+  it should "return an authentication error for an invalid token" in {
+    assume(gcpCredentialsPresent, "GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_LOCATION, or VERTEX_ACCESS_TOKEN not set")
+
+    val badConfig = VertexAIConfig.fromValues(
+      project = project.get,
+      location = location.get,
+      modelName = "gemini-1.5-flash",
+      accessToken = "invalid-token-for-testing",
+    )
+    val client = VertexAIClient(badConfig).toOption.get
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe an[org.llm4s.error.AuthenticationError]
+  }
+
+  // -----------------------------------------------------------------------
+  // Claude-on-Vertex smoke tests (optional — requires explicit access)
+  // -----------------------------------------------------------------------
+
+  "Vertex AI Claude (Anthropic on Vertex)" should "complete a basic request" in {
+    assume(gcpCredentialsPresent, "GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_LOCATION, or VERTEX_ACCESS_TOKEN not set")
+    assume(anthropicModel.isDefined, "VERTEX_ANTHROPIC_MODEL not set; skipping Anthropic-on-Vertex tests")
+
+    val clientResult = VertexAIClient(claudeConfig(anthropicModel.get))
+    withClue(s"Client creation failed: ${clientResult.swap.toOption}") {
+      clientResult.isRight shouldBe true
+    }
+
+    val client     = clientResult.toOption.get
+    val completion = client.complete(conversation, CompletionOptions())
+
+    withClue(s"Claude-on-Vertex completion failed: ${completion.swap.toOption}") {
+      completion.isRight shouldBe true
+    }
+    completion.toOption.get.content should not be empty
+  }
+
+  it should "populate token usage in the Claude response" in {
+    assume(gcpCredentialsPresent, "GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_LOCATION, or VERTEX_ACCESS_TOKEN not set")
+    assume(anthropicModel.isDefined, "VERTEX_ANTHROPIC_MODEL not set; skipping Anthropic-on-Vertex tests")
+
+    val client     = VertexAIClient(claudeConfig(anthropicModel.get)).toOption.get
+    val completion = client.complete(conversation, CompletionOptions())
+
+    withClue(s"Claude-on-Vertex completion failed: ${completion.swap.toOption}") {
+      completion.isRight shouldBe true
+    }
+    val usage = completion.toOption.get.usage
+    usage shouldBe defined
+    usage.foreach { u =>
+      u.promptTokens should be > 0
+      u.completionTokens should be > 0
+    }
+  }
+}

--- a/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
@@ -372,6 +372,12 @@ private[providersetup] object ProviderSetupRuntime:
           apiKey = input.flatMap(_.apiKey).getOrElse(cfg.apiKey),
           baseUrl = input.flatMap(_.baseUrl).getOrElse(cfg.baseUrl)
         )
+      case cfg: VertexAIConfig =>
+        cfg.copy(
+          model = input.flatMap(_.model).getOrElse(cfg.model),
+          accessToken = input.flatMap(_.apiKey).getOrElse(cfg.accessToken),
+          baseUrl = input.flatMap(_.baseUrl).getOrElse(cfg.baseUrl)
+        )
 
   def demoCompletionCmd(
     providerConfig: ProviderConfig,
@@ -580,3 +586,4 @@ private[providersetup] object ProviderSetupRuntime:
       case cfg: CohereConfig    => cfg.copy(model = modelName)
       case cfg: MistralConfig   => cfg.copy(model = modelName)
       case cfg: ZaiConfig       => cfg.copy(model = modelName)
+      case cfg: VertexAIConfig  => cfg.copy(model = modelName)

--- a/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
@@ -141,6 +141,7 @@ object PrometheusMetricsExample {
                 case _: org.llm4s.llmconnect.config.DeepSeekConfig  => "deepseek"
                 case _: org.llm4s.llmconnect.config.CohereConfig    => "cohere"
                 case _: org.llm4s.llmconnect.config.MistralConfig   => "mistral"
+                case _: org.llm4s.llmconnect.config.VertexAIConfig  => "vertex"
               }
 
               println(s"Using model: ${config.model}")


### PR DESCRIPTION
## Summary

Implements #1018: integration and smoke tests for the Google Vertex AI provider.

This PR adds the VertexAI provider implementation (required by the tests) plus a comprehensive test suite:

- **`VertexAIConfig`** — new config in `ProviderConfig.scala` with `project`, `location`, `model`, `accessToken`, and `baseUrl`; `fromValues()` derives the correct regional endpoint URL automatically
- **`VertexAIClient`** — new `LLMClient` implementation supporting:
  - Gemini-on-Vertex response format (`candidates` array) for `complete()`
  - Claude-on-Vertex (Anthropic messages format) for `complete()`
  - SSE streaming via `streamGenerateContent` endpoint
  - Bearer-token auth from `accessToken` (ADC-compatible)
  - Regional endpoint routing (`us-central1`, `europe-west1`, etc.)
  - `ConfigurationError` on empty access token (ADC auth failure) before any HTTP call
  - `forTest()` seam for `MockHttpClient` injection
- **`ProviderKind.VertexAI`** — added to the enum with `fromString` aliases (`"vertex"`, `"vertexai"`, `"vertex_ai"`)
- **`LLMConnect`** — routes `VertexAIConfig` to `VertexAIClient`

## Test Coverage

### Mock-based unit tests (`sbt test`, no GCP credentials needed)

**`VertexAIClientSpec`** covers all acceptance criteria:
- `complete()` with Gemini-on-Vertex response format → correct `Completion` parsed
- `complete()` with Claude-on-Vertex response format → correct `Completion` parsed
- `streamComplete()` → SSE chunks assembled correctly, token usage extracted
- Empty `accessToken` → `ConfigurationError` (ADC auth failure path)
- HTTP 401/403 → `AuthenticationError`
- HTTP 429 (quota exceeded) → `RateLimitError`
- Regional endpoint routing (`us-central1`, `europe-west1`)
- `rawPredict` endpoint used for Claude, `generateContent` for Gemini
- Bearer token included in `Authorization` header
- Network failure → wrapped error
- Provider exchange logging verified

**`VertexAIClientClosedStateTest`** covers lifecycle:
- `complete()`/`streamComplete()` after `close()` → `ConfigurationError`
- Idempotent `close()`

### Real-endpoint smoke tests (`sbt testSmoke`, requires GCP credentials)

**`VertexAISmokeSpec`** in `modules/it/`:
- Requires `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `VERTEX_ACCESS_TOKEN`; skips gracefully if absent
- Tests `complete()` with `gemini-1.5-flash`: `isRight`, response non-empty, token usage populated
- Tests `streamComplete()`: at least one chunk emitted
- Tests invalid token → `AuthenticationError`
- Optional Claude-on-Vertex tests gated on `VERTEX_ANTHROPIC_MODEL`

## CI Wiring

Added `vertex-smoke` job to `.github/workflows/ci.yml`:
- Triggered by `workflow_dispatch` (manual trigger only, avoids unintended API costs)
- Requires GCP secrets: `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `VERTEX_ACCESS_TOKEN`, `VERTEX_ANTHROPIC_MODEL`

Closes #1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)