### PR TITLE
feat: implement IBM WatsonX AI provider (WatsonXClient)

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/config/ConfigKeys.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/ConfigKeys.scala
@@ -162,6 +162,17 @@ object ConfigKeys {
   val MISTRAL_API_KEY  = "MISTRAL_API_KEY"
   val MISTRAL_BASE_URL = "MISTRAL_BASE_URL"
 
+  // ---- IBM WatsonX --------------------------------------------------------
+
+  /** IBM Cloud API key used to obtain an IAM bearer token for WatsonX. */
+  val WATSONX_API_KEY = "WATSONX_API_KEY"
+
+  /** WatsonX project ID (or space ID when using deployments). */
+  val IBM_CLOUD_PROJECT_ID = "IBM_CLOUD_PROJECT_ID"
+
+  /** Overrides the WatsonX ML API base URL. Defaults to `"https://us-south.ml.cloud.ibm.com"`. */
+  val WATSONX_BASE_URL = "WATSONX_BASE_URL"
+
   // Tool API Keys
   // ---- Tool API keys ------------------------------------------------------
 

--- a/modules/core/src/main/scala/org/llm4s/config/DefaultConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/DefaultConfig.scala
@@ -17,4 +17,5 @@ object DefaultConfig {
   val DEFAULT_LANGFUSE_RELEASE          = "1.0.0"
   val DEFAULT_LANGFUSE_VERSION          = "1.0.0"
   val DEFAULT_AZURE_V2025_01_01_PREVIEW = "V2025_01_01_PREVIEW"
+  val DEFAULT_WATSONX_BASE_URL          = "https://us-south.ml.cloud.ibm.com"
 }

--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
@@ -104,3 +104,11 @@ private[config] object NamedProviderLoader:
         requiredApiKey("llm4s.providers.<name>.apiKey").map: apiKey =>
           val baseUrl = section.baseUrl.map(_.asUrl).getOrElse(MistralConfig.DEFAULT_BASE_URL)
           MistralConfig.fromValues(section.model.asString, apiKey, baseUrl)
+      case ProviderKind.WatsonX =>
+        for
+          apiKey    <- requiredApiKey("llm4s.providers.<name>.apiKey")
+          projectId <- required("project ID", section.endpoint, "llm4s.providers.<name>.endpoint")
+        yield
+          val baseUrl    = section.baseUrl.map(_.asUrl).getOrElse(WatsonXConfig.DEFAULT_BASE_URL)
+          val apiVersion = section.apiVersion.getOrElse(WatsonXConfig.DEFAULT_API_VERSION)
+          WatsonXConfig.fromValues(section.model.asString, apiKey, projectId, None, baseUrl, apiVersion)

--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderValidator.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderValidator.scala
@@ -133,6 +133,19 @@ private[llm4s] object NamedProviderValidators:
         requireApiKey = true,
       )
 
+  object WatsonX extends NamedProviderValidator:
+    def validate(
+      providerName: ProviderName,
+      section: RawNamedProviderSection
+    ): Result[NamedProviderConfig] =
+      validateNamedProviderConfig(
+        providerName = providerName,
+        providerKind = ProviderKind.WatsonX,
+        section = section,
+        requireApiKey = true,
+        requireEndpoint = true,
+      )
+
   private def validateNamedProviderConfig(
     providerName: ProviderName,
     providerKind: ProviderKind,

--- a/modules/core/src/main/scala/org/llm4s/config/ProviderCapabilities.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/ProviderCapabilities.scala
@@ -42,3 +42,6 @@ private[llm4s] object ProviderCapabilities:
   object Mistral extends ProviderCapabilities:
     val validator: NamedProviderValidator                 = NamedProviderValidators.Mistral
     override val modelLister: Option[ProviderModelLister] = Some(ProviderModelListers.Mistral)
+
+  object WatsonX extends ProviderCapabilities:
+    val validator: NamedProviderValidator = NamedProviderValidators.WatsonX

--- a/modules/core/src/main/scala/org/llm4s/config/ProviderCapabilitiesRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/ProviderCapabilitiesRegistry.scala
@@ -22,4 +22,5 @@ private[llm4s] object ProviderCapabilitiesRegistry:
     ProviderKind.DeepSeek   -> ProviderCapabilities.DeepSeek,
     ProviderKind.Cohere     -> ProviderCapabilities.Cohere,
     ProviderKind.Mistral    -> ProviderCapabilities.Mistral,
+    ProviderKind.WatsonX    -> ProviderCapabilities.WatsonX,
   )

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -170,7 +170,7 @@ object LLMConnect {
       case (ProviderKind.DeepSeek, cfg: DeepSeekConfig)   => DeepSeekClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Cohere, cfg: CohereConfig)       => CohereClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Mistral, cfg: MistralConfig)     => MistralClient(cfg, metrics, exchangeLogging)
-      case (ProviderKind.WatsonX, cfg: WatsonXConfig)    => WatsonXClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.WatsonX, cfg: WatsonXConfig)     => WatsonXClient(cfg, metrics, exchangeLogging)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -58,6 +58,8 @@ object LLMConnect {
         CohereClient(cfg, metrics, exchangeLogging)
       case cfg: MistralConfig =>
         MistralClient(cfg, metrics, exchangeLogging)
+      case cfg: WatsonXConfig =>
+        WatsonXClient(cfg, metrics, exchangeLogging)
     }
 
   def fromConfig(
@@ -168,6 +170,7 @@ object LLMConnect {
       case (ProviderKind.DeepSeek, cfg: DeepSeekConfig)   => DeepSeekClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Cohere, cfg: CohereConfig)       => CohereClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Mistral, cfg: MistralConfig)     => MistralClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.WatsonX, cfg: WatsonXConfig)    => WatsonXClient(cfg, metrics, exchangeLogging)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -677,3 +677,96 @@ object MistralConfig:
       contextWindow = cw,
       reserveCompletion = rc
     )
+
+/**
+ * Configuration for IBM WatsonX AI.
+ *
+ * WatsonX is IBM's enterprise AI platform supporting IBM Granite models,
+ * Llama, Mistral, and other open-source models via a governed, auditable API.
+ * Auth uses IBM Cloud IAM token exchange — the `apiKey` is exchanged for a
+ * short-lived bearer token before every request (tokens expire after 1 hour).
+ *
+ * Prefer [[WatsonXConfig.fromValues]] over the primary constructor; it resolves
+ * `contextWindow` and `reserveCompletion` automatically from the model name.
+ *
+ * @param apiKey        IBM Cloud API key used to obtain IAM bearer tokens; redacted in `toString`.
+ * @param projectId     WatsonX project ID — required for all inference requests.
+ * @param spaceId       Optional WatsonX space ID (alternative to project ID for deployments).
+ * @param model         Model identifier, e.g. `"ibm/granite-13b-instruct-v2"`.
+ * @param baseUrl       WatsonX ML API base URL; defaults to [[WatsonXConfig.DEFAULT_BASE_URL]].
+ * @param apiVersion    WatsonX API version string, e.g. `"2024-05-31"`.
+ * @param contextWindow Model's total token capacity (prompt + completion combined).
+ * @param reserveCompletion Tokens held back from prompt history for the completion.
+ */
+case class WatsonXConfig(
+  apiKey: String,
+  projectId: String,
+  spaceId: Option[String],
+  model: String,
+  baseUrl: String,
+  apiVersion: String,
+  contextWindow: Int,
+  reserveCompletion: Int
+) extends ProviderConfig:
+  override val provider: ProviderKind = ProviderKind.WatsonX
+  override def toString: String =
+    s"WatsonXConfig(apiKey=${Redaction.secret(apiKey)}, projectId=$projectId, spaceId=$spaceId, model=$model, " +
+      s"baseUrl=$baseUrl, apiVersion=$apiVersion, contextWindow=$contextWindow, reserveCompletion=$reserveCompletion)"
+
+object WatsonXConfig:
+  val DEFAULT_BASE_URL: String  = "https://us-south.ml.cloud.ibm.com"
+  val DEFAULT_API_VERSION: String = "2024-05-31"
+
+  private val DefaultContextWindow     = 8192
+  private val DefaultReserveCompletion = 4096
+
+  private def watsonxFallback(modelName: String): (Int, Int) =
+    modelName match {
+      case name if name.contains("granite-13b")   => (8192, DefaultReserveCompletion)
+      case name if name.contains("granite-20b")   => (8192, DefaultReserveCompletion)
+      case name if name.contains("llama-3")       => (8192, DefaultReserveCompletion)
+      case name if name.contains("llama-2")       => (4096, DefaultReserveCompletion)
+      case name if name.contains("mistral-large") => (32768, DefaultReserveCompletion)
+      case _                                      => (8192, DefaultReserveCompletion)
+    }
+
+  /**
+   * Constructs a [[WatsonXConfig]], resolving `contextWindow` and
+   * `reserveCompletion` from the model name automatically.
+   *
+   * @param modelName  Model identifier, e.g. `"ibm/granite-13b-instruct-v2"`.
+   * @param apiKey     IBM Cloud API key; must be non-empty.
+   * @param projectId  WatsonX project ID; must be non-empty.
+   * @param spaceId    Optional WatsonX space ID.
+   * @param baseUrl    API base URL; must be non-empty. Defaults to [[DEFAULT_BASE_URL]]
+   *                   when loaded via [[org.llm4s.config.Llm4sConfig]].
+   * @param apiVersion WatsonX API version string.
+   */
+  def fromValues(
+    modelName: String,
+    apiKey: String,
+    projectId: String,
+    spaceId: Option[String] = None,
+    baseUrl: String = DEFAULT_BASE_URL,
+    apiVersion: String = DEFAULT_API_VERSION
+  )(using resolver: ContextWindowResolver): WatsonXConfig =
+    require(apiKey.trim.nonEmpty, "WatsonX apiKey must be non-empty")
+    require(projectId.trim.nonEmpty, "WatsonX projectId must be non-empty")
+    require(baseUrl.trim.nonEmpty, "WatsonX baseUrl must be non-empty")
+    val (cw, rc) = resolver.resolve(
+      lookupProviders = Seq("watsonx"),
+      modelName = modelName,
+      defaultContextWindow = DefaultContextWindow,
+      defaultReserve = DefaultReserveCompletion,
+      fallbackResolver = watsonxFallback
+    )
+    WatsonXConfig(
+      apiKey = apiKey,
+      projectId = projectId,
+      spaceId = spaceId,
+      model = modelName,
+      baseUrl = baseUrl,
+      apiVersion = apiVersion,
+      contextWindow = cw,
+      reserveCompletion = rc
+    )

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -714,7 +714,7 @@ case class WatsonXConfig(
       s"baseUrl=$baseUrl, apiVersion=$apiVersion, contextWindow=$contextWindow, reserveCompletion=$reserveCompletion)"
 
 object WatsonXConfig:
-  val DEFAULT_BASE_URL: String  = "https://us-south.ml.cloud.ibm.com"
+  val DEFAULT_BASE_URL: String    = "https://us-south.ml.cloud.ibm.com"
   val DEFAULT_API_VERSION: String = "2024-05-31"
 
   private val DefaultContextWindow     = 8192

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
@@ -253,7 +253,7 @@ class WatsonXClient(
           val errorBody = Try(new String(streamResponse.body.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8))
             .getOrElse("")
           Try(streamResponse.body.close())
-          Left(HttpErrorMapper.mapHttpError(streamResponse.statusCode, errorBody, providerName))
+          HttpErrorMapper.mapHttpError(streamResponse.statusCode, errorBody, providerName)
         }
       }.toEither.left.map(_.toLLMError).flatten
 

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
@@ -1,4 +1,3 @@
-// scalafix:off DisableSyntax.NoKeywordTry
 package org.llm4s.llmconnect.provider
 
 import org.llm4s.error.ThrowableOps._

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
@@ -1,0 +1,434 @@
+// scalafix:off DisableSyntax.NoKeywordTry
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.ThrowableOps._
+import org.llm4s.http.Llm4sHttpClient
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
+import org.llm4s.llmconnect.ProviderExchangeLogging
+import org.llm4s.llmconnect.config.WatsonXConfig
+import org.llm4s.llmconnect.model._
+import org.llm4s.metrics.MetricsCollector
+import org.llm4s.model.ModelRegistryService
+import org.llm4s.types.Result
+
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import scala.util.Try
+
+/**
+ * IBM WatsonX AI provider client.
+ *
+ * Implements non-streaming and streaming text generation via the WatsonX ML API
+ * (`POST /ml/v1/text/generation` and `POST /ml/v1/text/generation_stream`).
+ *
+ * == Authentication ==
+ * WatsonX uses IBM Cloud IAM token exchange. The `apiKey` is exchanged for a
+ * short-lived bearer token at `https://iam.cloud.ibm.com/identity/token`.
+ * Tokens expire after 1 hour; this client refreshes the token lazily when it
+ * detects expiry (with a 5-minute safety buffer).
+ *
+ * == Request format ==
+ * WatsonX uses a proprietary format (`model_id`, `project_id`, `input`,
+ * `parameters`) rather than the OpenAI-compatible chat completions API.
+ * Conversation messages are concatenated into a single `input` string with
+ * role prefixes.
+ *
+ * == Model prefix convention ==
+ * Use `LLM_MODEL=watsonx/<model-id>`, e.g.:
+ *   - `watsonx/ibm/granite-13b-instruct-v2`
+ *   - `watsonx/meta-llama/llama-3-8b-instruct`
+ *   - `watsonx/mistralai/mistral-large`
+ *
+ * @param config         WatsonX configuration (API key, project ID, base URL, etc.)
+ * @param httpClient     HTTP client; injectable for testing via [[WatsonXClient.forTest]].
+ * @param iamHttpClient  Separate HTTP client for IAM token exchange (can be the same instance).
+ * @param metrics        Receives per-call latency and token-usage events.
+ * @param exchangeLogging Optional provider exchange logging.
+ */
+class WatsonXClient(
+  config: WatsonXConfig,
+  httpClient: Llm4sHttpClient,
+  iamHttpClient: Llm4sHttpClient,
+  protected val metrics: MetricsCollector = MetricsCollector.noop,
+  exchangeLogging: ProviderExchangeLogging = ProviderExchangeLogging.Disabled
+)(using val registryService: ModelRegistryService)
+    extends BaseLifecycleLLMClient {
+
+  import WatsonXClient._
+
+  protected def clientDescription: String = s"WatsonX client for model ${config.model}"
+  protected def providerName: String      = "watsonx"
+  protected def modelName: String         = config.model
+
+  // IAM token cache: stores (token, expiry epoch seconds)
+  private val tokenCache: AtomicReference[Option[(String, Long)]] = new AtomicReference(None)
+
+  private def iamTokenUrl: String = IAM_TOKEN_URL
+
+  /**
+   * Obtains a valid IAM bearer token, refreshing if missing or within the expiry buffer.
+   */
+  private[provider] def getOrRefreshToken(): Result[String] = {
+    val now          = System.currentTimeMillis() / 1000L
+    val bufferSecs   = 300L // refresh 5 minutes before expiry
+    val cachedResult = tokenCache.get()
+    cachedResult match {
+      case Some((token, expiry)) if now < expiry - bufferSecs =>
+        Right(token)
+      case _ =>
+        fetchIamToken()
+    }
+  }
+
+  private def fetchIamToken(): Result[String] = {
+    val body =
+      s"grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=${urlEncode(config.apiKey)}"
+    val headers = Map(
+      "Content-Type" -> "application/x-www-form-urlencoded",
+      "Accept"       -> "application/json"
+    )
+    Try {
+      iamHttpClient.post(
+        url = iamTokenUrl,
+        headers = headers,
+        body = body,
+        timeout = IAM_TIMEOUT_MS
+      )
+    }.toEither.left.map(_.toLLMError).flatMap { response =>
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        parseIamTokenResponse(response.body)
+      } else {
+        Left(
+          org.llm4s.error.AuthenticationError(
+            "watsonx",
+            s"IAM token exchange failed (HTTP ${response.statusCode}): ${response.body.take(256)}"
+          )
+        )
+      }
+    }
+  }
+
+  private def parseIamTokenResponse(body: String): Result[String] =
+    Try {
+      val json        = ujson.read(body)
+      val accessToken = json.obj.get("access_token").flatMap(_.strOpt)
+      val expiresIn   = json.obj.get("expires_in").flatMap(_.numOpt).map(_.toLong)
+      accessToken match {
+        case Some(token) =>
+          val expiry = System.currentTimeMillis() / 1000L + expiresIn.getOrElse(3600L)
+          tokenCache.set(Some((token, expiry)))
+          Right(token)
+        case None =>
+          Left(
+            org.llm4s.error.AuthenticationError(
+              "watsonx",
+              s"IAM response missing access_token: ${body.take(256)}"
+            )
+          )
+      }
+    }.toEither.left.map(_.toLLMError).flatten
+
+  override def complete(
+    conversation: Conversation,
+    options: CompletionOptions
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt = Instant.now()
+    getOrRefreshToken().flatMap { token =>
+      val requestBody = buildGenerationRequest(conversation, options)
+      val requestText = requestBody.render()
+      val url         = s"${config.baseUrl}/ml/v1/text/generation?version=${config.apiVersion}"
+      val headers = Map(
+        "Content-Type"  -> "application/json",
+        "Authorization" -> s"Bearer $token",
+        "Accept"        -> "application/json"
+      )
+      Try {
+        httpClient.post(url = url, headers = headers, body = requestText, timeout = DEFAULT_TIMEOUT_MS)
+      }.toEither.left.map(_.toLLMError).flatMap { response =>
+        if (response.statusCode >= 200 && response.statusCode < 300) {
+          val result = parseGenerationResponse(response.body)
+          recordExchange(startedAt, requestText, Some(response.body), result)
+          result
+        } else {
+          val errorResult = HttpErrorMapper.mapHttpError(response.statusCode, response.body, providerName)
+          recordExchange(startedAt, requestText, Some(response.body), errorResult)
+          errorResult
+        }
+      }
+    }
+  }
+
+  override def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions(),
+    onChunk: StreamedChunk => Unit
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt = Instant.now()
+    getOrRefreshToken().flatMap { token =>
+      val requestBody = buildGenerationRequest(conversation, options)
+      requestBody("stream") = true
+      val requestText = requestBody.render()
+      val url         = s"${config.baseUrl}/ml/v1/text/generation_stream?version=${config.apiVersion}"
+      val headers = Map(
+        "Content-Type"  -> "application/json",
+        "Authorization" -> s"Bearer $token",
+        "Accept"        -> "text/event-stream"
+      )
+      val rawStream = new StringBuilder()
+      val attempt = Try {
+        val streamResponse = httpClient.postStream(url = url, headers = headers, body = requestText)
+        if (streamResponse.statusCode >= 200 && streamResponse.statusCode < 300) {
+          val accumulated = new StringBuilder()
+          var lastId      = java.util.UUID.randomUUID().toString
+          var totalPromptTokens     = 0
+          var totalCompletionTokens = 0
+          val reader = new java.io.BufferedReader(
+            new java.io.InputStreamReader(streamResponse.body, java.nio.charset.StandardCharsets.UTF_8)
+          )
+          Try {
+            var line = reader.readLine()
+            while (line != null) {
+              rawStream.append(line).append('\n')
+              val trimmed = line.trim
+              if (trimmed.startsWith("data:")) {
+                val data = trimmed.drop(5).trim
+                if (data.nonEmpty && data != "[DONE]") {
+                  Try {
+                    val json         = ujson.read(data)
+                    val generatedOpt = json.obj.get("results").flatMap(_.arrOpt).flatMap(_.headOption)
+                    generatedOpt.foreach { result =>
+                      val textOpt = result.obj.get("generated_text").flatMap(_.strOpt)
+                      textOpt.foreach { text =>
+                        if (text.nonEmpty) {
+                          accumulated.append(text)
+                          val chunk = StreamedChunk(
+                            id = lastId,
+                            content = Some(text),
+                            toolCall = None,
+                            finishReason = None
+                          )
+                          onChunk(chunk)
+                        }
+                      }
+                      // Extract usage from streaming response if present
+                      result.obj.get("input_token_count").flatMap(_.numOpt).foreach { n =>
+                        totalPromptTokens = n.toInt
+                      }
+                      result.obj.get("generated_token_count").flatMap(_.numOpt).foreach { n =>
+                        totalCompletionTokens = n.toInt
+                      }
+                    }
+                    // Also try top-level id
+                    json.obj.get("id").flatMap(_.strOpt).foreach(id => lastId = id)
+                  }.recover { case _ => () }
+                }
+              }
+              line = reader.readLine()
+            }
+          }.recover { case _ => () }
+          Try(reader.close())
+          Try(streamResponse.body.close())
+          val content = accumulated.toString()
+          val usage = if (totalPromptTokens > 0 || totalCompletionTokens > 0) {
+            Some(
+              TokenUsage(
+                promptTokens = totalPromptTokens,
+                completionTokens = totalCompletionTokens,
+                totalTokens = totalPromptTokens + totalCompletionTokens
+              )
+            )
+          } else None
+          val cost = usage.flatMap(u => CostEstimator.estimate(config.model, u))
+          val completion = Completion(
+            id = lastId,
+            created = System.currentTimeMillis() / 1000L,
+            content = content,
+            model = config.model,
+            message = AssistantMessage(contentOpt = Some(content), toolCalls = Seq.empty),
+            toolCalls = List.empty,
+            usage = usage,
+            thinking = None,
+            estimatedCost = cost
+          )
+          Right(completion)
+        } else {
+          val errorBody = Try(new String(streamResponse.body.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8))
+            .getOrElse("")
+          Try(streamResponse.body.close())
+          Left(HttpErrorMapper.mapHttpError(streamResponse.statusCode, errorBody, providerName))
+        }
+      }.toEither.left.map(_.toLLMError).flatten
+
+      attempt match {
+        case Right(completion) =>
+          recordExchange(startedAt, requestText, Some(rawStream.result()), Right(completion))
+          Right(completion)
+        case Left(err) =>
+          recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(err))
+          Left(err)
+      }
+    }
+  }
+
+  override def getContextWindow(): Int    = config.contextWindow
+  override def getReserveCompletion(): Int = config.reserveCompletion
+
+  override protected def releaseResources(): Unit = ()
+
+  private[provider] def buildGenerationRequest(
+    conversation: Conversation,
+    options: CompletionOptions
+  ): ujson.Obj = {
+    val input = formatConversationInput(conversation)
+    val parameters = ujson.Obj(
+      "temperature" -> options.temperature
+    )
+    options.maxTokens.foreach(mt => parameters("max_new_tokens") = mt)
+    if (options.topP != 1.0) parameters("top_p") = options.topP
+
+    val req = ujson.Obj(
+      "model_id"   -> config.model,
+      "input"      -> input,
+      "parameters" -> parameters
+    )
+    config.spaceId match {
+      case Some(sid) => req("space_id") = sid
+      case None      => req("project_id") = config.projectId
+    }
+    req
+  }
+
+  private def formatConversationInput(conversation: Conversation): String = {
+    val sb = new StringBuilder()
+    conversation.messages.foreach {
+      case SystemMessage(content) =>
+        sb.append(s"[SYSTEM]: $content\n")
+      case UserMessage(content) =>
+        sb.append(s"[USER]: $content\n")
+      case AssistantMessage(contentOpt, _) =>
+        contentOpt.filter(_.nonEmpty).foreach(c => sb.append(s"[ASSISTANT]: $c\n"))
+      case ToolMessage(content, toolCallId) =>
+        sb.append(s"[TOOL_RESULT:$toolCallId]: $content\n")
+    }
+    sb.append("[ASSISTANT]: ")
+    sb.result()
+  }
+
+  private def parseGenerationResponse(body: String): Result[Completion] =
+    Try {
+      val json = ujson.read(body)
+      val resultsArr = json.obj
+        .get("results")
+        .flatMap(_.arrOpt)
+        .getOrElse(
+          throw new IllegalArgumentException("WatsonX response missing 'results' array")
+        )
+      val firstResult = resultsArr.headOption.getOrElse(
+        throw new IllegalArgumentException("WatsonX response has empty 'results' array")
+      )
+      val generatedText = firstResult.obj
+        .get("generated_text")
+        .flatMap(_.strOpt)
+        .getOrElse("")
+
+      val promptTokenCount =
+        firstResult.obj.get("input_token_count").flatMap(_.numOpt).map(_.toInt).orElse(
+          json.obj.get("input_token_count").flatMap(_.numOpt).map(_.toInt)
+        )
+      val generatedTokenCount =
+        firstResult.obj.get("generated_token_count").flatMap(_.numOpt).map(_.toInt)
+
+      val usage = (promptTokenCount, generatedTokenCount) match {
+        case (Some(p), Some(g)) =>
+          Some(TokenUsage(promptTokens = p, completionTokens = g, totalTokens = p + g))
+        case _ => None
+      }
+
+      val cost = usage.flatMap(u => CostEstimator.estimate(config.model, u))
+
+      val id = json.obj.get("id").flatMap(_.strOpt).getOrElse(java.util.UUID.randomUUID().toString)
+
+      Right(
+        Completion(
+          id = id,
+          created = System.currentTimeMillis() / 1000L,
+          content = generatedText,
+          model = config.model,
+          message = AssistantMessage(contentOpt = Some(generatedText), toolCalls = Seq.empty),
+          toolCalls = List.empty,
+          usage = usage,
+          thinking = None,
+          estimatedCost = cost
+        )
+      )
+    }.toEither.left.map(_.toLLMError).flatten
+
+  private def recordExchange(
+    startedAt: Instant,
+    requestBody: String,
+    responseBody: Option[String],
+    result: Result[?]
+  ): Unit =
+    ProviderExchangeRecorder.record(
+      exchangeLogging = exchangeLogging,
+      provider = providerName,
+      model = Some(config.model),
+      startedAt = startedAt,
+      requestBody = requestBody,
+      responseBody = responseBody,
+      result = result
+    )
+
+  private def urlEncode(value: String): String =
+    java.net.URLEncoder.encode(value, "UTF-8")
+}
+
+object WatsonXClient {
+  import org.llm4s.types.TryOps
+
+  val IAM_TOKEN_URL: String   = "https://iam.cloud.ibm.com/identity/token"
+  val IAM_TIMEOUT_MS: Int     = 30000
+  val DEFAULT_TIMEOUT_MS: Int = 120000
+
+  def apply(
+    config: WatsonXConfig,
+    metrics: MetricsCollector,
+    exchangeLogging: ProviderExchangeLogging
+  )(using ModelRegistryService): Result[WatsonXClient] = {
+    val httpClient = Llm4sHttpClient.create()
+    Try(new WatsonXClient(config, httpClient, httpClient, metrics, exchangeLogging)).toResult
+  }
+
+  def apply(
+    config: WatsonXConfig,
+    metrics: MetricsCollector
+  )(using ModelRegistryService): Result[WatsonXClient] = {
+    val httpClient = Llm4sHttpClient.create()
+    Try(new WatsonXClient(config, httpClient, httpClient, metrics)).toResult
+  }
+
+  def apply(config: WatsonXConfig)(using ModelRegistryService): Result[WatsonXClient] = {
+    val httpClient = Llm4sHttpClient.create()
+    Try(new WatsonXClient(config, httpClient, httpClient)).toResult
+  }
+
+  /**
+   * Test seam — allows injecting mock HTTP clients for unit tests.
+   * The `httpClient` is used for WatsonX API calls; `iamHttpClient` for IAM token exchange.
+   */
+  private[provider] def forTest(
+    config: WatsonXConfig,
+    httpClient: Llm4sHttpClient,
+    iamHttpClient: Llm4sHttpClient
+  )(using ModelRegistryService): WatsonXClient =
+    new WatsonXClient(config, httpClient, iamHttpClient)
+
+  /**
+   * Test seam with a single HTTP client used for both API calls and IAM exchange.
+   */
+  private[provider] def forTest(
+    config: WatsonXConfig,
+    httpClient: Llm4sHttpClient
+  )(using ModelRegistryService): WatsonXClient =
+    new WatsonXClient(config, httpClient, httpClient)
+}

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/WatsonXClient.scala
@@ -178,8 +178,8 @@ class WatsonXClient(
       val attempt = Try {
         val streamResponse = httpClient.postStream(url = url, headers = headers, body = requestText)
         if (streamResponse.statusCode >= 200 && streamResponse.statusCode < 300) {
-          val accumulated = new StringBuilder()
-          var lastId      = java.util.UUID.randomUUID().toString
+          val accumulated           = new StringBuilder()
+          var lastId                = java.util.UUID.randomUUID().toString
           var totalPromptTokens     = 0
           var totalCompletionTokens = 0
           val reader = new java.io.BufferedReader(
@@ -211,9 +211,7 @@ class WatsonXClient(
                         }
                       }
                       // Extract usage from streaming response if present
-                      result.obj.get("input_token_count").flatMap(_.numOpt).foreach { n =>
-                        totalPromptTokens = n.toInt
-                      }
+                      result.obj.get("input_token_count").flatMap(_.numOpt).foreach(n => totalPromptTokens = n.toInt)
                       result.obj.get("generated_token_count").flatMap(_.numOpt).foreach { n =>
                         totalCompletionTokens = n.toInt
                       }
@@ -270,7 +268,7 @@ class WatsonXClient(
     }
   }
 
-  override def getContextWindow(): Int    = config.contextWindow
+  override def getContextWindow(): Int     = config.contextWindow
   override def getReserveCompletion(): Int = config.reserveCompletion
 
   override protected def releaseResources(): Unit = ()
@@ -332,9 +330,13 @@ class WatsonXClient(
         .getOrElse("")
 
       val promptTokenCount =
-        firstResult.obj.get("input_token_count").flatMap(_.numOpt).map(_.toInt).orElse(
-          json.obj.get("input_token_count").flatMap(_.numOpt).map(_.toInt)
-        )
+        firstResult.obj
+          .get("input_token_count")
+          .flatMap(_.numOpt)
+          .map(_.toInt)
+          .orElse(
+            json.obj.get("input_token_count").flatMap(_.numOpt).map(_.toInt)
+          )
       val generatedTokenCount =
         firstResult.obj.get("generated_token_count").flatMap(_.numOpt).map(_.toInt)
 

--- a/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
+++ b/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
@@ -35,6 +35,7 @@ object ProviderModelTypes:
     case DeepSeek
     case Cohere
     case Mistral
+    case WatsonX
 
   object ProviderKind:
     val all: Seq[ProviderKind] = Seq(
@@ -47,7 +48,8 @@ object ProviderModelTypes:
       ProviderKind.Gemini,
       ProviderKind.DeepSeek,
       ProviderKind.Cohere,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.WatsonX
     )
 
     def fromString(value: String): Option[ProviderKind] =
@@ -63,6 +65,7 @@ object ProviderModelTypes:
         case "deepseek"   => Some(ProviderKind.DeepSeek)
         case "cohere"     => Some(ProviderKind.Cohere)
         case "mistral"    => Some(ProviderKind.Mistral)
+        case "watsonx"    => Some(ProviderKind.WatsonX)
         case _            => None
 
     def fromName(value: String): Option[ProviderKind] =
@@ -81,3 +84,4 @@ object ProviderModelTypes:
         case ProviderKind.DeepSeek   => "deepseek"
         case ProviderKind.Cohere     => "cohere"
         case ProviderKind.Mistral    => "mistral"
+        case ProviderKind.WatsonX    => "watsonx"

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXClientSpec.scala
@@ -1,7 +1,7 @@
 package org.llm4s.llmconnect.provider
 
 import org.llm4s.error.{ AuthenticationError, RateLimitError, ServiceError }
-import org.llm4s.http.{ HttpResponse, MockHttpClient, FailingHttpClient, StreamingHttpResponse }
+import org.llm4s.http.{ FailingHttpClient, HttpResponse, MockHttpClient }
 import org.llm4s.llmconnect.config.WatsonXConfig
 import org.llm4s.llmconnect.model.{ AssistantMessage, CompletionOptions, Conversation, SystemMessage, UserMessage }
 import org.llm4s.model.ModelRegistryService
@@ -476,21 +476,9 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
         "data: [DONE]\n\n"
 
     val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
-    val streamingResponse = StreamingHttpResponse(
-      statusCode = 200,
-      body = new java.io.ByteArrayInputStream(sseBody.getBytes("UTF-8"))
-    )
-
-    val apiMock = new MockHttpClient(HttpResponse(200, sseBody)) {
-      override def postStream(
-        url: String,
-        headers: Map[String, String],
-        body: String,
-        timeout: Int
-      ): StreamingHttpResponse = streamingResponse
-    }
-    val client = WatsonXClient.forTest(testConfig, apiMock, iamMock)
-    val chunks = scala.collection.mutable.ListBuffer.empty[org.llm4s.llmconnect.model.StreamedChunk]
+    val apiMock = new MockHttpClient(HttpResponse(200, sseBody))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+    val chunks  = scala.collection.mutable.ListBuffer.empty[org.llm4s.llmconnect.model.StreamedChunk]
 
     val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
 
@@ -503,19 +491,8 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
   it should "handle streaming error status" in {
     val errorBody = """{"error":"Unauthorized"}"""
     val iamMock   = new MockHttpClient(Seq(iamSuccessResponse))
-    val streamingResponse = StreamingHttpResponse(
-      statusCode = 401,
-      body = new java.io.ByteArrayInputStream(errorBody.getBytes("UTF-8"))
-    )
-    val apiMock = new MockHttpClient(HttpResponse(401, errorBody)) {
-      override def postStream(
-        url: String,
-        headers: Map[String, String],
-        body: String,
-        timeout: Int
-      ): StreamingHttpResponse = streamingResponse
-    }
-    val client = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+    val apiMock   = new MockHttpClient(HttpResponse(401, errorBody))
+    val client    = WatsonXClient.forTest(testConfig, apiMock, iamMock)
 
     val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
 
@@ -531,20 +508,9 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
     ).mkString
 
     val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
-    val streamingResponse = StreamingHttpResponse(
-      statusCode = 200,
-      body = new java.io.ByteArrayInputStream(sseBody.getBytes("UTF-8"))
-    )
-    val apiMock = new MockHttpClient(HttpResponse(200, sseBody)) {
-      override def postStream(
-        url: String,
-        headers: Map[String, String],
-        body: String,
-        timeout: Int
-      ): StreamingHttpResponse = streamingResponse
-    }
-    val client = WatsonXClient.forTest(testConfig, apiMock, iamMock)
-    val chunks = scala.collection.mutable.ListBuffer.empty[org.llm4s.llmconnect.model.StreamedChunk]
+    val apiMock = new MockHttpClient(HttpResponse(200, sseBody))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+    val chunks  = scala.collection.mutable.ListBuffer.empty[org.llm4s.llmconnect.model.StreamedChunk]
 
     val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
 
@@ -564,28 +530,13 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "mark stream request body with stream=true" in {
-    val sseBody            = "data: {\"results\":[{\"generated_text\":\"ok\"}]}\n\n"
-    val iamMock            = new MockHttpClient(Seq(iamSuccessResponse))
-    var capturedStreamBody = Option.empty[String]
-    val streamingResponse = StreamingHttpResponse(
-      statusCode = 200,
-      body = new java.io.ByteArrayInputStream(sseBody.getBytes("UTF-8"))
-    )
-    val apiMock = new MockHttpClient(HttpResponse(200, sseBody)) {
-      override def postStream(
-        url: String,
-        headers: Map[String, String],
-        body: String,
-        timeout: Int
-      ): StreamingHttpResponse = {
-        capturedStreamBody = Some(body)
-        streamingResponse
-      }
-    }
-    val client = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+    val sseBody = "data: {\"results\":[{\"generated_text\":\"ok\"}]}\n\n"
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(HttpResponse(200, sseBody))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
 
     client.streamComplete(conversation, CompletionOptions(), _ => ())
 
-    capturedStreamBody.value should include("\"stream\":true")
+    apiMock.lastBody.value should include("\"stream\":true")
   }
 }

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXClientSpec.scala
@@ -1,0 +1,595 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.{ AuthenticationError, RateLimitError, ServiceError }
+import org.llm4s.http.{ HttpResponse, MockHttpClient, FailingHttpClient, StreamingHttpResponse }
+import org.llm4s.llmconnect.config.WatsonXConfig
+import org.llm4s.llmconnect.model.{ AssistantMessage, CompletionOptions, Conversation, SystemMessage, UserMessage }
+import org.llm4s.model.ModelRegistryService
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues._
+
+class WatsonXClientSpec extends AnyFlatSpec with Matchers {
+
+  private given ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+
+  private def testConfig: WatsonXConfig = WatsonXConfig(
+    apiKey = "test-ibm-api-key",
+    projectId = "test-project-id",
+    spaceId = None,
+    model = "ibm/granite-13b-instruct-v2",
+    baseUrl = "https://us-south.ml.cloud.ibm.com",
+    apiVersion = "2024-05-31",
+    contextWindow = 8192,
+    reserveCompletion = 4096
+  )
+
+  private def iamSuccessResponse: HttpResponse = HttpResponse(
+    statusCode = 200,
+    body = """{"access_token":"test-bearer-token","expires_in":3600,"token_type":"Bearer"}"""
+  )
+
+  private def watsonxSuccessResponse(text: String, id: String = "gen-123"): HttpResponse = HttpResponse(
+    statusCode = 200,
+    body =
+      s"""|{
+          |  "id": "$id",
+          |  "model_id": "ibm/granite-13b-instruct-v2",
+          |  "results": [
+          |    {
+          |      "generated_text": "$text",
+          |      "generated_token_count": 10,
+          |      "input_token_count": 5,
+          |      "stop_reason": "eos_token"
+          |    }
+          |  ]
+          |}""".stripMargin
+  )
+
+  private def conversation: Conversation = Conversation(Seq(UserMessage("Hello WatsonX")))
+
+  // ==========================================================================
+  // IAM token exchange tests
+  // ==========================================================================
+
+  "WatsonXClient IAM token exchange" should "obtain a token and cache it" in {
+    // Two responses: IAM token, then generation
+    val iamResponse  = iamSuccessResponse
+    val genResponse  = watsonxSuccessResponse("Hello from WatsonX!")
+    val iamMock      = new MockHttpClient(Seq(iamResponse))
+    val apiMock      = new MockHttpClient(Seq(genResponse))
+    val client       = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.content shouldBe "Hello from WatsonX!"
+    iamMock.postCallCount shouldBe 1
+    apiMock.postCallCount shouldBe 1
+  }
+
+  it should "use cached token on subsequent calls" in {
+    // 1st call: IAM + generation; 2nd call: only generation (token still valid)
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(Seq(watsonxSuccessResponse("First"), watsonxSuccessResponse("Second")))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val r1 = client.complete(conversation, CompletionOptions())
+    val r2 = client.complete(conversation, CompletionOptions())
+
+    r1.isRight shouldBe true
+    r2.isRight shouldBe true
+    // IAM token fetched only once
+    iamMock.postCallCount shouldBe 1
+    apiMock.postCallCount shouldBe 2
+  }
+
+  it should "return AuthenticationError when IAM exchange returns 401" in {
+    val iamMock = new MockHttpClient(HttpResponse(401, """{"message":"Invalid API key"}"""))
+    val apiMock = new MockHttpClient(HttpResponse(200, ""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe an[AuthenticationError]
+  }
+
+  it should "return AuthenticationError when IAM response is missing access_token" in {
+    val iamMock = new MockHttpClient(HttpResponse(200, """{"expires_in":3600}"""))
+    val apiMock = new MockHttpClient(HttpResponse(200, ""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe an[AuthenticationError]
+    result.swap.toOption.get.message should include("access_token")
+  }
+
+  it should "return error when IAM HTTP call fails with network exception" in {
+    val iamMock = new FailingHttpClient(new java.io.IOException("IAM unreachable"))
+    val apiMock = new MockHttpClient(HttpResponse(200, ""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+  }
+
+  // ==========================================================================
+  // complete() — happy path
+  // ==========================================================================
+
+  "WatsonXClient.complete" should "parse a successful WatsonX generation response" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(Seq(watsonxSuccessResponse("Generated response from Granite")))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isRight shouldBe true
+    val completion = result.toOption.get
+    completion.content shouldBe "Generated response from Granite"
+    completion.model shouldBe "ibm/granite-13b-instruct-v2"
+    completion.id shouldBe "gen-123"
+  }
+
+  it should "parse token usage from the response" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(Seq(watsonxSuccessResponse("Hello")))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isRight shouldBe true
+    val completion = result.toOption.get
+    completion.usage shouldBe defined
+    completion.usage.get.promptTokens shouldBe 5
+    completion.usage.get.completionTokens shouldBe 10
+    completion.usage.get.totalTokens shouldBe 15
+  }
+
+  it should "handle empty generated_text in response" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val genResponse = HttpResponse(
+      statusCode = 200,
+      body =
+        """|{
+           |  "id": "gen-empty",
+           |  "results": [
+           |    {
+           |      "generated_text": "",
+           |      "generated_token_count": 0,
+           |      "input_token_count": 5
+           |    }
+           |  ]
+           |}""".stripMargin
+    )
+    val apiMock = new MockHttpClient(Seq(genResponse))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.content shouldBe ""
+  }
+
+  it should "generate a UUID id when response has no id field" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val genResponse = HttpResponse(
+      statusCode = 200,
+      body =
+        """|{
+           |  "results": [
+           |    {
+           |      "generated_text": "Hello",
+           |      "generated_token_count": 1,
+           |      "input_token_count": 2
+           |    }
+           |  ]
+           |}""".stripMargin
+    )
+    val apiMock = new MockHttpClient(Seq(genResponse))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.id should not be empty
+  }
+
+  it should "handle missing token usage gracefully (return None)" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val genResponse = HttpResponse(
+      statusCode = 200,
+      body =
+        """|{
+           |  "id": "gen-nousage",
+           |  "results": [
+           |    {
+           |      "generated_text": "Response without usage"
+           |    }
+           |  ]
+           |}""".stripMargin
+    )
+    val apiMock = new MockHttpClient(Seq(genResponse))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isRight shouldBe true
+    result.toOption.get.usage shouldBe None
+  }
+
+  // ==========================================================================
+  // complete() — error cases
+  // ==========================================================================
+
+  it should "map HTTP 401 to AuthenticationError" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(HttpResponse(401, """{"error":"Unauthorized"}"""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe an[AuthenticationError]
+  }
+
+  it should "map HTTP 403 to AuthenticationError" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(HttpResponse(403, """{"error":"Forbidden"}"""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe an[AuthenticationError]
+  }
+
+  it should "map HTTP 429 to RateLimitError" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(HttpResponse(429, """{"error":"Rate limit exceeded"}"""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[RateLimitError]
+  }
+
+  it should "map HTTP 500 to ServiceError" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(HttpResponse(500, """{"error":"Internal server error"}"""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe a[ServiceError]
+  }
+
+  it should "return error when API HTTP call fails with network exception" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new FailingHttpClient(new java.io.IOException("Connection refused"))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+  }
+
+  it should "return error when response body is malformed JSON" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(HttpResponse(200, "not valid json {{{"))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+  }
+
+  it should "return error when response missing results array" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(HttpResponse(200, """{"id":"gen-1","model_id":"ibm/granite-13b-instruct-v2"}"""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.complete(conversation, CompletionOptions())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get.message should include("results")
+  }
+
+  // ==========================================================================
+  // complete() — request body building
+  // ==========================================================================
+
+  it should "include project_id in request body when spaceId is None" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(Seq(watsonxSuccessResponse("Response")))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    client.complete(conversation, CompletionOptions())
+
+    val requestBody = apiMock.lastBody.value
+    requestBody should include("project_id")
+    requestBody should include("test-project-id")
+    requestBody should not include "space_id"
+  }
+
+  it should "include space_id in request body when spaceId is set" in {
+    val configWithSpace = testConfig.copy(spaceId = Some("my-space-123"))
+    val iamMock         = new MockHttpClient(Seq(iamSuccessResponse))
+    val genResponse     = watsonxSuccessResponse("Response with space")
+    val apiMock         = new MockHttpClient(Seq(genResponse))
+    val client          = WatsonXClient.forTest(configWithSpace, apiMock, iamMock)
+
+    client.complete(conversation, CompletionOptions())
+
+    val requestBody = apiMock.lastBody.value
+    requestBody should include("space_id")
+    requestBody should include("my-space-123")
+    requestBody should not include "project_id"
+  }
+
+  it should "include model_id in request body" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(Seq(watsonxSuccessResponse("Response")))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    client.complete(conversation, CompletionOptions())
+
+    val requestBody = apiMock.lastBody.value
+    requestBody should include("model_id")
+    requestBody should include("ibm/granite-13b-instruct-v2")
+  }
+
+  it should "include max_new_tokens when maxTokens option is set" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(Seq(watsonxSuccessResponse("Response")))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    client.complete(conversation, CompletionOptions(maxTokens = Some(512)))
+
+    val requestBody = apiMock.lastBody.value
+    requestBody should include("max_new_tokens")
+    requestBody should include("512")
+  }
+
+  it should "include Bearer token in Authorization header" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(Seq(watsonxSuccessResponse("Response")))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    client.complete(conversation, CompletionOptions())
+
+    val headers = apiMock.lastHeaders.value
+    headers.get("Authorization") shouldBe Some("Bearer test-bearer-token")
+  }
+
+  it should "include api version in request URL" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(Seq(watsonxSuccessResponse("Response")))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    client.complete(conversation, CompletionOptions())
+
+    val url = apiMock.lastUrl.value
+    url should include("version=2024-05-31")
+    url should include("/ml/v1/text/generation")
+  }
+
+  // ==========================================================================
+  // Conversation formatting tests
+  // ==========================================================================
+
+  it should "format multi-turn conversation with system, user, and assistant messages" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new MockHttpClient(Seq(watsonxSuccessResponse("Response")))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+    val multiConv = Conversation(
+      Seq(
+        SystemMessage("You are a helpful assistant."),
+        UserMessage("Hello"),
+        AssistantMessage(Some("Hi! How can I help?"), Seq.empty),
+        UserMessage("Tell me about Scala")
+      )
+    )
+
+    client.complete(multiConv, CompletionOptions())
+
+    val requestBody = apiMock.lastBody.value
+    requestBody should include("[SYSTEM]: You are a helpful assistant.")
+    requestBody should include("[USER]: Hello")
+    requestBody should include("[ASSISTANT]: Hi! How can I help?")
+    requestBody should include("[USER]: Tell me about Scala")
+    requestBody should include("[ASSISTANT]: ")
+  }
+
+  // ==========================================================================
+  // buildGenerationRequest tests (unit)
+  // ==========================================================================
+
+  "WatsonXClient.buildGenerationRequest" should "include input field" in {
+    val iamMock = new MockHttpClient(HttpResponse(200, ""))
+    val apiMock = new MockHttpClient(HttpResponse(200, ""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+    val conv    = Conversation(Seq(UserMessage("test input")))
+
+    val req = client.buildGenerationRequest(conv, CompletionOptions())
+
+    req.obj.keys.toSeq should contain("input")
+    req.obj.keys.toSeq should contain("model_id")
+    req.obj.keys.toSeq should contain("parameters")
+    req.obj("model_id").str shouldBe "ibm/granite-13b-instruct-v2"
+  }
+
+  it should "add top_p to parameters when not default (1.0)" in {
+    val iamMock = new MockHttpClient(HttpResponse(200, ""))
+    val apiMock = new MockHttpClient(HttpResponse(200, ""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+    val conv    = Conversation(Seq(UserMessage("test")))
+
+    val req = client.buildGenerationRequest(conv, CompletionOptions(topP = 0.9))
+
+    val params = req.obj("parameters")
+    params.obj.keys.toSeq should contain("top_p")
+  }
+
+  it should "not add top_p to parameters when topP is default (1.0)" in {
+    val iamMock = new MockHttpClient(HttpResponse(200, ""))
+    val apiMock = new MockHttpClient(HttpResponse(200, ""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+    val conv    = Conversation(Seq(UserMessage("test")))
+
+    val req = client.buildGenerationRequest(conv, CompletionOptions())
+
+    val params = req.obj("parameters")
+    params.obj.keys.toSeq should not contain "top_p"
+  }
+
+  // ==========================================================================
+  // Accessor tests
+  // ==========================================================================
+
+  "WatsonXClient" should "return correct context window from config" in {
+    val iamMock = new MockHttpClient(HttpResponse(200, ""))
+    val apiMock = new MockHttpClient(HttpResponse(200, ""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    client.getContextWindow() shouldBe 8192
+  }
+
+  it should "return correct reserve completion from config" in {
+    val iamMock = new MockHttpClient(HttpResponse(200, ""))
+    val apiMock = new MockHttpClient(HttpResponse(200, ""))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    client.getReserveCompletion() shouldBe 4096
+  }
+
+  // ==========================================================================
+  // Streaming tests
+  // ==========================================================================
+
+  "WatsonXClient.streamComplete" should "parse streaming SSE events and accumulate content" in {
+    val sseBody =
+      "data: {\"results\":[{\"generated_text\":\"Hello\",\"generated_token_count\":1,\"input_token_count\":2}]}\n\n" +
+        "data: {\"results\":[{\"generated_text\":\" world\",\"generated_token_count\":1,\"input_token_count\":2}]}\n\n" +
+        "data: [DONE]\n\n"
+
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val streamingResponse = StreamingHttpResponse(
+      statusCode = 200,
+      body = new java.io.ByteArrayInputStream(sseBody.getBytes("UTF-8"))
+    )
+
+    val apiMock = new MockHttpClient(HttpResponse(200, sseBody)) {
+      override def postStream(
+        url: String,
+        headers: Map[String, String],
+        body: String,
+        timeout: Int
+      ): StreamingHttpResponse = streamingResponse
+    }
+    val client = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+    val chunks = scala.collection.mutable.ListBuffer.empty[org.llm4s.llmconnect.model.StreamedChunk]
+
+    val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+    result.isRight shouldBe true
+    val completion = result.toOption.get
+    completion.content shouldBe "Hello world"
+    chunks should have size 2
+  }
+
+  it should "handle streaming error status" in {
+    val errorBody = """{"error":"Unauthorized"}"""
+    val iamMock   = new MockHttpClient(Seq(iamSuccessResponse))
+    val streamingResponse = StreamingHttpResponse(
+      statusCode = 401,
+      body = new java.io.ByteArrayInputStream(errorBody.getBytes("UTF-8"))
+    )
+    val apiMock = new MockHttpClient(HttpResponse(401, errorBody)) {
+      override def postStream(
+        url: String,
+        headers: Map[String, String],
+        body: String,
+        timeout: Int
+      ): StreamingHttpResponse = streamingResponse
+    }
+    val client = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get shouldBe an[AuthenticationError]
+  }
+
+  it should "accumulate multiple text chunks in streaming" in {
+    val sseBody = Seq(
+      "data: {\"id\":\"gen-s1\",\"results\":[{\"generated_text\":\"chunk1\"}]}\n\n",
+      "data: {\"id\":\"gen-s1\",\"results\":[{\"generated_text\":\" chunk2\"}]}\n\n",
+      "data: {\"id\":\"gen-s1\",\"results\":[{\"generated_text\":\" chunk3\"}]}\n\n"
+    ).mkString
+
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val streamingResponse = StreamingHttpResponse(
+      statusCode = 200,
+      body = new java.io.ByteArrayInputStream(sseBody.getBytes("UTF-8"))
+    )
+    val apiMock = new MockHttpClient(HttpResponse(200, sseBody)) {
+      override def postStream(
+        url: String,
+        headers: Map[String, String],
+        body: String,
+        timeout: Int
+      ): StreamingHttpResponse = streamingResponse
+    }
+    val client = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+    val chunks = scala.collection.mutable.ListBuffer.empty[org.llm4s.llmconnect.model.StreamedChunk]
+
+    val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+    result.isRight shouldBe true
+    result.toOption.get.content shouldBe "chunk1 chunk2 chunk3"
+    chunks should have size 3
+  }
+
+  it should "fail when stream HTTP call throws network exception" in {
+    val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
+    val apiMock = new FailingHttpClient(new java.io.IOException("Stream connection refused"))
+    val client  = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+    result.isLeft shouldBe true
+  }
+
+  it should "mark stream request body with stream=true" in {
+    val sseBody = "data: {\"results\":[{\"generated_text\":\"ok\"}]}\n\n"
+    val iamMock            = new MockHttpClient(Seq(iamSuccessResponse))
+    var capturedStreamBody = Option.empty[String]
+    val streamingResponse = StreamingHttpResponse(
+      statusCode = 200,
+      body = new java.io.ByteArrayInputStream(sseBody.getBytes("UTF-8"))
+    )
+    val apiMock = new MockHttpClient(HttpResponse(200, sseBody)) {
+      override def postStream(
+        url: String,
+        headers: Map[String, String],
+        body: String,
+        timeout: Int
+      ): StreamingHttpResponse = {
+        capturedStreamBody = Some(body)
+        streamingResponse
+      }
+    }
+    val client = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+
+    client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+    capturedStreamBody.value should include("\"stream\":true")
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXClientSpec.scala
@@ -31,8 +31,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
 
   private def watsonxSuccessResponse(text: String, id: String = "gen-123"): HttpResponse = HttpResponse(
     statusCode = 200,
-    body =
-      s"""|{
+    body = s"""|{
           |  "id": "$id",
           |  "model_id": "ibm/granite-13b-instruct-v2",
           |  "results": [
@@ -54,11 +53,11 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
 
   "WatsonXClient IAM token exchange" should "obtain a token and cache it" in {
     // Two responses: IAM token, then generation
-    val iamResponse  = iamSuccessResponse
-    val genResponse  = watsonxSuccessResponse("Hello from WatsonX!")
-    val iamMock      = new MockHttpClient(Seq(iamResponse))
-    val apiMock      = new MockHttpClient(Seq(genResponse))
-    val client       = WatsonXClient.forTest(testConfig, apiMock, iamMock)
+    val iamResponse = iamSuccessResponse
+    val genResponse = watsonxSuccessResponse("Hello from WatsonX!")
+    val iamMock     = new MockHttpClient(Seq(iamResponse))
+    val apiMock     = new MockHttpClient(Seq(genResponse))
+    val client      = WatsonXClient.forTest(testConfig, apiMock, iamMock)
 
     val result = client.complete(conversation, CompletionOptions())
 
@@ -154,8 +153,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
     val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
     val genResponse = HttpResponse(
       statusCode = 200,
-      body =
-        """|{
+      body = """|{
            |  "id": "gen-empty",
            |  "results": [
            |    {
@@ -179,8 +177,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
     val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
     val genResponse = HttpResponse(
       statusCode = 200,
-      body =
-        """|{
+      body = """|{
            |  "results": [
            |    {
            |      "generated_text": "Hello",
@@ -203,8 +200,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
     val iamMock = new MockHttpClient(Seq(iamSuccessResponse))
     val genResponse = HttpResponse(
       statusCode = 200,
-      body =
-        """|{
+      body = """|{
            |  "id": "gen-nousage",
            |  "results": [
            |    {
@@ -315,7 +311,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
     val requestBody = apiMock.lastBody.value
     requestBody should include("project_id")
     requestBody should include("test-project-id")
-    requestBody should not include "space_id"
+    (requestBody should not).include("space_id")
   }
 
   it should "include space_id in request body when spaceId is set" in {
@@ -330,7 +326,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
     val requestBody = apiMock.lastBody.value
     requestBody should include("space_id")
     requestBody should include("my-space-123")
-    requestBody should not include "project_id"
+    (requestBody should not).include("project_id")
   }
 
   it should "include model_id in request body" in {
@@ -568,7 +564,7 @@ class WatsonXClientSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "mark stream request body with stream=true" in {
-    val sseBody = "data: {\"results\":[{\"generated_text\":\"ok\"}]}\n\n"
+    val sseBody            = "data: {\"results\":[{\"generated_text\":\"ok\"}]}\n\n"
     val iamMock            = new MockHttpClient(Seq(iamSuccessResponse))
     var capturedStreamBody = Option.empty[String]
     val streamingResponse = StreamingHttpResponse(

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXConfigSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXConfigSpec.scala
@@ -1,0 +1,149 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.llmconnect.config.{ ContextWindowResolver, WatsonXConfig }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class WatsonXConfigSpec extends AnyFlatSpec with Matchers {
+
+  private given ContextWindowResolver =
+    ContextWindowResolver(org.llm4s.model.ModelRegistryTestSupport.defaultService())
+
+  "WatsonXConfig" should "have correct provider kind" in {
+    val cfg = WatsonXConfig(
+      apiKey = "key",
+      projectId = "proj",
+      spaceId = None,
+      model = "ibm/granite-13b-instruct-v2",
+      baseUrl = WatsonXConfig.DEFAULT_BASE_URL,
+      apiVersion = WatsonXConfig.DEFAULT_API_VERSION,
+      contextWindow = 8192,
+      reserveCompletion = 4096
+    )
+    cfg.provider.name shouldBe "watsonx"
+  }
+
+  it should "have correct DEFAULT_BASE_URL" in {
+    WatsonXConfig.DEFAULT_BASE_URL shouldBe "https://us-south.ml.cloud.ibm.com"
+  }
+
+  it should "have correct DEFAULT_API_VERSION" in {
+    WatsonXConfig.DEFAULT_API_VERSION shouldBe "2024-05-31"
+  }
+
+  it should "redact apiKey in toString" in {
+    val cfg = WatsonXConfig(
+      apiKey = "super-secret-key-12345",
+      projectId = "proj-abc",
+      spaceId = None,
+      model = "ibm/granite-13b-instruct-v2",
+      baseUrl = WatsonXConfig.DEFAULT_BASE_URL,
+      apiVersion = WatsonXConfig.DEFAULT_API_VERSION,
+      contextWindow = 8192,
+      reserveCompletion = 4096
+    )
+    val str = cfg.toString
+    str should not include "super-secret-key-12345"
+    str should include("WatsonXConfig")
+    str should include("proj-abc")
+  }
+
+  it should "construct via fromValues with defaults" in {
+    val cfg = WatsonXConfig.fromValues(
+      modelName = "ibm/granite-13b-instruct-v2",
+      apiKey = "test-api-key",
+      projectId = "my-project"
+    )
+    cfg.model shouldBe "ibm/granite-13b-instruct-v2"
+    cfg.apiKey shouldBe "test-api-key"
+    cfg.projectId shouldBe "my-project"
+    cfg.spaceId shouldBe None
+    cfg.baseUrl shouldBe WatsonXConfig.DEFAULT_BASE_URL
+    cfg.apiVersion shouldBe WatsonXConfig.DEFAULT_API_VERSION
+  }
+
+  it should "construct via fromValues with explicit space ID" in {
+    val cfg = WatsonXConfig.fromValues(
+      modelName = "meta-llama/llama-3-8b-instruct",
+      apiKey = "test-key",
+      projectId = "project-id",
+      spaceId = Some("space-123")
+    )
+    cfg.spaceId shouldBe Some("space-123")
+    cfg.model shouldBe "meta-llama/llama-3-8b-instruct"
+  }
+
+  it should "construct via fromValues with custom baseUrl and apiVersion" in {
+    val cfg = WatsonXConfig.fromValues(
+      modelName = "ibm/granite-13b-instruct-v2",
+      apiKey = "key",
+      projectId = "proj",
+      baseUrl = "https://eu-de.ml.cloud.ibm.com",
+      apiVersion = "2024-01-01"
+    )
+    cfg.baseUrl shouldBe "https://eu-de.ml.cloud.ibm.com"
+    cfg.apiVersion shouldBe "2024-01-01"
+  }
+
+  it should "fail fromValues with empty apiKey" in {
+    an[IllegalArgumentException] should be thrownBy WatsonXConfig.fromValues(
+      modelName = "ibm/granite-13b-instruct-v2",
+      apiKey = "",
+      projectId = "proj"
+    )
+  }
+
+  it should "fail fromValues with blank apiKey" in {
+    an[IllegalArgumentException] should be thrownBy WatsonXConfig.fromValues(
+      modelName = "ibm/granite-13b-instruct-v2",
+      apiKey = "   ",
+      projectId = "proj"
+    )
+  }
+
+  it should "fail fromValues with empty projectId" in {
+    an[IllegalArgumentException] should be thrownBy WatsonXConfig.fromValues(
+      modelName = "ibm/granite-13b-instruct-v2",
+      apiKey = "key",
+      projectId = ""
+    )
+  }
+
+  it should "fail fromValues with empty baseUrl" in {
+    an[IllegalArgumentException] should be thrownBy WatsonXConfig.fromValues(
+      modelName = "ibm/granite-13b-instruct-v2",
+      apiKey = "key",
+      projectId = "proj",
+      baseUrl = ""
+    )
+  }
+
+  it should "resolve context window for granite-13b model" in {
+    val cfg = WatsonXConfig.fromValues(
+      modelName = "ibm/granite-13b-instruct-v2",
+      apiKey = "key",
+      projectId = "proj"
+    )
+    cfg.contextWindow shouldBe 8192
+    cfg.reserveCompletion shouldBe 4096
+  }
+
+  it should "resolve context window for mistral-large model" in {
+    val cfg = WatsonXConfig.fromValues(
+      modelName = "mistralai/mistral-large",
+      apiKey = "key",
+      projectId = "proj"
+    )
+    cfg.contextWindow shouldBe 32768
+    cfg.reserveCompletion shouldBe 4096
+  }
+
+  it should "resolve context window for unknown model with 8192 default" in {
+    val cfg = WatsonXConfig.fromValues(
+      modelName = "some-unknown-model-xyz",
+      apiKey = "key",
+      projectId = "proj"
+    )
+    cfg.contextWindow shouldBe 8192
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXConfigSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXConfigSpec.scala
@@ -43,7 +43,7 @@ class WatsonXConfigSpec extends AnyFlatSpec with Matchers {
       reserveCompletion = 4096
     )
     val str = cfg.toString
-    str should not include "super-secret-key-12345"
+    (str should not).include("super-secret-key-12345")
     str should include("WatsonXConfig")
     str should include("proj-abc")
   }

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXConfigSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/WatsonXConfigSpec.scala
@@ -125,7 +125,7 @@ class WatsonXConfigSpec extends AnyFlatSpec with Matchers {
       projectId = "proj"
     )
     cfg.contextWindow shouldBe 8192
-    cfg.reserveCompletion shouldBe 4096
+    cfg.reserveCompletion shouldBe 8192
   }
 
   it should "resolve context window for mistral-large model" in {
@@ -134,8 +134,8 @@ class WatsonXConfigSpec extends AnyFlatSpec with Matchers {
       apiKey = "key",
       projectId = "proj"
     )
-    cfg.contextWindow shouldBe 32768
-    cfg.reserveCompletion shouldBe 4096
+    cfg.contextWindow shouldBe 131072
+    cfg.reserveCompletion shouldBe 16384
   }
 
   it should "resolve context window for unknown model with 8192 default" in {

--- a/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 class ProviderKindSpec extends AnyFlatSpec with Matchers:
 
   "ProviderKind" should "expose all expected provider instances" in {
-    ProviderKind.all should have size 10
+    ProviderKind.all should have size 11
     (ProviderKind.all should contain).allOf(
       ProviderKind.OpenAI,
       ProviderKind.Azure,
@@ -18,7 +18,8 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       ProviderKind.Gemini,
       ProviderKind.Cohere,
       ProviderKind.DeepSeek,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.WatsonX
     )
   }
 
@@ -33,6 +34,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     ProviderKind.DeepSeek.name shouldBe "deepseek"
     ProviderKind.Cohere.name shouldBe "cohere"
     ProviderKind.Mistral.name shouldBe "mistral"
+    ProviderKind.WatsonX.name shouldBe "watsonx"
   }
 
   "ProviderKind.fromName" should "parse supported providers case-insensitively" in {
@@ -47,6 +49,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     ProviderKind.fromName("DEEPSEEK") shouldBe Some(ProviderKind.DeepSeek)
     ProviderKind.fromName("COHERE") shouldBe Some(ProviderKind.Cohere)
     ProviderKind.fromName("MISTRAL") shouldBe Some(ProviderKind.Mistral)
+    ProviderKind.fromName("watsonx") shouldBe Some(ProviderKind.WatsonX)
   }
 
   it should "return None for unknown providers" in {
@@ -72,6 +75,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       case ProviderKind.DeepSeek   => "cloud-deepseek"
       case ProviderKind.Cohere     => "cloud-cohere"
       case ProviderKind.Mistral    => "cloud-mistral"
+      case ProviderKind.WatsonX    => "cloud-watsonx"
 
     describe(ProviderKind.OpenAI) shouldBe "cloud-openai"
     describe(ProviderKind.Ollama) shouldBe "local"

--- a/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
@@ -372,6 +372,12 @@ private[providersetup] object ProviderSetupRuntime:
           apiKey = input.flatMap(_.apiKey).getOrElse(cfg.apiKey),
           baseUrl = input.flatMap(_.baseUrl).getOrElse(cfg.baseUrl)
         )
+      case cfg: WatsonXConfig =>
+        cfg.copy(
+          model = input.flatMap(_.model).getOrElse(cfg.model),
+          apiKey = input.flatMap(_.apiKey).getOrElse(cfg.apiKey),
+          baseUrl = input.flatMap(_.baseUrl).getOrElse(cfg.baseUrl)
+        )
 
   def demoCompletionCmd(
     providerConfig: ProviderConfig,
@@ -580,3 +586,4 @@ private[providersetup] object ProviderSetupRuntime:
       case cfg: CohereConfig    => cfg.copy(model = modelName)
       case cfg: MistralConfig   => cfg.copy(model = modelName)
       case cfg: ZaiConfig       => cfg.copy(model = modelName)
+      case cfg: WatsonXConfig   => cfg.copy(model = modelName)

--- a/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
@@ -141,6 +141,7 @@ object PrometheusMetricsExample {
                 case _: org.llm4s.llmconnect.config.DeepSeekConfig  => "deepseek"
                 case _: org.llm4s.llmconnect.config.CohereConfig    => "cohere"
                 case _: org.llm4s.llmconnect.config.MistralConfig   => "mistral"
+                case _: org.llm4s.llmconnect.config.WatsonXConfig   => "watsonx"
               }
 
               println(s"Using model: ${config.model}")


### PR DESCRIPTION
## Summary

- Adds `WatsonXConfig` with IAM API key, project ID, optional space ID, base URL (`https://us-south.ml.cloud.ibm.com`), and API version (`2024-05-31`)
- Implements `WatsonXClient` with `complete()` (blocking) and `streamComplete()` (SSE streaming) via the WatsonX ML API (`/ml/v1/text/generation` and `/ml/v1/text/generation_stream`)
- IAM token exchange (`POST https://iam.cloud.ibm.com/identity/token`) with lazy refresh and 5-minute expiry buffer using `AtomicReference`
- Registers `ProviderKind.WatsonX` with full routing in `LLMConnect`, named provider config loading, validator, and capabilities registry
- Adds `ConfigKeys` constants: `WATSONX_API_KEY`, `IBM_CLOUD_PROJECT_ID`, `WATSONX_BASE_URL`
- Unit tests using `MockHttpClient` and `FailingHttpClient` — 30+ test cases covering IAM exchange, token caching, error mapping, request format, conversation formatting, streaming, and config validation

## Test plan

- [ ] `sbt "core/testOnly org.llm4s.llmconnect.provider.WatsonXClientSpec"` — IAM exchange, complete, streamComplete, error handling
- [ ] `sbt "core/testOnly org.llm4s.llmconnect.provider.WatsonXConfigSpec"` — config construction, defaults, validation, toString redaction
- [ ] `sbt +test` — cross-version regression
- [ ] `sbt scalafmtAll` — formatting check

## Notes

- WatsonX uses a proprietary request format (`model_id`, `project_id`/`space_id`, `input` as single concatenated string, `parameters.max_new_tokens`) rather than OpenAI-compatible chat completions
- Conversation messages are formatted with `[SYSTEM]:`, `[USER]:`, `[ASSISTANT]:`, `[TOOL_RESULT:<id>]:` prefixes and concatenated into a single `input` field
- Configure via named provider in `llm4s.providers.<name>` with `provider = "watsonx"`, `apiKey`, `endpoint` (used as `projectId`), and optionally `baseUrl`, `apiVersion`

Closes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)