### PR TITLE
feat: implement Jina AI embedding provider (JinaEmbeddingProvider) for enterprise RAG

### DIFF
--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -153,6 +153,16 @@ llm4s {
       model   = ${?VOYAGE_EMBEDDING_MODEL}
     }
 
+    # Jina AI embeddings (cloud)
+    # Env: JINA_API_KEY (required), JINA_EMBEDDING_BASE_URL (optional), JINA_EMBEDDING_MODEL (optional)
+    jina {
+      apiKey  = ${?JINA_API_KEY}
+      # Default base URL used when EMBEDDING_MODEL=jina/... is set
+      baseUrl = "https://api.jina.ai"
+      baseUrl = ${?JINA_EMBEDDING_BASE_URL}
+      model   = ${?JINA_EMBEDDING_MODEL}
+    }
+
     # Ollama embeddings (local)
     # Env: OLLAMA_EMBEDDING_BASE_URL (default: http://localhost:11434), OLLAMA_EMBEDDING_MODEL
     ollama {

--- a/modules/core/src/main/scala/org/llm4s/config/ConfigKeys.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/ConfigKeys.scala
@@ -147,6 +147,17 @@ object ConfigKeys {
   /** Selects the Ollama embedding model when using the legacy provider format. */
   val OLLAMA_EMBEDDING_MODEL = "OLLAMA_EMBEDDING_MODEL"
 
+  // ---- Embeddings: Jina AI ------------------------------------------------
+
+  /** Jina AI API key. Required when using Jina embedding models. */
+  val JINA_API_KEY = "JINA_API_KEY"
+
+  /** Overrides the Jina AI embedding base URL. Defaults to `"https://api.jina.ai"`. */
+  val JINA_EMBEDDING_BASE_URL = "JINA_EMBEDDING_BASE_URL"
+
+  /** Selects the Jina AI embedding model when using the legacy provider format. */
+  val JINA_EMBEDDING_MODEL = "JINA_EMBEDDING_MODEL"
+
   // ---- Embeddings: chunking -----------------------------------------------
 
   /** Token count per chunk when splitting documents for embedding. Default: `1000`. */

--- a/modules/core/src/main/scala/org/llm4s/config/EmbeddingsConfigLoader.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/EmbeddingsConfigLoader.scala
@@ -31,12 +31,19 @@ private[config] object EmbeddingsConfigLoader {
     model: Option[String]
   )
 
+  final private case class EmbeddingsJinaSection(
+    apiKey: Option[String],
+    baseUrl: Option[String],
+    model: Option[String]
+  )
+
   final private case class EmbeddingsSection(
     model: Option[String],    // Unified format: provider/model (e.g., openai/text-embedding-3-small)
     provider: Option[String], // Legacy fallback
     openai: Option[EmbeddingsOpenAISection],
     voyage: Option[EmbeddingsVoyageSection],
-    ollama: Option[EmbeddingsOllamaSection]
+    ollama: Option[EmbeddingsOllamaSection],
+    jina: Option[EmbeddingsJinaSection]
   )
 
   final private case class EmbeddingsRoot(embeddings: Option[EmbeddingsSection])
@@ -52,8 +59,11 @@ private[config] object EmbeddingsConfigLoader {
   implicit private val embeddingsOllamaSectionReader: PureConfigReader[EmbeddingsOllamaSection] =
     PureConfigReader.forProduct3("apiKey", "baseUrl", "model")(EmbeddingsOllamaSection.apply)
 
+  implicit private val embeddingsJinaSectionReader: PureConfigReader[EmbeddingsJinaSection] =
+    PureConfigReader.forProduct3("apiKey", "baseUrl", "model")(EmbeddingsJinaSection.apply)
+
   implicit private val embeddingsSectionReader: PureConfigReader[EmbeddingsSection] =
-    PureConfigReader.forProduct5("model", "provider", "openai", "voyage", "ollama")(EmbeddingsSection.apply)
+    PureConfigReader.forProduct6("model", "provider", "openai", "voyage", "ollama", "jina")(EmbeddingsSection.apply)
 
   implicit private val embeddingsRootReader: PureConfigReader[EmbeddingsRoot] =
     PureConfigReader.forProduct1("embeddings")(EmbeddingsRoot.apply)
@@ -100,7 +110,7 @@ private[config] object EmbeddingsConfigLoader {
     root: EmbeddingsRoot,
     source: ConfigSource,
   ): Result[(String, EmbeddingProviderConfig)] = {
-    val emb = root.embeddings.getOrElse(EmbeddingsSection(None, None, None, None, None))
+    val emb = root.embeddings.getOrElse(EmbeddingsSection(None, None, None, None, None, None))
 
     // Check for unified model format first (e.g., "openai/text-embedding-3-small")
     emb.model.map(_.trim).filter(_.nonEmpty) match {
@@ -116,6 +126,8 @@ private[config] object EmbeddingsConfigLoader {
               buildVoyageEmbeddings(emb.voyage, Some(modelName)).map("voyage" -> _)
             case "ollama" =>
               buildOllamaEmbeddings(emb.ollama, Some(modelName)).map("ollama" -> _)
+            case "jina" =>
+              buildJinaEmbeddings(emb.jina, Some(modelName)).map("jina" -> _)
             case other =>
               Left(ConfigurationError(s"Unknown embedding provider: $other in '$modelSpec'"))
           }
@@ -136,6 +148,8 @@ private[config] object EmbeddingsConfigLoader {
             buildVoyageEmbeddings(emb.voyage, None).map("voyage" -> _)
           case Some("ollama") =>
             buildOllamaEmbeddings(emb.ollama, None).map("ollama" -> _)
+          case Some("jina") =>
+            buildJinaEmbeddings(emb.jina, None).map("jina" -> _)
           case Some(other) =>
             Left(ConfigurationError(s"Unknown embedding provider: $other"))
           case None =>
@@ -151,6 +165,7 @@ private[config] object EmbeddingsConfigLoader {
   private val DefaultOpenAIEmbeddingBaseUrl = "https://api.openai.com/v1"
   private val DefaultVoyageEmbeddingBaseUrl = "https://api.voyageai.com/v1"
   private val DefaultOllamaEmbeddingBaseUrl = "http://localhost:11434"
+  private val DefaultJinaEmbeddingBaseUrl   = "https://api.jina.ai"
 
   private def buildOpenAIEmbeddings(
     section: Option[EmbeddingsOpenAISection],
@@ -255,6 +270,39 @@ private[config] object EmbeddingsConfigLoader {
       modelOpt.toRight(
         ConfigurationError(
           "Missing Voyage embeddings model (set EMBEDDING_MODEL=voyage/model-name or VOYAGE_EMBEDDING_MODEL)"
+        )
+      )
+
+    for {
+      apiKey <- apiKeyResult
+      model  <- modelResult
+    } yield EmbeddingProviderConfig(baseUrl = baseUrl, model = model, apiKey = apiKey)
+  }
+
+  private def buildJinaEmbeddings(
+    section: Option[EmbeddingsJinaSection],
+    modelOverride: Option[String]
+  ): Result[EmbeddingProviderConfig] = {
+    // Use model from unified format, or fall back to section model
+    val modelOpt = modelOverride.orElse(section.flatMap(_.model)).map(_.trim).filter(_.nonEmpty)
+
+    // Use section baseUrl if provided, otherwise default
+    val baseUrl = section
+      .flatMap(_.baseUrl)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .getOrElse(DefaultJinaEmbeddingBaseUrl)
+
+    val apiKeyOpt = section.flatMap(_.apiKey).map(_.trim).filter(_.nonEmpty)
+
+    val apiKeyResult: Result[String] =
+      apiKeyOpt.toRight(
+        ConfigurationError("Missing Jina embeddings apiKey (llm4s.embeddings.jina.apiKey / JINA_API_KEY)")
+      )
+    val modelResult: Result[String] =
+      modelOpt.toRight(
+        ConfigurationError(
+          "Missing Jina embeddings model (set EMBEDDING_MODEL=jina/model-name or JINA_EMBEDDING_MODEL)"
         )
       )
 

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/EmbeddingClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/EmbeddingClient.scala
@@ -5,6 +5,7 @@ import org.llm4s.llmconnect.encoding.UniversalEncoder
 import org.llm4s.llmconnect.model.{ EmbeddingError, EmbeddingRequest, EmbeddingResponse, EmbeddingVector }
 import org.llm4s.llmconnect.provider.{
   EmbeddingProvider,
+  JinaEmbeddingProvider,
   OllamaEmbeddingProvider,
   OpenAIEmbeddingProvider,
   VoyageAIEmbeddingProvider
@@ -134,6 +135,7 @@ object EmbeddingClient {
       case "openai" => Right(new EmbeddingClient(OpenAIEmbeddingProvider.fromConfig(cfg)))
       case "voyage" => Right(new EmbeddingClient(VoyageAIEmbeddingProvider.fromConfig(cfg)))
       case "ollama" => Right(new EmbeddingClient(OllamaEmbeddingProvider.fromConfig(cfg)))
+      case "jina"   => Right(new EmbeddingClient(JinaEmbeddingProvider.fromConfig(cfg)))
       case other =>
         Left(
           EmbeddingError(

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/JinaEmbeddingProvider.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/JinaEmbeddingProvider.scala
@@ -1,0 +1,147 @@
+// scalafix:off DisableSyntax.NoKeywordCatch
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.http.{ HttpResponse => Llm4sHttpResponse, Llm4sHttpClient }
+import org.llm4s.llmconnect.config.EmbeddingProviderConfig
+import org.llm4s.llmconnect.model._
+import org.llm4s.util.Redaction
+import org.slf4j.LoggerFactory
+import ujson.{ Arr, Obj }
+
+import scala.util.Try
+import scala.util.control.NonFatal
+
+/**
+ * Embedding provider implementation for the Jina AI embedding API.
+ *
+ * Generates text embeddings by posting batched input to the Jina AI
+ * `/v1/embeddings` endpoint. Supports task-specific adapters for improved
+ * retrieval quality in enterprise RAG pipelines.
+ *
+ * == Supported Tasks ==
+ *  - `retrieval.passage` — encode document passages for indexing
+ *  - `retrieval.query`   — encode user queries for search
+ *  - `text-matching`     — general-purpose similarity (default)
+ *
+ * == Supported Models ==
+ *  - `jina-embeddings-v3` — 8192-token context, 1024-dimensional, multilingual
+ *
+ * Requires a valid Jina AI API key (`JINA_API_KEY`) in the provider configuration.
+ *
+ * @see [[EmbeddingProvider]] for the common embedding interface
+ */
+object JinaEmbeddingProvider {
+
+  /** Default task type used when no task is supplied in request metadata. */
+  val DefaultTask: String = "text-matching"
+
+  /** Metadata key used to pass the task type through [[EmbeddingRequest]]. */
+  val TaskMetaKey: String = "jina_task"
+
+  /** Creates an [[EmbeddingProvider]] backed by Jina AI using the given configuration. */
+  def fromConfig(cfg: EmbeddingProviderConfig): EmbeddingProvider =
+    create(cfg, Llm4sHttpClient.create())
+
+  private[provider] def forTest(cfg: EmbeddingProviderConfig, httpClient: Llm4sHttpClient): EmbeddingProvider =
+    create(cfg, httpClient)
+
+  private def create(cfg: EmbeddingProviderConfig, httpClient: Llm4sHttpClient): EmbeddingProvider =
+    new EmbeddingProvider {
+      private val logger = LoggerFactory.getLogger(getClass)
+
+      override def embed(request: EmbeddingRequest): Either[EmbeddingError, EmbeddingResponse] = {
+        val model = request.model.name
+        val input = request.input
+
+        // Task comes from model config metadata (stored as extra field) or defaults.
+        // EmbeddingRequest only carries input + model; we use a naming convention on
+        // the model name ("model:task") so callers can optionally encode the task.
+        // Alternatively the task can be appended to the model name as "model::task".
+        val task      = extractTask(model)
+        val modelName = stripTask(model)
+
+        val payload = buildPayload(input, modelName, task)
+
+        val url = s"${cfg.baseUrl}/v1/embeddings"
+        logger.debug(s"[JinaEmbeddingProvider] POST $url model=$modelName task=$task inputs=${input.size}")
+
+        val headers = Map(
+          "Authorization" -> s"Bearer ${cfg.apiKey}",
+          "Content-Type"  -> "application/json"
+        )
+
+        val respEither: Either[EmbeddingError, Llm4sHttpResponse] =
+          try Right(httpClient.post(url, headers, payload.render(), timeout = 120000))
+          catch {
+            case e: InterruptedException =>
+              Thread.currentThread().interrupt()
+              Left(
+                EmbeddingError(
+                  code = None,
+                  message = s"HTTP request interrupted: ${e.getMessage}",
+                  provider = "jina"
+                )
+              )
+            case NonFatal(e) =>
+              Left(EmbeddingError(code = None, message = s"HTTP request failed: ${e.getMessage}", provider = "jina"))
+          }
+
+        respEither.flatMap { response =>
+          response.statusCode match {
+            case 200 =>
+              Try {
+                val json    = ujson.read(response.body)
+                val vectors = json("data").arr.map(r => r("embedding").arr.map(_.num).toVector).toSeq
+                val metadata = Map(
+                  "provider" -> "jina",
+                  "model"    -> modelName,
+                  "task"     -> task,
+                  "count"    -> input.size.toString
+                )
+                EmbeddingResponse(embeddings = vectors, metadata = metadata)
+              }.toEither.left
+                .map { ex =>
+                  logger.error(s"[JinaEmbeddingProvider] Parse error: ${ex.getMessage}")
+                  EmbeddingError(code = None, message = s"Parsing error: ${ex.getMessage}", provider = "jina")
+                }
+            case 401 =>
+              val body = Redaction.truncateForLog(response.body)
+              logger.error(s"[JinaEmbeddingProvider] Auth error (401): $body")
+              Left(EmbeddingError(code = Some("401"), message = s"Authentication failed: $body", provider = "jina"))
+            case 429 =>
+              val body = Redaction.truncateForLog(response.body)
+              logger.warn(s"[JinaEmbeddingProvider] Rate limit (429): $body")
+              Left(EmbeddingError(code = Some("429"), message = s"Rate limit exceeded: $body", provider = "jina"))
+            case status =>
+              val body = Redaction.truncateForLog(response.body)
+              logger.error(s"[JinaEmbeddingProvider] HTTP error $status: $body")
+              Left(EmbeddingError(code = Some(status.toString), message = body, provider = "jina"))
+          }
+        }
+      }
+    }
+
+  /**
+   * Extract an optional task suffix encoded in the model name.
+   *
+   * Supports two encoding conventions callers can use:
+   *  - `"jina-embeddings-v3::retrieval.passage"` — double-colon separator
+   *  - bare `"jina-embeddings-v3"` — uses [[DefaultTask]]
+   */
+  private[provider] def extractTask(rawModel: String): String =
+    rawModel.split("::", 2) match {
+      case Array(_, task) if task.nonEmpty => task
+      case _                               => DefaultTask
+    }
+
+  /** Strip the optional task suffix to obtain the real model name. */
+  private[provider] def stripTask(rawModel: String): String =
+    rawModel.split("::", 2)(0)
+
+  private def buildPayload(input: Seq[String], model: String, task: String): Obj =
+    Obj(
+      "input" -> Arr.from(input),
+      "model" -> model,
+      "task"  -> task
+    )
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/JinaEmbeddingProviderSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/JinaEmbeddingProviderSpec.scala
@@ -1,0 +1,285 @@
+package org.llm4s.llmconnect.provider
+
+import ch.qos.logback.classic.{ Level, Logger => LBLogger }
+import org.llm4s.http.{ FailingHttpClient, HttpResponse, MockHttpClient }
+import org.llm4s.llmconnect.config.{ EmbeddingModelConfig, EmbeddingProviderConfig }
+import org.llm4s.llmconnect.model.{ EmbeddingRequest, Image, MultimediaEmbeddingRequest }
+import org.scalatest.Outcome
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ujson.read
+
+class JinaEmbeddingProviderSpec extends AnyFlatSpec with Matchers {
+
+  // Suppress noisy provider logs during tests
+  override def withFixture(test: NoArgTest): Outcome = {
+    val loggerName = "org.llm4s.llmconnect.provider.JinaEmbeddingProvider$$anon$1"
+    val logger     = org.slf4j.LoggerFactory.getLogger(loggerName).asInstanceOf[LBLogger]
+    val previous   = logger.getLevel
+    logger.setLevel(Level.OFF)
+    try super.withFixture(test)
+    finally logger.setLevel(previous)
+  }
+
+  // ---- test fixtures -------------------------------------------------------
+
+  private val cfg = EmbeddingProviderConfig(
+    baseUrl = "http://jina-test",
+    model = "jina-embeddings-v3",
+    apiKey = "jina-test-key"
+  )
+
+  private val modelCfg = EmbeddingModelConfig("jina-embeddings-v3", 1024)
+  private val req      = EmbeddingRequest(Seq("hello", "world"), modelCfg)
+
+  private def httpOk(body: String): HttpResponse               = HttpResponse(200, body, Map.empty)
+  private def httpErr(status: Int, body: String): HttpResponse = HttpResponse(status, body, Map.empty)
+
+  private def embeddingBody(vectors: Seq[Seq[Double]]): String = {
+    val dataItems = vectors
+      .map { v =>
+        val floats = v.mkString("[", ",", "]")
+        s"""{"embedding":$floats}"""
+      }
+      .mkString("[", ",", "]")
+    s"""{"data":$dataItems}"""
+  }
+
+  // ---- happy-path tests ----------------------------------------------------
+
+  "JinaEmbeddingProvider" should "embed a single text and return the correct vector" in {
+    val body     = embeddingBody(Seq(Seq(0.1, 0.2, 0.3)))
+    val mockHttp = new MockHttpClient(httpOk(body))
+
+    val singleReq = EmbeddingRequest(Seq("hello"), modelCfg)
+    val provider  = JinaEmbeddingProvider.forTest(cfg, mockHttp)
+    val result    = provider.embed(singleReq)
+
+    result.isRight shouldBe true
+    val resp = result.toOption.get
+    resp.embeddings should have size 1
+    resp.embeddings(0) shouldBe Vector(0.1, 0.2, 0.3)
+  }
+
+  it should "embed a batch of texts and return all vectors in order" in {
+    val body     = embeddingBody(Seq(Seq(1.0), Seq(2.0), Seq(3.0)))
+    val mockHttp = new MockHttpClient(httpOk(body))
+
+    val multiReq = EmbeddingRequest(Seq("a", "b", "c"), modelCfg)
+    val provider = JinaEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(multiReq)
+
+    result.isRight shouldBe true
+    val resp = result.toOption.get
+    resp.embeddings should have size 3
+    resp.embeddings(0)(0) shouldBe 1.0
+    resp.embeddings(1)(0) shouldBe 2.0
+    resp.embeddings(2)(0) shouldBe 3.0
+  }
+
+  it should "include correct metadata in the response" in {
+    val body     = embeddingBody(Seq(Seq(0.5), Seq(0.6)))
+    val mockHttp = new MockHttpClient(httpOk(body))
+
+    val provider = JinaEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(req)
+
+    result.isRight shouldBe true
+    val meta = result.toOption.get.metadata
+    meta("provider") shouldBe "jina"
+    meta("model") shouldBe "jina-embeddings-v3"
+    meta("task") shouldBe JinaEmbeddingProvider.DefaultTask
+    meta("count") shouldBe "2"
+  }
+
+  // ---- task parameter tests ------------------------------------------------
+
+  it should "send the default task (text-matching) when no task suffix is in the model name" in {
+    val body     = embeddingBody(Seq(Seq(0.1, 0.2)))
+    val mockHttp = new MockHttpClient(httpOk(body))
+
+    val provider = JinaEmbeddingProvider.forTest(cfg, mockHttp)
+    provider.embed(req)
+
+    val sentBody = mockHttp.lastBody.get
+    val json     = read(sentBody)
+    json("task").str shouldBe "text-matching"
+  }
+
+  it should "send retrieval.passage task when encoded in the model name" in {
+    val passageCfg  = EmbeddingProviderConfig("http://jina-test", "jina-embeddings-v3", "jina-test-key")
+    val passageModel = EmbeddingModelConfig("jina-embeddings-v3::retrieval.passage", 1024)
+    val passageReq   = EmbeddingRequest(Seq("long document text"), passageModel)
+
+    val body     = embeddingBody(Seq(Seq(0.9, 0.8)))
+    val mockHttp = new MockHttpClient(httpOk(body))
+
+    val provider = JinaEmbeddingProvider.forTest(passageCfg, mockHttp)
+    val result   = provider.embed(passageReq)
+
+    result.isRight shouldBe true
+    val sentBody = mockHttp.lastBody.get
+    val json     = read(sentBody)
+    json("task").str shouldBe "retrieval.passage"
+    json("model").str shouldBe "jina-embeddings-v3"
+  }
+
+  it should "send retrieval.query task when encoded in the model name" in {
+    val queryModel = EmbeddingModelConfig("jina-embeddings-v3::retrieval.query", 1024)
+    val queryReq   = EmbeddingRequest(Seq("search query"), queryModel)
+
+    val body     = embeddingBody(Seq(Seq(0.3, 0.4)))
+    val mockHttp = new MockHttpClient(httpOk(body))
+
+    val provider = JinaEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(queryReq)
+
+    result.isRight shouldBe true
+    val sentBody = mockHttp.lastBody.get
+    val json     = read(sentBody)
+    json("task").str shouldBe "retrieval.query"
+  }
+
+  it should "send the correct URL with Bearer auth header" in {
+    val body     = embeddingBody(Seq(Seq(0.1)))
+    val mockHttp = new MockHttpClient(httpOk(body))
+
+    val singleReq = EmbeddingRequest(Seq("test"), modelCfg)
+    JinaEmbeddingProvider.forTest(cfg, mockHttp).embed(singleReq)
+
+    mockHttp.lastUrl.get shouldBe "http://jina-test/v1/embeddings"
+    mockHttp.lastHeaders.get("Authorization") shouldBe "Bearer jina-test-key"
+    mockHttp.lastHeaders.get("Content-Type") shouldBe "application/json"
+  }
+
+  it should "send the input texts in the request body" in {
+    val body     = embeddingBody(Seq(Seq(0.1), Seq(0.2)))
+    val mockHttp = new MockHttpClient(httpOk(body))
+
+    JinaEmbeddingProvider.forTest(cfg, mockHttp).embed(req)
+
+    val json = read(mockHttp.lastBody.get)
+    json("input").arr.map(_.str).toSeq shouldBe Seq("hello", "world")
+  }
+
+  // ---- error handling tests ------------------------------------------------
+
+  it should "return EmbeddingError with code 401 on HTTP 401" in {
+    val mockHttp = new MockHttpClient(httpErr(401, "Unauthorized"))
+    val provider = JinaEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(req)
+
+    result.isLeft shouldBe true
+    val err = result.left.toOption.get
+    err.code shouldBe Some("401")
+    err.context("provider") shouldBe "jina"
+  }
+
+  it should "return EmbeddingError with code 429 on HTTP 429 (rate limit)" in {
+    val mockHttp = new MockHttpClient(httpErr(429, "Rate limit exceeded"))
+    val provider = JinaEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(req)
+
+    result.isLeft shouldBe true
+    val err = result.left.toOption.get
+    err.code shouldBe Some("429")
+    err.context("provider") shouldBe "jina"
+  }
+
+  it should "return EmbeddingError with code 500 on HTTP 500" in {
+    val mockHttp = new MockHttpClient(httpErr(500, "Internal Server Error"))
+    val provider = JinaEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(req)
+
+    result.isLeft shouldBe true
+    val err = result.left.toOption.get
+    err.code shouldBe Some("500")
+    err.context("provider") shouldBe "jina"
+  }
+
+  it should "return EmbeddingError on malformed JSON response" in {
+    val mockHttp = new MockHttpClient(httpOk("not-valid-json{{{"))
+    val provider = JinaEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(req)
+
+    result.isLeft shouldBe true
+    result.left.toOption.get.context("provider") shouldBe "jina"
+  }
+
+  it should "return EmbeddingError on missing 'data' field in JSON" in {
+    val mockHttp = new MockHttpClient(httpOk("""{"result": []}"""))
+    val provider = JinaEmbeddingProvider.forTest(cfg, mockHttp)
+    val result   = provider.embed(req)
+
+    result.isLeft shouldBe true
+    result.left.toOption.get.context("provider") shouldBe "jina"
+  }
+
+  it should "return EmbeddingError on network failure" in {
+    val failingHttp = new FailingHttpClient(new java.io.IOException("connection refused"))
+    val provider    = JinaEmbeddingProvider.forTest(cfg, failingHttp)
+    val result      = provider.embed(req)
+
+    result.isLeft shouldBe true
+    val err = result.left.toOption.get
+    err.code shouldBe None
+    err.message should include("connection refused")
+    err.context("provider") shouldBe "jina"
+  }
+
+  it should "return EmbeddingError for interrupted request" in {
+    val interruptedException = new InterruptedException("interrupted")
+    val failingHttp          = new FailingHttpClient(interruptedException)
+    val provider             = JinaEmbeddingProvider.forTest(cfg, failingHttp)
+    val result               = provider.embed(req)
+
+    result.isLeft shouldBe true
+    val err = result.left.toOption.get
+    err.message should include("interrupted")
+    err.context("provider") shouldBe "jina"
+  }
+
+  // ---- task extraction helpers ---------------------------------------------
+
+  "JinaEmbeddingProvider.extractTask" should "return default task for plain model name" in {
+    JinaEmbeddingProvider.extractTask("jina-embeddings-v3") shouldBe JinaEmbeddingProvider.DefaultTask
+  }
+
+  it should "extract retrieval.passage from model::task encoding" in {
+    JinaEmbeddingProvider.extractTask("jina-embeddings-v3::retrieval.passage") shouldBe "retrieval.passage"
+  }
+
+  it should "extract retrieval.query from model::task encoding" in {
+    JinaEmbeddingProvider.extractTask("jina-embeddings-v3::retrieval.query") shouldBe "retrieval.query"
+  }
+
+  it should "extract text-matching from model::task encoding" in {
+    JinaEmbeddingProvider.extractTask("jina-embeddings-v3::text-matching") shouldBe "text-matching"
+  }
+
+  "JinaEmbeddingProvider.stripTask" should "return model name unchanged when no task suffix" in {
+    JinaEmbeddingProvider.stripTask("jina-embeddings-v3") shouldBe "jina-embeddings-v3"
+  }
+
+  it should "strip the task suffix and return only the model name" in {
+    JinaEmbeddingProvider.stripTask("jina-embeddings-v3::retrieval.passage") shouldBe "jina-embeddings-v3"
+  }
+
+  // ---- multimodal default --------------------------------------------------
+
+  it should "return 501 Not Implemented for multimodal embed by default" in {
+    val body     = embeddingBody(Seq(Seq(0.1)))
+    val mockHttp = new MockHttpClient(httpOk(body))
+    val provider = JinaEmbeddingProvider.forTest(cfg, mockHttp)
+
+    val multiReq = MultimediaEmbeddingRequest(
+      inputs = Seq.empty,
+      model = modelCfg,
+      modality = Image
+    )
+    val result = provider.embedMultimodal(multiReq)
+
+    result.isLeft shouldBe true
+    result.left.toOption.get.code shouldBe Some("501")
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/JinaEmbeddingProviderSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/JinaEmbeddingProviderSpec.scala
@@ -107,7 +107,7 @@ class JinaEmbeddingProviderSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "send retrieval.passage task when encoded in the model name" in {
-    val passageCfg  = EmbeddingProviderConfig("http://jina-test", "jina-embeddings-v3", "jina-test-key")
+    val passageCfg   = EmbeddingProviderConfig("http://jina-test", "jina-embeddings-v3", "jina-test-key")
     val passageModel = EmbeddingModelConfig("jina-embeddings-v3::retrieval.passage", 1024)
     val passageReq   = EmbeddingRequest(Seq("long document text"), passageModel)
 

--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/JinaEmbeddingsSmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/JinaEmbeddingsSmokeSpec.scala
@@ -1,0 +1,102 @@
+package org.llm4s.llmconnect.smoke
+
+import org.llm4s.llmconnect.config.{ EmbeddingModelConfig, EmbeddingProviderConfig }
+import org.llm4s.llmconnect.model.EmbeddingRequest
+import org.llm4s.llmconnect.provider.{ EmbeddingProvider, JinaEmbeddingProvider }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Cloud smoke tests for Jina AI embeddings.
+ *
+ * These tests live in the dedicated integration-test module so default `sbt test`
+ * stays fast. Run them with `sbt "it/testOnly org.llm4s.llmconnect.smoke.*"`
+ * or the `sbt testSmoke` alias.
+ *
+ * Requires: `JINA_API_KEY` environment variable.
+ * If the key is absent the tests are skipped gracefully via assume().
+ */
+class JinaEmbeddingsSmokeSpec extends AnyFlatSpec with Matchers {
+
+  private val jinaApiKey: Option[String] = Option(System.getenv("JINA_API_KEY")).filter(_.nonEmpty)
+
+  private val DefaultJinaBaseUrl = "https://api.jina.ai"
+  private val DefaultJinaModel   = "jina-embeddings-v3"
+  private val ExpectedDimensions = 1024
+
+  private def makeProvider(apiKey: String): EmbeddingProvider = {
+    val cfg = EmbeddingProviderConfig(
+      baseUrl = DefaultJinaBaseUrl,
+      model = DefaultJinaModel,
+      apiKey = apiKey
+    )
+    JinaEmbeddingProvider.fromConfig(cfg)
+  }
+
+  "Jina AI embeddings" should "embed 3 sentences with jina-embeddings-v3" in {
+    assume(jinaApiKey.isDefined, "JINA_API_KEY not set — skipping Jina smoke test")
+
+    val provider = makeProvider(jinaApiKey.get)
+    val modelCfg = EmbeddingModelConfig(DefaultJinaModel, ExpectedDimensions)
+    val request = EmbeddingRequest(
+      input = Seq(
+        "The quick brown fox jumps over the lazy dog.",
+        "Machine learning is transforming enterprise software.",
+        "Jina AI provides state-of-the-art embedding models for RAG."
+      ),
+      model = modelCfg
+    )
+
+    val result = provider.embed(request)
+
+    withClue(s"Embedding failed: ${result.swap.toOption}") {
+      result.isRight shouldBe true
+    }
+
+    val response = result.toOption.get
+
+    response.embeddings should not be empty
+    response.embeddings should have size 3
+
+    response.embeddings.foreach { vec =>
+      vec should not be empty
+      vec should have size ExpectedDimensions
+    }
+  }
+
+  it should "embed with retrieval.passage task encoded in model name" in {
+    assume(jinaApiKey.isDefined, "JINA_API_KEY not set — skipping Jina smoke test")
+
+    val provider = makeProvider(jinaApiKey.get)
+    // Encode task in model name using :: convention supported by JinaEmbeddingProvider
+    val modelCfg = EmbeddingModelConfig(s"$DefaultJinaModel::retrieval.passage", ExpectedDimensions)
+    val request = EmbeddingRequest(
+      input = Seq("Enterprise RAG pipelines benefit from task-specific embeddings."),
+      model = modelCfg
+    )
+
+    val result = provider.embed(request)
+
+    withClue(s"Embedding with task failed: ${result.swap.toOption}") {
+      result.isRight shouldBe true
+    }
+
+    val response = result.toOption.get
+    response.embeddings should have size 1
+    response.embeddings(0) should have size ExpectedDimensions
+  }
+
+  it should "return a 401 error for an invalid API key" in {
+    assume(jinaApiKey.isDefined, "JINA_API_KEY not set — skipping Jina smoke test")
+
+    val provider = makeProvider("jina-invalid-key-for-smoke-test")
+    val modelCfg = EmbeddingModelConfig(DefaultJinaModel, ExpectedDimensions)
+    val request  = EmbeddingRequest(Seq("test"), modelCfg)
+
+    val result = provider.embed(request)
+
+    result.isLeft shouldBe true
+    val err = result.left.toOption.get
+    err.code shouldBe Some("401")
+  }
+}


### PR DESCRIPTION
## Summary

Implements #1028: adds `JinaEmbeddingProvider` for Jina AI's `jina-embeddings-v3` model, a state-of-the-art embedding model with 8192-token context, strong multilingual performance, and task-specific adapters widely used in enterprise RAG pipelines.

## Changes

- **New:** `modules/core/src/main/scala/org/llm4s/llmconnect/provider/JinaEmbeddingProvider.scala`
  - Implements `EmbeddingProvider` trait
  - Calls `POST https://api.jina.ai/v1/embeddings` with `model`, `input`, and `task` fields
  - Supports task-specific adapters via `model::task` naming convention (e.g. `jina-embeddings-v3::retrieval.passage`)
  - Returns `EmbeddingError` with code `"401"` on auth failure, `"429"` on rate limit
  - Provides `forTest` seam for dependency injection (uses `Llm4sHttpClient`, not `java.net.http.HttpClient`)

- **Modified:** `modules/core/src/main/scala/org/llm4s/llmconnect/EmbeddingClient.scala`
  - Registers `"jina"` provider in `EmbeddingClient.from()` routing

- **Modified:** `modules/core/src/main/scala/org/llm4s/config/EmbeddingsConfigLoader.scala`
  - Adds `EmbeddingsJinaSection`, wires `jina` provider in both unified format (`EMBEDDING_MODEL=jina/jina-embeddings-v3`) and legacy fallback

- **Modified:** `modules/core/src/main/scala/org/llm4s/config/ConfigKeys.scala`
  - Adds `JINA_API_KEY`, `JINA_EMBEDDING_BASE_URL`, `JINA_EMBEDDING_MODEL` constants

- **Modified:** `modules/core/src/main/resources/reference.conf`
  - Adds `llm4s.embeddings.jina` section with env var mappings

## Test Coverage

21 unit tests in `JinaEmbeddingProviderSpec` using `MockHttpClient` and `FailingHttpClient` — no real API keys required for `sbt test`:
- Embed single text → correct float vector returned
- Embed batch → correct batch response in order
- Metadata verified (provider, model, task, count)
- Task parameter `text-matching` sent by default
- Task `retrieval.passage` and `retrieval.query` sent correctly when encoded in model name
- URL and auth headers verified
- HTTP 401 → `EmbeddingError(code = Some("401"))`
- HTTP 429 → `EmbeddingError(code = Some("429"))`
- HTTP 500 → `EmbeddingError(code = Some("500"))`
- Malformed JSON → `EmbeddingError`
- Missing `data` field → `EmbeddingError`
- Network failure (FailingHttpClient) → `EmbeddingError`
- InterruptedException → `EmbeddingError`
- Task extraction helpers tested
- Multimodal embed returns 501 Not Implemented

## Smoke Tests

`modules/it/src/test/scala/org/llm4s/llmconnect/smoke/JinaEmbeddingsSmokeSpec.scala`:
- Requires `JINA_API_KEY`; skips gracefully via `assume()` if absent
- Embeds 3 sentences with `jina-embeddings-v3`; verifies `isRight`, non-empty, all 1024-dimensional
- Tests `retrieval.passage` task via `::` encoding
- Tests invalid API key returns 401

Closes #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)