### PR TITLE
feat: IBM WatsonX provider with integration and smoke tests (#1020)

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
@@ -104,3 +104,9 @@ private[config] object NamedProviderLoader:
         requiredApiKey("llm4s.providers.<name>.apiKey").map: apiKey =>
           val baseUrl = section.baseUrl.map(_.asUrl).getOrElse(MistralConfig.DEFAULT_BASE_URL)
           MistralConfig.fromValues(section.model.asString, apiKey, baseUrl)
+      case ProviderKind.WatsonX =>
+        for
+          apiKey    <- requiredApiKey("llm4s.providers.<name>.apiKey")
+          projectId <- required("project ID", section.endpoint, "llm4s.providers.<name>.endpoint")
+          baseUrl = section.baseUrl.map(_.asUrl).getOrElse(WatsonXConfig.DEFAULT_BASE_URL)
+        yield WatsonXConfig.fromValues(section.model.asString, apiKey, projectId, baseUrl)

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -170,7 +170,7 @@ object LLMConnect {
       case (ProviderKind.DeepSeek, cfg: DeepSeekConfig)   => DeepSeekClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Cohere, cfg: CohereConfig)       => CohereClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Mistral, cfg: MistralConfig)     => MistralClient(cfg, metrics, exchangeLogging)
-      case (ProviderKind.WatsonX, cfg: WatsonXConfig)    => WatsonXClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.WatsonX, cfg: WatsonXConfig)     => WatsonXClient(cfg, metrics, exchangeLogging)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -58,6 +58,8 @@ object LLMConnect {
         CohereClient(cfg, metrics, exchangeLogging)
       case cfg: MistralConfig =>
         MistralClient(cfg, metrics, exchangeLogging)
+      case cfg: WatsonXConfig =>
+        WatsonXClient(cfg, metrics, exchangeLogging)
     }
 
   def fromConfig(
@@ -168,6 +170,7 @@ object LLMConnect {
       case (ProviderKind.DeepSeek, cfg: DeepSeekConfig)   => DeepSeekClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Cohere, cfg: CohereConfig)       => CohereClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Mistral, cfg: MistralConfig)     => MistralClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.WatsonX, cfg: WatsonXConfig)    => WatsonXClient(cfg, metrics, exchangeLogging)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -677,3 +677,89 @@ object MistralConfig:
       contextWindow = cw,
       reserveCompletion = rc
     )
+
+/**
+ * Configuration for IBM WatsonX AI.
+ *
+ * IBM WatsonX uses IAM token-based authentication: the `apiKey` is exchanged for
+ * a short-lived bearer token at `iamUrl`. The bearer token is then used in
+ * all WatsonX API calls along with the `projectId`.
+ *
+ * Prefer [[WatsonXConfig.fromValues]] over the primary constructor; it resolves
+ * `contextWindow` and `reserveCompletion` automatically from the model name.
+ *
+ * @param apiKey        IBM Cloud API key; redacted in `toString`.
+ * @param projectId     IBM WatsonX project ID.
+ * @param model         Model identifier, e.g. `"ibm/granite-3-8b-instruct"`.
+ * @param baseUrl       WatsonX API base URL; defaults to [[WatsonXConfig.DEFAULT_BASE_URL]].
+ * @param iamUrl        IBM IAM token endpoint; defaults to [[WatsonXConfig.DEFAULT_IAM_URL]].
+ * @param contextWindow Model's total token capacity (prompt + completion combined).
+ * @param reserveCompletion Tokens held back from prompt history for the completion.
+ */
+case class WatsonXConfig(
+  apiKey: String,
+  projectId: String,
+  model: String,
+  baseUrl: String,
+  iamUrl: String,
+  contextWindow: Int,
+  reserveCompletion: Int
+) extends ProviderConfig:
+  override val provider: ProviderKind = ProviderKind.WatsonX
+  override def toString: String =
+    s"WatsonXConfig(apiKey=${Redaction.secret(apiKey)}, projectId=$projectId, model=$model, baseUrl=$baseUrl, " +
+      s"iamUrl=$iamUrl, contextWindow=$contextWindow, reserveCompletion=$reserveCompletion)"
+
+object WatsonXConfig {
+  val DEFAULT_BASE_URL: String = "https://us-south.ml.cloud.ibm.com"
+  val DEFAULT_IAM_URL: String  = "https://iam.cloud.ibm.com/identity/token"
+
+  private val DefaultContextWindow     = 8192
+  private val DefaultReserveCompletion = 2048
+
+  private val watsonxFallback: String => (Int, Int) = {
+    case name if name.contains("granite-3-8b") => (8192, DefaultReserveCompletion)
+    case name if name.contains("granite-13b")  => (8192, DefaultReserveCompletion)
+    case name if name.contains("granite")      => (8192, DefaultReserveCompletion)
+    case _                                     => (DefaultContextWindow, DefaultReserveCompletion)
+  }
+
+  /**
+   * Constructs a [[WatsonXConfig]], resolving `contextWindow` and
+   * `reserveCompletion` from the model name automatically.
+   *
+   * @param modelName Model identifier, e.g. `"ibm/granite-3-8b-instruct"`.
+   * @param apiKey    IBM Cloud API key; must be non-empty.
+   * @param projectId IBM WatsonX project ID; must be non-empty.
+   * @param baseUrl   WatsonX API base URL; must be non-empty.
+   * @param iamUrl    IBM IAM token endpoint URL; must be non-empty.
+   */
+  def fromValues(
+    modelName: String,
+    apiKey: String,
+    projectId: String,
+    baseUrl: String = DEFAULT_BASE_URL,
+    iamUrl: String = DEFAULT_IAM_URL
+  )(using resolver: ContextWindowResolver): WatsonXConfig = {
+    require(apiKey.trim.nonEmpty, "WatsonX apiKey must be non-empty")
+    require(projectId.trim.nonEmpty, "WatsonX projectId must be non-empty")
+    require(baseUrl.trim.nonEmpty, "WatsonX baseUrl must be non-empty")
+    require(iamUrl.trim.nonEmpty, "WatsonX iamUrl must be non-empty")
+    val (cw, rc) = resolver.resolve(
+      lookupProviders = Seq("watsonx"),
+      modelName = modelName,
+      defaultContextWindow = DefaultContextWindow,
+      defaultReserve = DefaultReserveCompletion,
+      fallbackResolver = watsonxFallback
+    )
+    WatsonXConfig(
+      apiKey = apiKey,
+      projectId = projectId,
+      model = modelName,
+      baseUrl = baseUrl,
+      iamUrl = iamUrl,
+      contextWindow = cw,
+      reserveCompletion = rc
+    )
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
@@ -92,7 +92,7 @@ class WatsonXClient(
 
   private def parseIamResponse(body: String): Result[String] =
     Try {
-      val json = ujson.read(body)
+      val json     = ujson.read(body)
       val tokenOpt = json.obj.get("access_token").flatMap(_.strOpt).filter(_.nonEmpty)
       val expiresInOpt =
         json.obj.get("expires_in").flatMap(_.numOpt).map(_.toLong)
@@ -113,25 +113,26 @@ class WatsonXClient(
   ): Result[Completion] = completeWithMetrics {
     val startedAt = Instant.now()
     for {
-      token       <- getBearerToken()
-      prompt      <- buildPrompt(conversation)
-      requestBody  = buildRequestBody(prompt, options)
-      requestText  = requestBody.render()
-      url          = s"${config.baseUrl}/ml/v1/text/generation?version=2023-05-29"
-      headers      = Map(
-        "Content-Type" -> "application/json",
+      token  <- getBearerToken()
+      prompt <- buildPrompt(conversation)
+      requestBody = buildRequestBody(prompt, options)
+      requestText = requestBody.render()
+      url         = s"${config.baseUrl}/ml/v1/text/generation?version=2023-05-29"
+      headers = Map(
+        "Content-Type"  -> "application/json",
         "Authorization" -> s"Bearer $token"
       )
-      response    <- Try(httpClient.post(url, headers, requestText, timeout = 120000)).toEither.left.map(_.toLLMError)
-      result      <- if (response.statusCode >= 200 && response.statusCode < 300) {
-        val r = parseCompletionResponse(response.body)
-        recordExchange(startedAt, requestText, Some(response.body), r)
-        r
-      } else {
-        val err = handleErrorResponse(response.statusCode, response.body, token)
-        recordExchange(startedAt, requestText, Some(response.body), err)
-        err
-      }
+      response <- Try(httpClient.post(url, headers, requestText, timeout = 120000)).toEither.left.map(_.toLLMError)
+      result <-
+        if (response.statusCode >= 200 && response.statusCode < 300) {
+          val r = parseCompletionResponse(response.body)
+          recordExchange(startedAt, requestText, Some(response.body), r)
+          r
+        } else {
+          val err = handleErrorResponse(response.statusCode, response.body, token)
+          recordExchange(startedAt, requestText, Some(response.body), err)
+          err
+        }
     } yield result
   }
 
@@ -142,26 +143,27 @@ class WatsonXClient(
   ): Result[Completion] = completeWithMetrics {
     val startedAt = Instant.now()
     for {
-      token       <- getBearerToken()
-      prompt      <- buildPrompt(conversation)
-      requestBody  = buildRequestBody(prompt, options)
-      requestText  = requestBody.render()
-      url          = s"${config.baseUrl}/ml/v1/text/generation_stream?version=2023-05-29"
-      headers      = Map(
+      token  <- getBearerToken()
+      prompt <- buildPrompt(conversation)
+      requestBody = buildRequestBody(prompt, options)
+      requestText = requestBody.render()
+      url         = s"${config.baseUrl}/ml/v1/text/generation_stream?version=2023-05-29"
+      headers = Map(
         "Content-Type"  -> "application/json",
         "Authorization" -> s"Bearer $token",
         "Accept"        -> "text/event-stream"
       )
-      streamResp   = httpClient.postStream(url, headers, requestText, timeout = 600000)
-      result       <- if (streamResp.statusCode < 200 || streamResp.statusCode >= 300) {
-        val errBody = new String(streamResp.body.readAllBytes(), StandardCharsets.UTF_8)
-        streamResp.body.close()
-        val err = handleErrorResponse(streamResp.statusCode, errBody, token)
-        recordExchange(startedAt, requestText, Some(errBody), err)
-        err
-      } else {
-        processStreamResponse(startedAt, requestText, streamResp.body, onChunk)
-      }
+      streamResp = httpClient.postStream(url, headers, requestText, timeout = 600000)
+      result <-
+        if (streamResp.statusCode < 200 || streamResp.statusCode >= 300) {
+          val errBody = new String(streamResp.body.readAllBytes(), StandardCharsets.UTF_8)
+          streamResp.body.close()
+          val err = handleErrorResponse(streamResp.statusCode, errBody, token)
+          recordExchange(startedAt, requestText, Some(errBody), err)
+          err
+        } else {
+          processStreamResponse(startedAt, requestText, streamResp.body, onChunk)
+        }
     } yield result
   }
 
@@ -171,12 +173,12 @@ class WatsonXClient(
     body: java.io.InputStream,
     onChunk: StreamedChunk => Unit
   ): Result[Completion] = {
-    val reader      = new BufferedReader(new InputStreamReader(body, StandardCharsets.UTF_8))
-    val rawStream   = new StringBuilder()
-    val accumulated = new StringBuilder()
+    val reader                        = new BufferedReader(new InputStreamReader(body, StandardCharsets.UTF_8))
+    val rawStream                     = new StringBuilder()
+    val accumulated                   = new StringBuilder()
     var promptTokens: Option[Int]     = None
     var completionTokens: Option[Int] = None
-    val messageId = java.util.UUID.randomUUID().toString
+    val messageId                     = java.util.UUID.randomUUID().toString
 
     val result = Try {
       try {
@@ -208,7 +210,7 @@ class WatsonXClient(
 
                 // Extract token usage if present
                 for {
-                  results   <- json.obj.get("results").flatMap(_.arrOpt)
+                  results     <- json.obj.get("results").flatMap(_.arrOpt)
                   firstResult <- results.headOption
                   inputTokens <- firstResult.obj.get("input_token_count").flatMap(_.numOpt)
                 } promptTokens = Some(inputTokens.toInt)
@@ -228,46 +230,48 @@ class WatsonXClient(
       }
     }.toEither.left.map(_.toLLMError)
 
-    result.flatMap { _ =>
-      val text = accumulated.toString()
-      if (text.isEmpty) {
-        Left(ValidationError("response", "Empty streaming response from WatsonX"))
-      } else {
-        val usageOpt = for {
-          pt <- promptTokens
-          ct <- completionTokens
-        } yield TokenUsage(promptTokens = pt, completionTokens = ct, totalTokens = pt + ct)
+    result
+      .flatMap { _ =>
+        val text = accumulated.toString()
+        if (text.isEmpty) {
+          Left(ValidationError("response", "Empty streaming response from WatsonX"))
+        } else {
+          val usageOpt = for {
+            pt <- promptTokens
+            ct <- completionTokens
+          } yield TokenUsage(promptTokens = pt, completionTokens = ct, totalTokens = pt + ct)
 
-        val costOpt = usageOpt.flatMap(u => CostEstimator.estimate(config.model, u))
-        val completion = Completion(
-          id = messageId,
-          created = System.currentTimeMillis() / 1000L,
-          content = text,
-          model = config.model,
-          message = AssistantMessage(contentOpt = Some(text), toolCalls = Seq.empty),
-          toolCalls = List.empty,
-          usage = usageOpt,
-          thinking = None,
-          estimatedCost = costOpt
-        )
-        recordExchange(startedAt, requestText, Some(rawStream.result()), Right(completion))
-        Right(completion)
+          val costOpt = usageOpt.flatMap(u => CostEstimator.estimate(config.model, u))
+          val completion = Completion(
+            id = messageId,
+            created = System.currentTimeMillis() / 1000L,
+            content = text,
+            model = config.model,
+            message = AssistantMessage(contentOpt = Some(text), toolCalls = Seq.empty),
+            toolCalls = List.empty,
+            usage = usageOpt,
+            thinking = None,
+            estimatedCost = costOpt
+          )
+          recordExchange(startedAt, requestText, Some(rawStream.result()), Right(completion))
+          Right(completion)
+        }
       }
-    }.tapLeft(err =>
-      recordExchange(
-        startedAt,
-        requestText,
-        Option.when(rawStream.nonEmpty)(rawStream.result()),
-        Left(err)
+      .tapLeft(err =>
+        recordExchange(
+          startedAt,
+          requestText,
+          Option.when(rawStream.nonEmpty)(rawStream.result()),
+          Left(err)
+        )
       )
-    )
   }
 
   override def getContextWindow(): Int = config.contextWindow
 
   override def getReserveCompletion(): Int = config.reserveCompletion
 
-  private def buildPrompt(conversation: Conversation): Result[String] = {
+  private def buildPrompt(conversation: Conversation): Result[String] =
     if (conversation.messages.isEmpty) {
       Left(ValidationError("conversation", "WatsonX requires at least one message"))
     } else {
@@ -285,7 +289,6 @@ class WatsonXClient(
       sb.append("Assistant:")
       Right(sb.toString())
     }
-  }
 
   private def buildRequestBody(prompt: String, options: CompletionOptions): ujson.Obj = {
     val params = ujson.Obj(
@@ -350,14 +353,13 @@ class WatsonXClient(
       }
     }.toEither.left.map(_.toLLMError).flatten
 
-  private def handleErrorResponse(statusCode: Int, body: String, token: String): Result[Nothing] = {
+  private def handleErrorResponse(statusCode: Int, body: String, token: String): Result[Nothing] =
     // Detect invalid project_id: WatsonX returns a specific error message
     if (body.contains("project_id") || body.contains("BXZAI0001E")) {
       Left(ValidationError("project_id", s"Invalid project_id: ${body.take(200)}"))
     } else {
       HttpErrorMapper.mapHttpError(statusCode, body, providerName)
     }
-  }
 
   private def recordExchange(
     startedAt: Instant,

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
@@ -1,0 +1,404 @@
+// scalafix:off DisableSyntax.NoKeywordTry
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.{ ConfigurationError, ValidationError }
+import org.llm4s.error.ThrowableOps._
+import org.llm4s.http.Llm4sHttpClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
+import org.llm4s.llmconnect.ProviderExchangeLogging
+import org.llm4s.llmconnect.config.WatsonXConfig
+import org.llm4s.llmconnect.model._
+import org.llm4s.llmconnect.provider.ProviderResultOps.*
+import org.llm4s.model.ModelRegistryService
+import org.llm4s.types.Result
+
+import java.io.{ BufferedReader, InputStreamReader }
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import scala.util.Try
+
+/**
+ * [[LLMClient]] implementation for IBM WatsonX AI.
+ *
+ * Authentication uses IBM IAM: the `apiKey` in [[WatsonXConfig]] is exchanged
+ * for a short-lived bearer token at the IAM endpoint. The token is cached and
+ * automatically refreshed when it expires (after ~3600 seconds). All calls to
+ * the WatsonX `/ml/v1/text/generation` endpoint include both the bearer token
+ * and the `project_id`.
+ *
+ * == Supported operations ==
+ *  - `complete()` via the `/ml/v1/text/generation` REST endpoint.
+ *  - `streamComplete()` via the `/ml/v1/text/generation_stream` SSE endpoint.
+ *
+ * == Message format ==
+ *
+ * WatsonX uses a prompt-based API (not a chat-completions API). The client
+ * converts the conversation into a single prompt string using role prefixes:
+ *  - `SystemMessage` content is prepended as-is.
+ *  - `UserMessage` content is prefixed with `"Human: "`.
+ *  - `AssistantMessage` content is prefixed with `"Assistant: "`.
+ *
+ * The prompt is then passed as the `input` field in the request body.
+ *
+ * @param config      [[WatsonXConfig]] carrying the API key, project ID, model, and URLs.
+ * @param metrics     Receives per-call latency and token-usage events.
+ * @param httpClient  HTTP client used for all outbound calls; injectable for testing.
+ */
+class WatsonXClient(
+  config: WatsonXConfig,
+  protected val metrics: org.llm4s.metrics.MetricsCollector = org.llm4s.metrics.MetricsCollector.noop,
+  exchangeLogging: ProviderExchangeLogging = ProviderExchangeLogging.Disabled,
+  private[provider] val httpClient: Llm4sHttpClient = Llm4sHttpClient.create()
+)(using val registryService: ModelRegistryService)
+    extends BaseLifecycleLLMClient {
+
+  protected def clientDescription: String = s"WatsonX client for model ${config.model}"
+  protected def providerName: String      = "watsonx"
+  protected def modelName: String         = config.model
+
+  // Cached IAM token: (token, expiresAtEpochSeconds)
+  private[provider] val cachedToken: AtomicReference[Option[(String, Long)]] =
+    new AtomicReference(None)
+
+  // Obtain a valid bearer token, refreshing if expired or absent
+  private[provider] def getBearerToken(): Result[String] = {
+    val now = System.currentTimeMillis() / 1000L
+    cachedToken.get() match {
+      case Some((token, expiresAt)) if expiresAt > now + 60 =>
+        Right(token)
+      case _ =>
+        exchangeIamToken()
+    }
+  }
+
+  private def exchangeIamToken(): Result[String] = {
+    val body =
+      s"grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=${config.apiKey}"
+    val headers = Map(
+      "Content-Type" -> "application/x-www-form-urlencoded",
+      "Accept"       -> "application/json"
+    )
+    Try {
+      httpClient.post(config.iamUrl, headers, body, timeout = 30000)
+    }.toEither.left.map(_.toLLMError).flatMap { response =>
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        parseIamResponse(response.body)
+      } else {
+        Left(ConfigurationError(s"IAM token exchange failed (HTTP ${response.statusCode}): ${response.body.take(200)}"))
+      }
+    }
+  }
+
+  private def parseIamResponse(body: String): Result[String] =
+    Try {
+      val json = ujson.read(body)
+      val tokenOpt = json.obj.get("access_token").flatMap(_.strOpt).filter(_.nonEmpty)
+      val expiresInOpt =
+        json.obj.get("expires_in").flatMap(_.numOpt).map(_.toLong)
+
+      tokenOpt match {
+        case None =>
+          Left(ConfigurationError(s"IAM response missing access_token: ${body.take(200)}"))
+        case Some(token) =>
+          val expiresAt = System.currentTimeMillis() / 1000L + expiresInOpt.getOrElse(3600L)
+          cachedToken.set(Some((token, expiresAt)))
+          Right(token)
+      }
+    }.toEither.left.map(e => ConfigurationError(s"Failed to parse IAM response: ${e.getMessage}")).flatten
+
+  override def complete(
+    conversation: Conversation,
+    options: CompletionOptions
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt = Instant.now()
+    for {
+      token       <- getBearerToken()
+      prompt      <- buildPrompt(conversation)
+      requestBody  = buildRequestBody(prompt, options)
+      requestText  = requestBody.render()
+      url          = s"${config.baseUrl}/ml/v1/text/generation?version=2023-05-29"
+      headers      = Map(
+        "Content-Type" -> "application/json",
+        "Authorization" -> s"Bearer $token"
+      )
+      response    <- Try(httpClient.post(url, headers, requestText, timeout = 120000)).toEither.left.map(_.toLLMError)
+      result      <- if (response.statusCode >= 200 && response.statusCode < 300) {
+        val r = parseCompletionResponse(response.body)
+        recordExchange(startedAt, requestText, Some(response.body), r)
+        r
+      } else {
+        val err = handleErrorResponse(response.statusCode, response.body, token)
+        recordExchange(startedAt, requestText, Some(response.body), err)
+        err
+      }
+    } yield result
+  }
+
+  override def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions(),
+    onChunk: StreamedChunk => Unit
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt = Instant.now()
+    for {
+      token       <- getBearerToken()
+      prompt      <- buildPrompt(conversation)
+      requestBody  = buildRequestBody(prompt, options)
+      requestText  = requestBody.render()
+      url          = s"${config.baseUrl}/ml/v1/text/generation_stream?version=2023-05-29"
+      headers      = Map(
+        "Content-Type"  -> "application/json",
+        "Authorization" -> s"Bearer $token",
+        "Accept"        -> "text/event-stream"
+      )
+      streamResp   = httpClient.postStream(url, headers, requestText, timeout = 600000)
+      result       <- if (streamResp.statusCode < 200 || streamResp.statusCode >= 300) {
+        val errBody = new String(streamResp.body.readAllBytes(), StandardCharsets.UTF_8)
+        streamResp.body.close()
+        val err = handleErrorResponse(streamResp.statusCode, errBody, token)
+        recordExchange(startedAt, requestText, Some(errBody), err)
+        err
+      } else {
+        processStreamResponse(startedAt, requestText, streamResp.body, onChunk)
+      }
+    } yield result
+  }
+
+  private def processStreamResponse(
+    startedAt: Instant,
+    requestText: String,
+    body: java.io.InputStream,
+    onChunk: StreamedChunk => Unit
+  ): Result[Completion] = {
+    val reader      = new BufferedReader(new InputStreamReader(body, StandardCharsets.UTF_8))
+    val rawStream   = new StringBuilder()
+    val accumulated = new StringBuilder()
+    var promptTokens: Option[Int]     = None
+    var completionTokens: Option[Int] = None
+    val messageId = java.util.UUID.randomUUID().toString
+
+    val result = Try {
+      try {
+        var line: String = null
+        while ({ line = reader.readLine(); line != null }) {
+          rawStream.append(line).append('\n')
+          val trimmed = line.trim
+          if (trimmed.startsWith("data: ")) {
+            val jsonStr = trimmed.stripPrefix("data: ").trim
+            if (jsonStr.nonEmpty && jsonStr != "[DONE]") {
+              Try(ujson.read(jsonStr)).foreach { json =>
+                // Extract generated text from the chunk
+                val textDelta = json.obj
+                  .get("results")
+                  .flatMap(_.arrOpt)
+                  .flatMap(_.headOption)
+                  .flatMap(_.obj.get("generated_text"))
+                  .flatMap(_.strOpt)
+                  .getOrElse("")
+
+                if (textDelta.nonEmpty) {
+                  accumulated.append(textDelta)
+                  val chunk = StreamedChunk(
+                    id = messageId,
+                    content = Some(textDelta)
+                  )
+                  onChunk(chunk)
+                }
+
+                // Extract token usage if present
+                for {
+                  results   <- json.obj.get("results").flatMap(_.arrOpt)
+                  firstResult <- results.headOption
+                  inputTokens <- firstResult.obj.get("input_token_count").flatMap(_.numOpt)
+                } promptTokens = Some(inputTokens.toInt)
+
+                for {
+                  results      <- json.obj.get("results").flatMap(_.arrOpt)
+                  firstResult  <- results.headOption
+                  outputTokens <- firstResult.obj.get("generated_token_count").flatMap(_.numOpt)
+                } completionTokens = Some(outputTokens.toInt)
+              }
+            }
+          }
+        }
+      } finally {
+        Try(reader.close())
+        Try(body.close())
+      }
+    }.toEither.left.map(_.toLLMError)
+
+    result.flatMap { _ =>
+      val text = accumulated.toString()
+      if (text.isEmpty) {
+        Left(ValidationError("response", "Empty streaming response from WatsonX"))
+      } else {
+        val usageOpt = for {
+          pt <- promptTokens
+          ct <- completionTokens
+        } yield TokenUsage(promptTokens = pt, completionTokens = ct, totalTokens = pt + ct)
+
+        val costOpt = usageOpt.flatMap(u => CostEstimator.estimate(config.model, u))
+        val completion = Completion(
+          id = messageId,
+          created = System.currentTimeMillis() / 1000L,
+          content = text,
+          model = config.model,
+          message = AssistantMessage(contentOpt = Some(text), toolCalls = Seq.empty),
+          toolCalls = List.empty,
+          usage = usageOpt,
+          thinking = None,
+          estimatedCost = costOpt
+        )
+        recordExchange(startedAt, requestText, Some(rawStream.result()), Right(completion))
+        Right(completion)
+      }
+    }.tapLeft(err =>
+      recordExchange(
+        startedAt,
+        requestText,
+        Option.when(rawStream.nonEmpty)(rawStream.result()),
+        Left(err)
+      )
+    )
+  }
+
+  override def getContextWindow(): Int = config.contextWindow
+
+  override def getReserveCompletion(): Int = config.reserveCompletion
+
+  private def buildPrompt(conversation: Conversation): Result[String] = {
+    if (conversation.messages.isEmpty) {
+      Left(ValidationError("conversation", "WatsonX requires at least one message"))
+    } else {
+      val sb = new StringBuilder()
+      conversation.messages.foreach {
+        case SystemMessage(content) =>
+          sb.append(content).append("\n\n")
+        case UserMessage(content) =>
+          sb.append("Human: ").append(content).append("\n")
+        case AssistantMessage(contentOpt, _) =>
+          contentOpt.filter(_.nonEmpty).foreach(c => sb.append("Assistant: ").append(c).append("\n"))
+        case _ =>
+          () // Skip unsupported message types
+      }
+      sb.append("Assistant:")
+      Right(sb.toString())
+    }
+  }
+
+  private def buildRequestBody(prompt: String, options: CompletionOptions): ujson.Obj = {
+    val params = ujson.Obj(
+      "decoding_method" -> "greedy",
+      "temperature"     -> options.temperature
+    )
+    options.maxTokens.foreach(mt => params("max_new_tokens") = mt)
+
+    ujson.Obj(
+      "model_id"   -> config.model,
+      "input"      -> prompt,
+      "project_id" -> config.projectId,
+      "parameters" -> params
+    )
+  }
+
+  private def parseCompletionResponse(body: String): Result[Completion] =
+    Try {
+      val json = ujson.read(body)
+
+      val textOpt = json.obj
+        .get("results")
+        .flatMap(_.arrOpt)
+        .flatMap(_.headOption)
+        .flatMap(_.obj.get("generated_text"))
+        .flatMap(_.strOpt)
+        .map(_.trim)
+
+      textOpt match {
+        case None | Some("") =>
+          Left(ValidationError("response", "Missing or empty generated_text in WatsonX response"))
+        case Some(text) =>
+          val id      = json.obj.get("id").flatMap(_.strOpt).getOrElse(java.util.UUID.randomUUID().toString)
+          val created = System.currentTimeMillis() / 1000L
+
+          val usageOpt = for {
+            results     <- json.obj.get("results").flatMap(_.arrOpt)
+            firstResult <- results.headOption
+            inputToks   <- firstResult.obj.get("input_token_count").flatMap(_.numOpt)
+            outputToks  <- firstResult.obj.get("generated_token_count").flatMap(_.numOpt)
+          } yield TokenUsage(
+            promptTokens = inputToks.toInt,
+            completionTokens = outputToks.toInt,
+            totalTokens = inputToks.toInt + outputToks.toInt
+          )
+
+          val costOpt = usageOpt.flatMap(u => CostEstimator.estimate(config.model, u))
+
+          Right(
+            Completion(
+              id = id,
+              created = created,
+              content = text,
+              model = config.model,
+              message = AssistantMessage(contentOpt = Some(text), toolCalls = Seq.empty),
+              toolCalls = List.empty,
+              usage = usageOpt,
+              thinking = None,
+              estimatedCost = costOpt
+            )
+          )
+      }
+    }.toEither.left.map(_.toLLMError).flatten
+
+  private def handleErrorResponse(statusCode: Int, body: String, token: String): Result[Nothing] = {
+    // Detect invalid project_id: WatsonX returns a specific error message
+    if (body.contains("project_id") || body.contains("BXZAI0001E")) {
+      Left(ValidationError("project_id", s"Invalid project_id: ${body.take(200)}"))
+    } else {
+      HttpErrorMapper.mapHttpError(statusCode, body, providerName)
+    }
+  }
+
+  private def recordExchange(
+    startedAt: Instant,
+    requestBody: String,
+    responseBody: Option[String],
+    result: Result[?]
+  ): Unit =
+    ProviderExchangeRecorder.record(
+      exchangeLogging = exchangeLogging,
+      provider = providerName,
+      model = Some(config.model),
+      startedAt = startedAt,
+      requestBody = requestBody,
+      responseBody = responseBody,
+      result = result
+    )
+}
+
+object WatsonXClient {
+  import org.llm4s.types.TryOps
+
+  def apply(config: WatsonXConfig)(using ModelRegistryService): Result[WatsonXClient] =
+    Try(new WatsonXClient(config)).toResult
+
+  def apply(
+    config: WatsonXConfig,
+    metrics: org.llm4s.metrics.MetricsCollector
+  )(using ModelRegistryService): Result[WatsonXClient] =
+    Try(new WatsonXClient(config, metrics)).toResult
+
+  def apply(
+    config: WatsonXConfig,
+    metrics: org.llm4s.metrics.MetricsCollector,
+    exchangeLogging: ProviderExchangeLogging
+  )(using ModelRegistryService): Result[WatsonXClient] =
+    Try(new WatsonXClient(config, metrics, exchangeLogging)).toResult
+
+  /** Test seam: inject a mock HTTP client for unit tests. */
+  private[provider] def forTest(
+    config: WatsonXConfig,
+    httpClient: Llm4sHttpClient
+  )(using ModelRegistryService): WatsonXClient =
+    new WatsonXClient(config, httpClient = httpClient)
+}

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
@@ -1,4 +1,4 @@
-// scalafix:off DisableSyntax.NoKeywordTry
+// scalafix:off DisableSyntax.NoKeywordTry, DisableSyntax.NoKeywordFinally
 package org.llm4s.llmconnect.provider
 
 import org.llm4s.error.{ ConfigurationError, ValidationError }

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
@@ -129,7 +129,7 @@ class WatsonXClient(
           recordExchange(startedAt, requestText, Some(response.body), r)
           r
         } else {
-          val err = handleErrorResponse(response.statusCode, response.body, token)
+          val err = handleErrorResponse(response.statusCode, response.body)
           recordExchange(startedAt, requestText, Some(response.body), err)
           err
         }
@@ -158,7 +158,7 @@ class WatsonXClient(
         if (streamResp.statusCode < 200 || streamResp.statusCode >= 300) {
           val errBody = new String(streamResp.body.readAllBytes(), StandardCharsets.UTF_8)
           streamResp.body.close()
-          val err = handleErrorResponse(streamResp.statusCode, errBody, token)
+          val err = handleErrorResponse(streamResp.statusCode, errBody)
           recordExchange(startedAt, requestText, Some(errBody), err)
           err
         } else {
@@ -353,7 +353,7 @@ class WatsonXClient(
       }
     }.toEither.left.map(_.toLLMError).flatten
 
-  private def handleErrorResponse(statusCode: Int, body: String, token: String): Result[Nothing] =
+  private def handleErrorResponse(statusCode: Int, body: String): Result[Nothing] =
     // Detect invalid project_id: WatsonX returns a specific error message
     if (body.contains("project_id") || body.contains("BXZAI0001E")) {
       Left(ValidationError("project_id", s"Invalid project_id: ${body.take(200)}"))

--- a/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
+++ b/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
@@ -35,6 +35,7 @@ object ProviderModelTypes:
     case DeepSeek
     case Cohere
     case Mistral
+    case WatsonX
 
   object ProviderKind:
     val all: Seq[ProviderKind] = Seq(
@@ -47,7 +48,8 @@ object ProviderModelTypes:
       ProviderKind.Gemini,
       ProviderKind.DeepSeek,
       ProviderKind.Cohere,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.WatsonX
     )
 
     def fromString(value: String): Option[ProviderKind] =
@@ -63,6 +65,7 @@ object ProviderModelTypes:
         case "deepseek"   => Some(ProviderKind.DeepSeek)
         case "cohere"     => Some(ProviderKind.Cohere)
         case "mistral"    => Some(ProviderKind.Mistral)
+        case "watsonx"    => Some(ProviderKind.WatsonX)
         case _            => None
 
     def fromName(value: String): Option[ProviderKind] =
@@ -81,3 +84,4 @@ object ProviderModelTypes:
         case ProviderKind.DeepSeek   => "deepseek"
         case ProviderKind.Cohere     => "cohere"
         case ProviderKind.Mistral    => "mistral"
+        case ProviderKind.WatsonX    => "watsonx"

--- a/modules/core/src/test/scala/org/llm4s/http/MockHttpClient.scala
+++ b/modules/core/src/test/scala/org/llm4s/http/MockHttpClient.scala
@@ -107,8 +107,8 @@ final class MockHttpClient(response: HttpResponse) extends Llm4sHttpClient {
     body: String,
     timeout: Int
   ): StreamingHttpResponse = {
-    record(url, headers, None, Some(body), timeout, countPost = true)
-    StreamingHttpResponse(response.statusCode, new java.io.ByteArrayInputStream(response.body.getBytes()))
+    val resp = record(url, headers, None, Some(body), timeout, countPost = true)
+    StreamingHttpResponse(resp.statusCode, new java.io.ByteArrayInputStream(resp.body.getBytes()))
   }
 }
 

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXClientSpec.scala
@@ -1,0 +1,630 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.{ AuthenticationError, ConfigurationError, RateLimitError, ServiceError, ValidationError }
+import org.llm4s.http.{ FailingHttpClient, HttpResponse, MockHttpClient }
+import org.llm4s.llmconnect.{ ProviderExchange, ProviderExchangeLogging, ProviderExchangeSink }
+import org.llm4s.llmconnect.config.WatsonXConfig
+import org.llm4s.llmconnect.model.{ AssistantMessage, CompletionOptions, Conversation, SystemMessage, UserMessage }
+import org.llm4s.model.{ ModelRegistryService, ModelRegistryTestSupport }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues._
+
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Unit tests for [[WatsonXClient]].
+ *
+ * All tests use [[MockHttpClient]] and [[FailingHttpClient]] — no IBM credentials required.
+ * Tests verify:
+ *  - IAM token exchange and caching
+ *  - IAM token refresh on expiry
+ *  - Successful `complete()` response parsing
+ *  - Successful `streamComplete()` chunk assembly
+ *  - Error mapping for HTTP 401 / 429 / 400 / 500
+ *  - Invalid project_id detection
+ *  - IAM failure propagation
+ *  - Network failure handling
+ */
+class WatsonXClientSpec extends AnyFlatSpec with Matchers {
+
+  private given ModelRegistryService = ModelRegistryTestSupport.defaultService()
+
+  // A valid IAM response stub
+  private val iamResponse: String =
+    """{
+      |  "access_token": "test-bearer-token-abc123",
+      |  "token_type": "Bearer",
+      |  "expires_in": 3600
+      |}""".stripMargin
+
+  // A valid WatsonX /ml/v1/text/generation response
+  private def watsonxResponse(text: String = "Hello from WatsonX!"): String =
+    s"""{
+       |  "id": "cmpl-watsonx-001",
+       |  "model_id": "ibm/granite-3-8b-instruct",
+       |  "created": 1700000000,
+       |  "results": [
+       |    {
+       |      "generated_text": "$text",
+       |      "generated_token_count": 8,
+       |      "input_token_count": 12,
+       |      "stop_reason": "eos_token"
+       |    }
+       |  ]
+       |}""".stripMargin
+
+  private def testConfig: WatsonXConfig = WatsonXConfig(
+    apiKey = "test-ibm-api-key",
+    projectId = "test-project-id-1234",
+    model = "ibm/granite-3-8b-instruct",
+    baseUrl = "https://us-south.ml.cloud.ibm.com",
+    iamUrl = "https://iam.cloud.ibm.com/identity/token",
+    contextWindow = 8192,
+    reserveCompletion = 2048
+  )
+
+  private def conversation: Conversation = Conversation(Seq(UserMessage("Say hi")))
+
+  // ==========================================================================
+  // complete() — happy path
+  // ==========================================================================
+
+  "WatsonXClient.complete" should "parse a successful WatsonX response" in {
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, watsonxResponse()))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isRight shouldBe true
+    val completion = result.toOption.get
+    completion.content shouldBe "Hello from WatsonX!"
+    completion.model shouldBe "ibm/granite-3-8b-instruct"
+    completion.id shouldBe "cmpl-watsonx-001"
+    completion.usage.isDefined shouldBe true
+    completion.usage.get.promptTokens shouldBe 12
+    completion.usage.get.completionTokens shouldBe 8
+    completion.usage.get.totalTokens shouldBe 20
+  }
+
+  it should "cache the IAM token and not re-exchange on subsequent calls" in {
+    val mock = new MockHttpClient(
+      Seq(
+        HttpResponse(200, iamResponse),
+        HttpResponse(200, watsonxResponse("First")),
+        HttpResponse(200, watsonxResponse("Second"))
+      )
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val r1 = client.complete(conversation, CompletionOptions())
+    val r2 = client.complete(conversation, CompletionOptions())
+
+    r1.isRight shouldBe true
+    r2.isRight shouldBe true
+    // IAM was called only once (postCallCount includes both IAM and completion calls)
+    // First call: 2 posts (IAM + completion), Second call: 1 post (completion only)
+    mock.postCallCount shouldBe 3
+    r1.toOption.get.content shouldBe "First"
+    r2.toOption.get.content shouldBe "Second"
+  }
+
+  it should "return ValidationError for an empty conversation" in {
+    val mock = new MockHttpClient(HttpResponse(200, iamResponse))
+    val client = WatsonXClient.forTest(testConfig, mock)
+    val emptyConv = Conversation(Seq.empty)
+
+    val result = client.complete(emptyConv, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[ValidationError]
+    result.swap.toOption.get.message should include("at least one message")
+  }
+
+  it should "handle multi-turn conversation with system and assistant messages" in {
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, watsonxResponse("Sure!")))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+    val multiConv = Conversation(
+      Seq(
+        SystemMessage("You are a helpful assistant."),
+        UserMessage("Hello"),
+        AssistantMessage(Some("Hi!"), Seq.empty),
+        UserMessage("Tell me a joke")
+      )
+    )
+
+    val result = client.complete(multiConv, CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.content shouldBe "Sure!"
+    // The request body should contain prompt with "Human:" prefixes
+    mock.lastBody.value should include("Human: Hello")
+    mock.lastBody.value should include("Human: Tell me a joke")
+    mock.lastBody.value should include("Assistant: Hi!")
+  }
+
+  it should "include the project_id in the request body" in {
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, watsonxResponse()))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    client.complete(conversation, CompletionOptions())
+
+    mock.lastBody.value should include("test-project-id-1234")
+  }
+
+  it should "include the model_id in the request body" in {
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, watsonxResponse()))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    client.complete(conversation, CompletionOptions())
+
+    mock.lastBody.value should include("ibm/granite-3-8b-instruct")
+  }
+
+  it should "send maxTokens in request parameters when specified" in {
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, watsonxResponse("Short")))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    client.complete(conversation, CompletionOptions(maxTokens = Some(100)))
+
+    mock.lastBody.value should include("max_new_tokens")
+    mock.lastBody.value should include("100")
+  }
+
+  it should "return ValidationError when generated_text is missing in response" in {
+    val emptyResponse =
+      """{
+        |  "id": "cmpl-empty",
+        |  "model_id": "ibm/granite-3-8b-instruct",
+        |  "results": [
+        |    {
+        |      "generated_token_count": 0,
+        |      "input_token_count": 5,
+        |      "stop_reason": "eos_token"
+        |    }
+        |  ]
+        |}""".stripMargin
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, emptyResponse))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[ValidationError]
+    result.swap.toOption.get.message should include("generated_text")
+  }
+
+  it should "handle response without token usage gracefully" in {
+    val responseNoUsage =
+      """{
+        |  "id": "cmpl-no-usage",
+        |  "model_id": "ibm/granite-3-8b-instruct",
+        |  "results": [
+        |    {
+        |      "generated_text": "Hello!",
+        |      "stop_reason": "eos_token"
+        |    }
+        |  ]
+        |}""".stripMargin
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, responseNoUsage))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.content shouldBe "Hello!"
+    result.toOption.get.usage shouldBe None
+  }
+
+  it should "generate a UUID when response has no id field" in {
+    val responseNoId =
+      """{
+        |  "model_id": "ibm/granite-3-8b-instruct",
+        |  "results": [
+        |    {
+        |      "generated_text": "Hi there!",
+        |      "generated_token_count": 3,
+        |      "input_token_count": 5,
+        |      "stop_reason": "eos_token"
+        |    }
+        |  ]
+        |}""".stripMargin
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, responseNoId))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.id should not be empty
+  }
+
+  // ==========================================================================
+  // IAM token exchange and refresh
+  // ==========================================================================
+
+  "WatsonXClient IAM token" should "return ConfigurationError when IAM exchange fails (non-2xx)" in {
+    val mock = new MockHttpClient(HttpResponse(400, """{"error": "Bad request"}"""))
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[ConfigurationError]
+    result.swap.toOption.get.message should include("IAM token exchange failed")
+  }
+
+  it should "return ConfigurationError when IAM response has no access_token" in {
+    val badIam = """{"token_type": "Bearer", "expires_in": 3600}"""
+    val mock = new MockHttpClient(HttpResponse(200, badIam))
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[ConfigurationError]
+    result.swap.toOption.get.message should include("access_token")
+  }
+
+  it should "return ConfigurationError when IAM returns invalid JSON" in {
+    val mock = new MockHttpClient(HttpResponse(200, "not-json"))
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[ConfigurationError]
+  }
+
+  it should "refresh token when cached token has expired (less than 60s remaining)" in {
+    // First two calls: IAM + completion (for first complete() call)
+    // Then we manually expire the token and make a second call
+    val mock = new MockHttpClient(
+      Seq(
+        HttpResponse(200, iamResponse),
+        HttpResponse(200, watsonxResponse("First")),
+        HttpResponse(200, iamResponse),
+        HttpResponse(200, watsonxResponse("Second"))
+      )
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    // First call works normally
+    val r1 = client.complete(conversation, CompletionOptions())
+    r1.isRight shouldBe true
+
+    // Manually inject an expired token into the cache
+    client.cachedToken.set(Some(("old-token", System.currentTimeMillis() / 1000L - 100)))
+
+    // Second call should re-exchange the token
+    val r2 = client.complete(conversation, CompletionOptions())
+    r2.isRight shouldBe true
+    r2.toOption.get.content shouldBe "Second"
+
+    // Total posts: 2 (IAM + completion) + 2 (IAM + completion) = 4
+    mock.postCallCount shouldBe 4
+  }
+
+  it should "send the bearer token as Authorization header on WatsonX API calls" in {
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, watsonxResponse()))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    client.complete(conversation, CompletionOptions())
+
+    mock.lastHeaders.value.get("Authorization") shouldBe Some("Bearer test-bearer-token-abc123")
+  }
+
+  // ==========================================================================
+  // Error mapping
+  // ==========================================================================
+
+  "WatsonXClient.complete error handling" should "map HTTP 401 to AuthenticationError" in {
+    val mock = new MockHttpClient(
+      Seq(
+        HttpResponse(200, iamResponse),
+        HttpResponse(401, """{"message": "Unauthorized"}""")
+      )
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[AuthenticationError]
+  }
+
+  it should "map HTTP 403 to AuthenticationError" in {
+    val mock = new MockHttpClient(
+      Seq(
+        HttpResponse(200, iamResponse),
+        HttpResponse(403, """{"message": "Forbidden"}""")
+      )
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[AuthenticationError]
+  }
+
+  it should "map HTTP 429 to RateLimitError (WatsonX quota exceeded)" in {
+    val mock = new MockHttpClient(
+      Seq(
+        HttpResponse(200, iamResponse),
+        HttpResponse(429, """{"message": "Rate limit exceeded"}""")
+      )
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[RateLimitError]
+  }
+
+  it should "map HTTP 500 to ServiceError" in {
+    val mock = new MockHttpClient(
+      Seq(
+        HttpResponse(200, iamResponse),
+        HttpResponse(500, """{"message": "Internal server error"}""")
+      )
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[ServiceError]
+  }
+
+  it should "map invalid project_id error body to ValidationError" in {
+    val projectIdError =
+      """{
+        |  "errors": [
+        |    {
+        |      "code": "BXZAI0001E",
+        |      "message": "The project_id provided is not valid"
+        |    }
+        |  ]
+        |}""".stripMargin
+    val mock = new MockHttpClient(
+      Seq(
+        HttpResponse(200, iamResponse),
+        HttpResponse(400, projectIdError)
+      )
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[ValidationError]
+    result.swap.toOption.get.message should include("project_id")
+  }
+
+  it should "detect invalid project_id from error body containing 'project_id'" in {
+    val projectIdError = """{"message": "Invalid project_id provided"}"""
+    val mock = new MockHttpClient(
+      Seq(
+        HttpResponse(200, iamResponse),
+        HttpResponse(400, projectIdError)
+      )
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[ValidationError]
+  }
+
+  it should "return UnknownError on network failure during WatsonX call" in {
+    val failingClient = new FailingHttpClient(new java.io.IOException("connection refused"))
+    val client = WatsonXClient.forTest(testConfig, failingClient)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+  }
+
+  // ==========================================================================
+  // streamComplete() — happy path
+  // ==========================================================================
+
+  "WatsonXClient.streamComplete" should "assemble chunks into a complete Completion" in {
+    val sseBody =
+      """data: {"results":[{"generated_text":"Hello","generated_token_count":1,"input_token_count":5,"stop_reason":"not_finished"}]}
+        |data: {"results":[{"generated_text":" World","generated_token_count":1,"input_token_count":5,"stop_reason":"eos_token"}]}
+        |data: [DONE]
+        |""".stripMargin
+
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, sseBody))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val chunks = ListBuffer.empty[org.llm4s.llmconnect.model.StreamedChunk]
+    val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+    result.isRight shouldBe true
+    val completion = result.toOption.get
+    completion.content shouldBe "Hello World"
+    chunks should have size 2
+    chunks.head.content shouldBe Some("Hello")
+    chunks(1).content shouldBe Some(" World")
+  }
+
+  it should "return ValidationError when stream emits no text" in {
+    val emptySseBody = "data: [DONE]\n"
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, emptySseBody))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[ValidationError]
+  }
+
+  it should "propagate HTTP errors from streaming endpoint" in {
+    val mock = new MockHttpClient(
+      Seq(
+        HttpResponse(200, iamResponse),
+        HttpResponse(429, """{"message": "Too many requests"}""")
+      )
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[RateLimitError]
+  }
+
+  it should "capture token usage from streaming response" in {
+    val sseBody =
+      """data: {"results":[{"generated_text":"Hi!","generated_token_count":2,"input_token_count":10,"stop_reason":"eos_token"}]}
+        |data: [DONE]
+        |""".stripMargin
+
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, sseBody))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+    result.isRight shouldBe true
+    val completion = result.toOption.get
+    completion.usage.isDefined shouldBe true
+    completion.usage.get.promptTokens shouldBe 10
+    completion.usage.get.completionTokens shouldBe 2
+  }
+
+  // ==========================================================================
+  // Provider exchange logging
+  // ==========================================================================
+
+  "WatsonXClient" should "record provider exchanges when logging is enabled" in {
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, watsonxResponse()))
+    )
+    val recorded = ListBuffer.empty[ProviderExchange]
+    val sink = new ProviderExchangeSink {
+      override def record(exchange: ProviderExchange): Unit =
+        recorded += exchange
+    }
+    val client = new WatsonXClient(
+      testConfig,
+      exchangeLogging = ProviderExchangeLogging.Enabled(sink),
+      httpClient = mock
+    )
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isRight shouldBe true
+    recorded should have size 1
+    recorded.head.provider shouldBe "watsonx"
+    recorded.head.model shouldBe Some("ibm/granite-3-8b-instruct")
+    recorded.head.requestBody should include("input")
+    recorded.head.responseBody.value should include("Hello from WatsonX!")
+  }
+
+  // ==========================================================================
+  // Lifecycle methods
+  // ==========================================================================
+
+  "WatsonXClient" should "return correct context window from config" in {
+    val mock   = new MockHttpClient(HttpResponse(200, "{}"))
+    val client = WatsonXClient.forTest(testConfig, mock)
+    client.getContextWindow() shouldBe 8192
+  }
+
+  it should "return correct reserve completion from config" in {
+    val mock   = new MockHttpClient(HttpResponse(200, "{}"))
+    val client = WatsonXClient.forTest(testConfig, mock)
+    client.getReserveCompletion() shouldBe 2048
+  }
+
+  it should "return ConfigurationError after being closed" in {
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, watsonxResponse()))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+    client.close()
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[ConfigurationError]
+    result.swap.toOption.get.message should include("closed")
+  }
+
+  // ==========================================================================
+  // WatsonXConfig
+  // ==========================================================================
+
+  "WatsonXConfig" should "have correct defaults for base URL and IAM URL" in {
+    WatsonXConfig.DEFAULT_BASE_URL shouldBe "https://us-south.ml.cloud.ibm.com"
+    WatsonXConfig.DEFAULT_IAM_URL shouldBe "https://iam.cloud.ibm.com/identity/token"
+  }
+
+  it should "include apiKey (redacted) and projectId in toString" in {
+    val cfg = testConfig
+    val str = cfg.toString
+    str should include("projectId=test-project-id-1234")
+    str should not include "test-ibm-api-key"
+    str should include("ibm/granite-3-8b-instruct")
+  }
+
+  it should "have provider kind WatsonX" in {
+    import org.llm4s.types.ProviderModelTypes.ProviderKind
+    testConfig.provider shouldBe ProviderKind.WatsonX
+  }
+
+  // ==========================================================================
+  // IAM failure propagates to complete
+  // ==========================================================================
+
+  "WatsonXClient" should "propagate IAM network failure as error" in {
+    val failingClient = new FailingHttpClient(new java.net.ConnectException("IAM unreachable"))
+    val client = WatsonXClient.forTest(testConfig, failingClient)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+  }
+
+  it should "use the IAM URL from config for token exchange" in {
+    val mock = new MockHttpClient(
+      Seq(HttpResponse(200, iamResponse), HttpResponse(200, watsonxResponse()))
+    )
+    val client = WatsonXClient.forTest(testConfig, mock)
+
+    client.complete(conversation, CompletionOptions())
+
+    // The first POST call should go to the IAM URL
+    // (we can check via getRequests or postCallCount behavior)
+    // Both IAM and WatsonX use POST
+    mock.postCallCount shouldBe 2
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXClientSpec.scala
@@ -112,8 +112,8 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return ValidationError for an empty conversation" in {
-    val mock = new MockHttpClient(HttpResponse(200, iamResponse))
-    val client = WatsonXClient.forTest(testConfig, mock)
+    val mock      = new MockHttpClient(HttpResponse(200, iamResponse))
+    val client    = WatsonXClient.forTest(testConfig, mock)
     val emptyConv = Conversation(Seq.empty)
 
     val result = client.complete(emptyConv, CompletionOptions())
@@ -259,7 +259,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
   // ==========================================================================
 
   "WatsonXClient IAM token" should "return ConfigurationError when IAM exchange fails (non-2xx)" in {
-    val mock = new MockHttpClient(HttpResponse(400, """{"error": "Bad request"}"""))
+    val mock   = new MockHttpClient(HttpResponse(400, """{"error": "Bad request"}"""))
     val client = WatsonXClient.forTest(testConfig, mock)
 
     val result = client.complete(conversation, CompletionOptions())
@@ -271,7 +271,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
 
   it should "return ConfigurationError when IAM response has no access_token" in {
     val badIam = """{"token_type": "Bearer", "expires_in": 3600}"""
-    val mock = new MockHttpClient(HttpResponse(200, badIam))
+    val mock   = new MockHttpClient(HttpResponse(200, badIam))
     val client = WatsonXClient.forTest(testConfig, mock)
 
     val result = client.complete(conversation, CompletionOptions())
@@ -282,7 +282,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return ConfigurationError when IAM returns invalid JSON" in {
-    val mock = new MockHttpClient(HttpResponse(200, "not-json"))
+    val mock   = new MockHttpClient(HttpResponse(200, "not-json"))
     val client = WatsonXClient.forTest(testConfig, mock)
 
     val result = client.complete(conversation, CompletionOptions())
@@ -438,7 +438,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
 
   it should "return UnknownError on network failure during WatsonX call" in {
     val failingClient = new FailingHttpClient(new java.io.IOException("connection refused"))
-    val client = WatsonXClient.forTest(testConfig, failingClient)
+    val client        = WatsonXClient.forTest(testConfig, failingClient)
 
     val result = client.complete(conversation, CompletionOptions())
 
@@ -592,7 +592,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
     val cfg = testConfig
     val str = cfg.toString
     str should include("projectId=test-project-id-1234")
-    str should not include "test-ibm-api-key"
+    (str should not).include("test-ibm-api-key")
     str should include("ibm/granite-3-8b-instruct")
   }
 
@@ -607,7 +607,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
 
   "WatsonXClient" should "propagate IAM network failure as error" in {
     val failingClient = new FailingHttpClient(new java.net.ConnectException("IAM unreachable"))
-    val client = WatsonXClient.forTest(testConfig, failingClient)
+    val client        = WatsonXClient.forTest(testConfig, failingClient)
 
     val result = client.complete(conversation, CompletionOptions())
 

--- a/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 class ProviderKindSpec extends AnyFlatSpec with Matchers:
 
   "ProviderKind" should "expose all expected provider instances" in {
-    ProviderKind.all should have size 10
+    ProviderKind.all should have size 11
     (ProviderKind.all should contain).allOf(
       ProviderKind.OpenAI,
       ProviderKind.Azure,
@@ -18,7 +18,8 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       ProviderKind.Gemini,
       ProviderKind.Cohere,
       ProviderKind.DeepSeek,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.WatsonX
     )
   }
 
@@ -33,6 +34,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     ProviderKind.DeepSeek.name shouldBe "deepseek"
     ProviderKind.Cohere.name shouldBe "cohere"
     ProviderKind.Mistral.name shouldBe "mistral"
+    ProviderKind.WatsonX.name shouldBe "watsonx"
   }
 
   "ProviderKind.fromName" should "parse supported providers case-insensitively" in {
@@ -47,6 +49,8 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     ProviderKind.fromName("DEEPSEEK") shouldBe Some(ProviderKind.DeepSeek)
     ProviderKind.fromName("COHERE") shouldBe Some(ProviderKind.Cohere)
     ProviderKind.fromName("MISTRAL") shouldBe Some(ProviderKind.Mistral)
+    ProviderKind.fromName("watsonx") shouldBe Some(ProviderKind.WatsonX)
+    ProviderKind.fromName("WATSONX") shouldBe Some(ProviderKind.WatsonX)
   }
 
   it should "return None for unknown providers" in {

--- a/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
@@ -72,6 +72,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       case ProviderKind.DeepSeek   => "cloud-deepseek"
       case ProviderKind.Cohere     => "cloud-cohere"
       case ProviderKind.Mistral    => "cloud-mistral"
+      case ProviderKind.WatsonX    => "cloud-watsonx"
 
     describe(ProviderKind.OpenAI) shouldBe "cloud-openai"
     describe(ProviderKind.Ollama) shouldBe "local"

--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/WatsonXSmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/WatsonXSmokeSpec.scala
@@ -1,0 +1,119 @@
+package org.llm4s.llmconnect.smoke
+
+import org.llm4s.error.{ AuthenticationError, ConfigurationError }
+import org.llm4s.llmconnect.config.{ ContextWindowResolver, WatsonXConfig }
+import org.llm4s.llmconnect.model.{ CompletionOptions, Conversation, StreamedChunk, UserMessage }
+import org.llm4s.llmconnect.provider.WatsonXClient
+import org.llm4s.model.ModelRegistryService
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Cloud smoke tests for IBM WatsonX.
+ *
+ * These tests live in the dedicated integration-test module so default `sbt test`
+ * stays fast. Run them with `sbt "it/testOnly org.llm4s.llmconnect.smoke.*"`
+ * or the `sbt testSmoke` alias.
+ *
+ * Requires: `WATSONX_API_KEY` and `WATSONX_PROJECT_ID` environment variables.
+ * Optional: `WATSONX_BASE_URL` (defaults to us-south.ml.cloud.ibm.com).
+ *
+ * Tagged as `CloudSmoke` — skip gracefully when credentials are absent.
+ */
+class WatsonXSmokeSpec extends AnyFlatSpec with Matchers {
+
+  private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
+  private given ContextWindowResolver = ContextWindowResolver(mrs)
+
+  private val apiKey: Option[String]    = Option(System.getenv("WATSONX_API_KEY")).filter(_.nonEmpty)
+  private val projectId: Option[String] = Option(System.getenv("WATSONX_PROJECT_ID")).filter(_.nonEmpty)
+  private val baseUrl: String           = Option(System.getenv("WATSONX_BASE_URL")).filter(_.nonEmpty)
+    .getOrElse(WatsonXConfig.DEFAULT_BASE_URL)
+
+  private def config(key: String, pid: String): WatsonXConfig =
+    WatsonXConfig.fromValues(
+      modelName = "ibm/granite-3-8b-instruct",
+      apiKey = key,
+      projectId = pid,
+      baseUrl = baseUrl
+    )
+
+  private def conversation: Conversation = Conversation(Seq(UserMessage("Say hi in one word")))
+
+  "WatsonX" should "complete a basic request with ibm/granite-3-8b-instruct" in {
+    assume(apiKey.isDefined, "WATSONX_API_KEY not set — skipping WatsonX smoke test")
+    assume(projectId.isDefined, "WATSONX_PROJECT_ID not set — skipping WatsonX smoke test")
+
+    val clientResult = WatsonXClient(config(apiKey.get, projectId.get))
+    withClue(s"Client creation failed: ${clientResult.swap.toOption}") {
+      clientResult.isRight shouldBe true
+    }
+
+    val client     = clientResult.toOption.get
+    val completion = client.complete(conversation, CompletionOptions())
+
+    withClue(s"Completion failed: ${completion.swap.toOption}") {
+      completion.isRight shouldBe true
+    }
+    completion.toOption.get.content should not be empty
+  }
+
+  it should "return non-empty token usage on a basic completion" in {
+    assume(apiKey.isDefined, "WATSONX_API_KEY not set — skipping WatsonX smoke test")
+    assume(projectId.isDefined, "WATSONX_PROJECT_ID not set — skipping WatsonX smoke test")
+
+    val client     = WatsonXClient(config(apiKey.get, projectId.get)).toOption.get
+    val completion = client.complete(conversation, CompletionOptions()).toOption.get
+
+    withClue("Expected token usage to be populated") {
+      completion.usage.isDefined shouldBe true
+    }
+    completion.usage.get.promptTokens should be > 0
+    completion.usage.get.completionTokens should be > 0
+    completion.usage.get.totalTokens should be > 0
+  }
+
+  it should "stream a response with at least one chunk" in {
+    assume(apiKey.isDefined, "WATSONX_API_KEY not set — skipping WatsonX smoke test")
+    assume(projectId.isDefined, "WATSONX_PROJECT_ID not set — skipping WatsonX smoke test")
+
+    val client = WatsonXClient(config(apiKey.get, projectId.get)).toOption.get
+    val chunks = scala.collection.mutable.ListBuffer.empty[StreamedChunk]
+    val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+    withClue(s"Streaming failed: ${result.swap.toOption}") {
+      result.isRight shouldBe true
+    }
+    result.toOption.get.content should not be empty
+    chunks should not be empty
+  }
+
+  it should "succeed with IAM token exchange (verifying no credential errors)" in {
+    assume(apiKey.isDefined, "WATSONX_API_KEY not set — skipping WatsonX smoke test")
+    assume(projectId.isDefined, "WATSONX_PROJECT_ID not set — skipping WatsonX smoke test")
+
+    val client = WatsonXClient(config(apiKey.get, projectId.get)).toOption.get
+
+    // getBearerToken exercises the IAM token exchange end-to-end
+    val tokenResult = client.getBearerToken()
+
+    withClue(s"IAM token exchange failed: ${tokenResult.swap.toOption}") {
+      tokenResult.isRight shouldBe true
+    }
+    tokenResult.toOption.get should not be empty
+  }
+
+  it should "return ConfigurationError or AuthenticationError for invalid API key" in {
+    assume(projectId.isDefined, "WATSONX_PROJECT_ID not set — skipping WatsonX smoke test")
+
+    val client = WatsonXClient(config("invalid-api-key-for-testing", projectId.get)).toOption.get
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get match {
+      case _: ConfigurationError  => succeed
+      case _: AuthenticationError => succeed
+      case other                  => fail(s"Expected ConfigurationError or AuthenticationError, got: $other")
+    }
+  }
+}

--- a/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
@@ -372,6 +372,12 @@ private[providersetup] object ProviderSetupRuntime:
           apiKey = input.flatMap(_.apiKey).getOrElse(cfg.apiKey),
           baseUrl = input.flatMap(_.baseUrl).getOrElse(cfg.baseUrl)
         )
+      case cfg: WatsonXConfig =>
+        cfg.copy(
+          model = input.flatMap(_.model).getOrElse(cfg.model),
+          apiKey = input.flatMap(_.apiKey).getOrElse(cfg.apiKey),
+          baseUrl = input.flatMap(_.baseUrl).getOrElse(cfg.baseUrl)
+        )
 
   def demoCompletionCmd(
     providerConfig: ProviderConfig,
@@ -580,3 +586,4 @@ private[providersetup] object ProviderSetupRuntime:
       case cfg: CohereConfig    => cfg.copy(model = modelName)
       case cfg: MistralConfig   => cfg.copy(model = modelName)
       case cfg: ZaiConfig       => cfg.copy(model = modelName)
+      case cfg: WatsonXConfig   => cfg.copy(model = modelName)

--- a/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
@@ -141,6 +141,7 @@ object PrometheusMetricsExample {
                 case _: org.llm4s.llmconnect.config.DeepSeekConfig  => "deepseek"
                 case _: org.llm4s.llmconnect.config.CohereConfig    => "cohere"
                 case _: org.llm4s.llmconnect.config.MistralConfig   => "mistral"
+                case _: org.llm4s.llmconnect.config.WatsonXConfig   => "watsonx"
               }
 
               println(s"Using model: ${config.model}")


### PR DESCRIPTION
## Summary

Implements #1020: integration and smoke tests for the IBM WatsonX provider.

This PR includes both the **WatsonXClient** implementation (since #1019 had not landed yet) and all the requested tests.

### Changes

**New source files:**
- `modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala` — WatsonX client with IAM token exchange, caching, refresh, `complete()`, and `streamComplete()`.
- `modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala` — Added `WatsonXConfig` case class with `apiKey`, `projectId`, `model`, `baseUrl`, `iamUrl` fields.
- `modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala` — Added `WatsonX` to `ProviderKind` enum.
- `modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala` — Registered `WatsonXConfig -> WatsonXClient` routing.

**New test files:**
- `modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXClientSpec.scala` — 30+ mock-based unit tests covering all acceptance criteria.
- `modules/it/src/test/scala/org/llm4s/llmconnect/smoke/WatsonXSmokeSpec.scala` — Real-endpoint smoke tests (skipped when credentials absent).

## Test Coverage

All unit tests use `MockHttpClient` / `FailingHttpClient` — no IBM credentials required for `sbt test`.

**Covered scenarios:**
- IAM token exchange and bearer token extraction
- IAM token caching (no re-exchange within TTL)
- IAM token refresh when expired (< 60s remaining)
- IAM failure → `ConfigurationError`
- IAM invalid JSON → `ConfigurationError`
- Successful `complete()` with token usage
- `complete()` with missing `generated_text` → `ValidationError`
- WatsonX quota error (HTTP 429) → `RateLimitError`
- WatsonX auth failure (HTTP 401/403) → `AuthenticationError`
- WatsonX server error (HTTP 500) → `ServiceError`
- Invalid `project_id` detected from error body → `ValidationError`
- `streamComplete()` assembles chunks and captures token usage
- Empty stream → `ValidationError`
- Stream HTTP errors → `RateLimitError`
- Network failure → propagated error
- Lifecycle: `close()` → `ConfigurationError` on subsequent calls
- Provider exchange logging

## Smoke Tests

Located in `modules/it/src/test/scala/org/llm4s/llmconnect/smoke/WatsonXSmokeSpec.scala`:
- Requires `WATSONX_API_KEY`, `WATSONX_PROJECT_ID`; skips gracefully if absent
- Tests `complete()` with `ibm/granite-3-8b-instruct`
- Verifies token usage is populated
- Tests `streamComplete()`: at least one chunk emitted
- Tests IAM token exchange end-to-end

Run with: `sbt testSmoke` (requires IBM Cloud credentials)

Closes #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)