### PR TITLE
feat(provider): implement Fireworks AI provider (FireworksClient) — enterprise open-source inference

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/config/ConfigKeys.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/ConfigKeys.scala
@@ -162,6 +162,11 @@ object ConfigKeys {
   val MISTRAL_API_KEY  = "MISTRAL_API_KEY"
   val MISTRAL_BASE_URL = "MISTRAL_BASE_URL"
 
+  // Fireworks AI
+  /** Fireworks AI API key. Required when using Fireworks-hosted models. */
+  val FIREWORKS_API_KEY  = "FIREWORKS_API_KEY"
+  val FIREWORKS_BASE_URL = "FIREWORKS_BASE_URL"
+
   // Tool API Keys
   // ---- Tool API keys ------------------------------------------------------
 

--- a/modules/core/src/main/scala/org/llm4s/config/DefaultConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/DefaultConfig.scala
@@ -17,4 +17,5 @@ object DefaultConfig {
   val DEFAULT_LANGFUSE_RELEASE          = "1.0.0"
   val DEFAULT_LANGFUSE_VERSION          = "1.0.0"
   val DEFAULT_AZURE_V2025_01_01_PREVIEW = "V2025_01_01_PREVIEW"
+  val DEFAULT_FIREWORKS_BASE_URL        = "https://api.fireworks.ai/inference/v1"
 }

--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderLoader.scala
@@ -104,3 +104,7 @@ private[config] object NamedProviderLoader:
         requiredApiKey("llm4s.providers.<name>.apiKey").map: apiKey =>
           val baseUrl = section.baseUrl.map(_.asUrl).getOrElse(MistralConfig.DEFAULT_BASE_URL)
           MistralConfig.fromValues(section.model.asString, apiKey, baseUrl)
+      case ProviderKind.Fireworks =>
+        requiredApiKey("llm4s.providers.<name>.apiKey").map: apiKey =>
+          val baseUrl = section.baseUrl.map(_.asUrl).getOrElse(FireworksConfig.DEFAULT_BASE_URL)
+          FireworksConfig.fromValues(section.model.asString, apiKey, baseUrl)

--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderValidator.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderValidator.scala
@@ -133,6 +133,18 @@ private[llm4s] object NamedProviderValidators:
         requireApiKey = true,
       )
 
+  object Fireworks extends NamedProviderValidator:
+    def validate(
+      providerName: ProviderName,
+      section: RawNamedProviderSection
+    ): Result[NamedProviderConfig] =
+      validateNamedProviderConfig(
+        providerName = providerName,
+        providerKind = ProviderKind.Fireworks,
+        section = section,
+        requireApiKey = true,
+      )
+
   private def validateNamedProviderConfig(
     providerName: ProviderName,
     providerKind: ProviderKind,

--- a/modules/core/src/main/scala/org/llm4s/config/ProviderCapabilities.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/ProviderCapabilities.scala
@@ -42,3 +42,6 @@ private[llm4s] object ProviderCapabilities:
   object Mistral extends ProviderCapabilities:
     val validator: NamedProviderValidator                 = NamedProviderValidators.Mistral
     override val modelLister: Option[ProviderModelLister] = Some(ProviderModelListers.Mistral)
+
+  object Fireworks extends ProviderCapabilities:
+    val validator: NamedProviderValidator = NamedProviderValidators.Fireworks

--- a/modules/core/src/main/scala/org/llm4s/config/ProviderCapabilitiesRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/ProviderCapabilitiesRegistry.scala
@@ -22,4 +22,5 @@ private[llm4s] object ProviderCapabilitiesRegistry:
     ProviderKind.DeepSeek   -> ProviderCapabilities.DeepSeek,
     ProviderKind.Cohere     -> ProviderCapabilities.Cohere,
     ProviderKind.Mistral    -> ProviderCapabilities.Mistral,
+    ProviderKind.Fireworks  -> ProviderCapabilities.Fireworks,
   )

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -58,6 +58,8 @@ object LLMConnect {
         CohereClient(cfg, metrics, exchangeLogging)
       case cfg: MistralConfig =>
         MistralClient(cfg, metrics, exchangeLogging)
+      case cfg: FireworksConfig =>
+        FireworksClient(cfg, metrics, exchangeLogging)
     }
 
   def fromConfig(
@@ -167,7 +169,8 @@ object LLMConnect {
       case (ProviderKind.Gemini, cfg: GeminiConfig)       => GeminiClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.DeepSeek, cfg: DeepSeekConfig)   => DeepSeekClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Cohere, cfg: CohereConfig)       => CohereClient(cfg, metrics, exchangeLogging)
-      case (ProviderKind.Mistral, cfg: MistralConfig)     => MistralClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.Mistral, cfg: MistralConfig)       => MistralClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.Fireworks, cfg: FireworksConfig)   => FireworksClient(cfg, metrics, exchangeLogging)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/LLMConnect.scala
@@ -169,8 +169,8 @@ object LLMConnect {
       case (ProviderKind.Gemini, cfg: GeminiConfig)       => GeminiClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.DeepSeek, cfg: DeepSeekConfig)   => DeepSeekClient(cfg, metrics, exchangeLogging)
       case (ProviderKind.Cohere, cfg: CohereConfig)       => CohereClient(cfg, metrics, exchangeLogging)
-      case (ProviderKind.Mistral, cfg: MistralConfig)       => MistralClient(cfg, metrics, exchangeLogging)
-      case (ProviderKind.Fireworks, cfg: FireworksConfig)   => FireworksClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.Mistral, cfg: MistralConfig)     => MistralClient(cfg, metrics, exchangeLogging)
+      case (ProviderKind.Fireworks, cfg: FireworksConfig) => FireworksClient(cfg, metrics, exchangeLogging)
       case (prov, wrongCfg) =>
         val cfgType = wrongCfg.getClass.getSimpleName
         val msg     = s"Invalid config type $cfgType for provider $prov"

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -677,3 +677,80 @@ object MistralConfig:
       contextWindow = cw,
       reserveCompletion = rc
     )
+
+/**
+ * Configuration for the Fireworks AI inference platform.
+ *
+ * Fireworks AI is an enterprise OpenAI-compatible inference platform for open-source models
+ * (Llama, Mixtral, Qwen, FireFunction, etc.) with SLA guarantees and SOC 2 compliance.
+ * The API is fully OpenAI-compatible; this config routes to [[org.llm4s.llmconnect.provider.FireworksClient]].
+ *
+ * Prefer [[FireworksConfig.fromValues]] over the primary constructor; it resolves
+ * `contextWindow` and `reserveCompletion` automatically from the model name.
+ *
+ * @param apiKey        Fireworks AI API key; redacted in `toString`.
+ * @param model         Model identifier, e.g. `"accounts/fireworks/models/llama-v3p1-8b-instruct"`.
+ * @param baseUrl       API base URL; defaults to [[FireworksConfig.DEFAULT_BASE_URL]].
+ * @param contextWindow Model's total token capacity (prompt + completion combined).
+ * @param reserveCompletion Tokens held back from prompt history for the completion.
+ */
+case class FireworksConfig(
+  apiKey: String,
+  model: String,
+  baseUrl: String,
+  contextWindow: Int,
+  reserveCompletion: Int
+) extends ProviderConfig:
+  override val provider: ProviderKind = ProviderKind.Fireworks
+  override def toString: String =
+    s"FireworksConfig(apiKey=${Redaction.secret(apiKey)}, model=$model, baseUrl=$baseUrl, " +
+      s"contextWindow=$contextWindow, reserveCompletion=$reserveCompletion)"
+
+object FireworksConfig:
+  val DEFAULT_BASE_URL: String = "https://api.fireworks.ai/inference/v1"
+
+  private val DefaultContextWindow     = 131072
+  private val DefaultReserveCompletion = 4096
+
+  private def fireworksFallback(modelName: String): (Int, Int) =
+    modelName.toLowerCase match {
+      case name if name.contains("llama-v3p1-405b") => (131072, DefaultReserveCompletion)
+      case name if name.contains("llama-v3p1-70b")  => (131072, DefaultReserveCompletion)
+      case name if name.contains("llama-v3p1-8b")   => (131072, DefaultReserveCompletion)
+      case name if name.contains("mixtral-8x7b")    => (32768, DefaultReserveCompletion)
+      case name if name.contains("mixtral-8x22b")   => (65536, DefaultReserveCompletion)
+      case name if name.contains("firefunction")     => (32768, DefaultReserveCompletion)
+      case _                                         => (DefaultContextWindow, DefaultReserveCompletion)
+    }
+
+  /**
+   * Constructs a [[FireworksConfig]], resolving `contextWindow` and
+   * `reserveCompletion` from the model name automatically.
+   *
+   * @param modelName Model identifier, e.g. `"accounts/fireworks/models/llama-v3p1-8b-instruct"`.
+   * @param apiKey    Fireworks AI API key; must be non-empty.
+   * @param baseUrl   API base URL; must be non-empty. Defaults to
+   *                  [[FireworksConfig.DEFAULT_BASE_URL]] when loaded via
+   *                  [[org.llm4s.config.Llm4sConfig]].
+   */
+  def fromValues(
+    modelName: String,
+    apiKey: String,
+    baseUrl: String
+  )(using resolver: ContextWindowResolver): FireworksConfig =
+    require(apiKey.trim.nonEmpty, "Fireworks apiKey must be non-empty")
+    require(baseUrl.trim.nonEmpty, "Fireworks baseUrl must be non-empty")
+    val (cw, rc) = resolver.resolve(
+      lookupProviders = Seq("fireworks"),
+      modelName = modelName,
+      defaultContextWindow = DefaultContextWindow,
+      defaultReserve = DefaultReserveCompletion,
+      fallbackResolver = fireworksFallback
+    )
+    FireworksConfig(
+      apiKey = apiKey,
+      model = modelName,
+      baseUrl = baseUrl,
+      contextWindow = cw,
+      reserveCompletion = rc
+    )

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/config/ProviderConfig.scala
@@ -719,8 +719,8 @@ object FireworksConfig:
       case name if name.contains("llama-v3p1-8b")   => (131072, DefaultReserveCompletion)
       case name if name.contains("mixtral-8x7b")    => (32768, DefaultReserveCompletion)
       case name if name.contains("mixtral-8x22b")   => (65536, DefaultReserveCompletion)
-      case name if name.contains("firefunction")     => (32768, DefaultReserveCompletion)
-      case _                                         => (DefaultContextWindow, DefaultReserveCompletion)
+      case name if name.contains("firefunction")    => (32768, DefaultReserveCompletion)
+      case _                                        => (DefaultContextWindow, DefaultReserveCompletion)
     }
 
   /**

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/FireworksClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/FireworksClient.scala
@@ -1,0 +1,366 @@
+// scalafix:off DisableSyntax.NoKeywordTry, DisableSyntax.NoKeywordFinally
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.llmconnect.BaseLifecycleLLMClient
+import org.llm4s.llmconnect.ProviderExchangeLogging
+import org.llm4s.llmconnect.config.FireworksConfig
+import org.llm4s.llmconnect.model._
+import org.llm4s.llmconnect.provider.ProviderResultOps.*
+import org.llm4s.llmconnect.streaming.{ SSEParser, StreamingAccumulator, StreamingToolArgumentParser }
+import org.llm4s.metrics.MetricsCollector
+import org.llm4s.model.ModelRegistryService
+import org.llm4s.toolapi.ToolRegistry
+import org.llm4s.types.{ Result, TryOps }
+import org.llm4s.error.ThrowableOps._
+
+import java.net.URI
+import java.net.http.{ HttpClient, HttpRequest, HttpResponse }
+import java.time.Duration
+import java.time.Instant
+import java.io.{ BufferedReader, InputStreamReader }
+import java.nio.charset.StandardCharsets
+import scala.util.Try
+
+/**
+ * Fireworks AI LLM client using the OpenAI-compatible chat completions API.
+ *
+ * Fireworks AI is an enterprise inference platform for open-source models such as
+ * Llama, Mixtral, Qwen, and the Fireworks-optimised FireFunction series.
+ * It exposes a fully OpenAI-compatible REST API at `https://api.fireworks.ai/inference/v1`.
+ *
+ * Supported:
+ *  - Non-streaming and streaming chat completions via `/chat/completions`.
+ *  - Tool / function calling (FireFunction models are optimised for this).
+ *
+ * @param config         Fireworks configuration containing API key, model, and base URL.
+ * @param metrics        MetricsCollector for recording request metrics.
+ * @param exchangeLogging Controls whether raw HTTP exchanges are logged.
+ */
+class FireworksClient(
+  config: FireworksConfig,
+  protected val metrics: MetricsCollector = MetricsCollector.noop,
+  exchangeLogging: ProviderExchangeLogging = ProviderExchangeLogging.Disabled
+)(using val registryService: ModelRegistryService)
+    extends BaseLifecycleLLMClient {
+
+  private val httpClient = HttpClient.newHttpClient()
+
+  protected def clientDescription: String = s"Fireworks client for model ${config.model}"
+  protected def providerName: String      = "fireworks"
+  protected def modelName: String         = config.model
+
+  override def complete(
+    conversation: Conversation,
+    options: CompletionOptions
+  ): Result[Completion] = completeWithMetrics {
+    val requestBody = createRequestBody(conversation, options)
+    val requestText = requestBody.render()
+    val startedAt   = Instant.now()
+
+    val attempt = Try {
+      val request = HttpRequest
+        .newBuilder()
+        .uri(URI.create(s"${config.baseUrl}/chat/completions"))
+        .header("Content-Type", "application/json")
+        .header("Authorization", s"Bearer ${config.apiKey}")
+        .header("User-Agent", "llm4s/1.0")
+        .POST(HttpRequest.BodyPublishers.ofString(requestText))
+        .build()
+
+      httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+    }.toEither.left.map(_.toLLMError)
+
+    attempt.flatMap { response =>
+      if (response.statusCode() >= 200 && response.statusCode() < 300) {
+        val result = Try {
+          val responseJson = ujson.read(response.body())
+          parseCompletion(responseJson)
+        }.toEither.left.map(_.toLLMError)
+        recordExchange(startedAt, requestText, Some(response.body()), result)
+        result
+      } else {
+        val errorResult = HttpErrorMapper.mapHttpError(response.statusCode(), response.body(), providerName)
+        recordExchange(startedAt, requestText, Some(response.body()), errorResult)
+        errorResult
+      }
+    }
+  }
+
+  override def streamComplete(
+    conversation: Conversation,
+    options: CompletionOptions = CompletionOptions(),
+    onChunk: StreamedChunk => Unit
+  ): Result[Completion] = completeWithMetrics {
+    val startedAt   = Instant.now()
+    val requestBody = createRequestBody(conversation, options)
+    requestBody("stream") = true
+    val requestText = requestBody.render()
+
+    val accumulator = StreamingAccumulator.create()
+    val rawStream   = StringBuilder()
+
+    val requestResult = Try {
+      val request = HttpRequest
+        .newBuilder()
+        .uri(URI.create(s"${config.baseUrl}/chat/completions"))
+        .header("Content-Type", "application/json")
+        .header("Authorization", s"Bearer ${config.apiKey}")
+        .header("User-Agent", "llm4s/1.0")
+        .timeout(Duration.ofMinutes(5))
+        .POST(HttpRequest.BodyPublishers.ofString(requestText))
+        .build()
+      httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
+    }.toResult
+      .tapLeft(error =>
+        recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(error))
+      )
+
+    requestResult.flatMap { response =>
+      if (response.statusCode() != 200) {
+        val errorBody = new String(response.body().readAllBytes(), StandardCharsets.UTF_8)
+        Try(response.body().close())
+        val errorResult = HttpErrorMapper.mapHttpError(response.statusCode(), errorBody, providerName)
+        recordExchange(startedAt, requestText, Some(errorBody), errorResult)
+        errorResult
+      } else {
+        val sseParser = SSEParser.createStreamingParser()
+        val reader    = new BufferedReader(new InputStreamReader(response.body(), StandardCharsets.UTF_8))
+        val loopTry = Try {
+          Iterator.continually(reader.readLine()).takeWhile(_ != null).foreach { line =>
+            rawStream.append(line).append('\n')
+            sseParser.addChunk(line + "\n")
+            while (sseParser.hasEvents)
+              sseParser.nextEvent().foreach { event =>
+                event.data.foreach { data =>
+                  if (data != "[DONE]") {
+                    val json   = ujson.read(data)
+                    val chunks = parseStreamingChunks(json)
+                    chunks.foreach { c =>
+                      accumulator.addChunk(c)
+                      onChunk(c)
+                    }
+                  }
+                }
+              }
+          }
+        }
+        Try(reader.close())
+        Try(response.body().close())
+        loopTry.toResult
+          .flatMap(_ =>
+            accumulator.toCompletion.map { c =>
+              val cost       = c.usage.flatMap(u => CostEstimator.estimate(config.model, u))
+              val completion = c.copy(model = config.model, estimatedCost = cost)
+              recordExchange(startedAt, requestText, Some(rawStream.result()), Right(completion))
+              completion
+            }
+          )
+          .tapLeft(error =>
+            recordExchange(startedAt, requestText, Option.when(rawStream.nonEmpty)(rawStream.result()), Left(error))
+          )
+      }
+    }
+  }
+
+  private def parseStreamingChunks(json: ujson.Value): Seq[StreamedChunk] = {
+    val choices = json("choices").arr
+    if (choices.nonEmpty) {
+      val choice = choices(0)
+      val delta  = choice("delta")
+
+      val content      = delta.obj.get("content").flatMap(_.strOpt)
+      val finishReason = choice.obj.get("finish_reason").flatMap(_.strOpt).filter(_ != "null")
+
+      val toolCalls = delta.obj.get("tool_calls").map(_.arr).getOrElse(Seq.empty).collect {
+        case call if call.obj.contains("function") =>
+          val function = call("function")
+          val rawArgs  = function.obj.get("arguments").flatMap(_.strOpt).getOrElse("")
+          ToolCall(
+            id = call.obj.get("id").flatMap(_.strOpt).getOrElse(""),
+            name = function.obj.get("name").flatMap(_.strOpt).getOrElse(""),
+            arguments = StreamingToolArgumentParser.parse(rawArgs)
+          )
+      }
+
+      val chunkId = json.obj.get("id").flatMap(_.strOpt).getOrElse("")
+      if (toolCalls.isEmpty) {
+        Seq(
+          StreamedChunk(
+            id = chunkId,
+            content = content,
+            toolCall = None,
+            finishReason = finishReason,
+            thinkingDelta = None
+          )
+        )
+      } else {
+        val first = StreamedChunk(
+          id = chunkId,
+          content = content,
+          toolCall = Some(toolCalls.head),
+          finishReason = finishReason,
+          thinkingDelta = None
+        )
+        val rest = toolCalls.drop(1).map { tc =>
+          StreamedChunk(
+            id = chunkId,
+            content = None,
+            toolCall = Some(tc),
+            finishReason = None,
+            thinkingDelta = None
+          )
+        }
+        Seq(first) ++ rest
+      }
+    } else {
+      Seq.empty
+    }
+  }
+
+  private[provider] def createRequestBody(conversation: Conversation, options: CompletionOptions): ujson.Obj = {
+    val messages = conversation.messages.map {
+      case UserMessage(content) =>
+        ujson.Obj("role" -> "user", "content" -> content)
+      case SystemMessage(content) =>
+        ujson.Obj("role" -> "system", "content" -> content)
+      case AssistantMessage(content, toolCalls) =>
+        val base = ujson.Obj("role" -> "assistant")
+        content.filter(_.nonEmpty).foreach(c => base("content") = c)
+        if (toolCalls.nonEmpty) {
+          base("tool_calls") = ujson.Arr.from(toolCalls.map { tc =>
+            ujson.Obj(
+              "id"   -> tc.id,
+              "type" -> "function",
+              "function" -> ujson.Obj(
+                "name"      -> tc.name,
+                "arguments" -> tc.arguments.render()
+              )
+            )
+          })
+        }
+        base
+      case ToolMessage(content, toolCallId) =>
+        ujson.Obj(
+          "role"         -> "tool",
+          "tool_call_id" -> toolCallId,
+          "content"      -> content
+        )
+    }
+
+    val base = ujson.Obj(
+      "model"       -> config.model,
+      "messages"    -> ujson.Arr.from(messages),
+      "temperature" -> options.temperature,
+      "top_p"       -> options.topP
+    )
+
+    options.maxTokens.foreach(mt => base("max_tokens") = mt)
+    if (options.presencePenalty != 0) base("presence_penalty") = options.presencePenalty
+    if (options.frequencyPenalty != 0) base("frequency_penalty") = options.frequencyPenalty
+
+    if (options.tools.nonEmpty) {
+      val toolRegistry = new ToolRegistry(options.tools)
+      base("tools") = toolRegistry.getOpenAITools()
+    }
+
+    options.responseFormat.foreach { fmt =>
+      ResponseFormatMapper.toOpenAIResponseFormat(fmt).foreach(rf => base("response_format") = rf)
+    }
+
+    base
+  }
+
+  private def parseCompletion(json: ujson.Value): Completion = {
+    val choice  = json("choices")(0)
+    val message = choice("message")
+
+    val toolCalls = message.obj
+      .get("tool_calls")
+      .map(parseToolCalls)
+      .getOrElse(Seq.empty)
+
+    val contentStr = message.obj.get("content").flatMap(_.strOpt).getOrElse("")
+
+    val usage = json.obj.get("usage").flatMap { u =>
+      u.objOpt.map { usageObj =>
+        TokenUsage(
+          promptTokens = usageObj("prompt_tokens").num.toInt,
+          completionTokens = usageObj("completion_tokens").num.toInt,
+          totalTokens = usageObj("total_tokens").num.toInt
+        )
+      }
+    }
+
+    val modelId = json.obj.get("model").flatMap(_.strOpt).getOrElse(config.model)
+    val cost    = usage.flatMap(u => CostEstimator.estimate(config.model, u))
+
+    Completion(
+      id = json.obj.get("id").flatMap(_.strOpt).getOrElse(""),
+      created = json.obj.get("created").flatMap(_.numOpt).map(_.toLong).getOrElse(System.currentTimeMillis() / 1000),
+      content = contentStr,
+      model = modelId,
+      message = AssistantMessage(
+        contentOpt = Some(contentStr),
+        toolCalls = toolCalls.toList
+      ),
+      toolCalls = toolCalls.toList,
+      usage = usage,
+      thinking = None,
+      estimatedCost = cost
+    )
+  }
+
+  private def parseToolCalls(toolCallsJson: ujson.Value): Seq[ToolCall] =
+    toolCallsJson.arr.map { call =>
+      val function = call("function")
+      val argsStr  = function.obj.get("arguments").flatMap(_.strOpt).getOrElse("{}")
+      ToolCall(
+        id = call.obj.get("id").flatMap(_.strOpt).getOrElse(""),
+        name = function.obj.get("name").flatMap(_.strOpt).getOrElse(""),
+        arguments = Try(ujson.read(argsStr)).getOrElse(ujson.Obj())
+      )
+    }.toSeq
+
+  private def recordExchange(
+    startedAt: Instant,
+    requestBody: String,
+    responseBody: Option[String],
+    result: Result[Completion]
+  ): Unit =
+    ProviderExchangeRecorder.record(
+      exchangeLogging = exchangeLogging,
+      provider = providerName,
+      model = Some(config.model),
+      startedAt = startedAt,
+      requestBody = requestBody,
+      responseBody = responseBody,
+      result = result
+    )
+
+  override def getContextWindow(): Int = config.contextWindow
+
+  override def getReserveCompletion(): Int = config.reserveCompletion
+
+  override protected def releaseResources(): Unit =
+    (httpClient: Any) match {
+      case c: AutoCloseable => c.close()
+      case _                => ()
+    }
+}
+
+object FireworksClient {
+  import org.llm4s.types.TryOps
+
+  def apply(
+    config: FireworksConfig,
+    metrics: MetricsCollector,
+    exchangeLogging: ProviderExchangeLogging
+  )(using ModelRegistryService): Result[FireworksClient] =
+    Try(new FireworksClient(config, metrics, exchangeLogging)).toResult
+
+  def apply(config: FireworksConfig, metrics: MetricsCollector)(using ModelRegistryService): Result[FireworksClient] =
+    Try(new FireworksClient(config, metrics)).toResult
+
+  def apply(config: FireworksConfig)(using ModelRegistryService): Result[FireworksClient] =
+    Try(new FireworksClient(config, MetricsCollector.noop)).toResult
+}

--- a/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
+++ b/modules/core/src/main/scala/org/llm4s/types/ProviderModelTypes.scala
@@ -35,6 +35,7 @@ object ProviderModelTypes:
     case DeepSeek
     case Cohere
     case Mistral
+    case Fireworks
 
   object ProviderKind:
     val all: Seq[ProviderKind] = Seq(
@@ -47,7 +48,8 @@ object ProviderModelTypes:
       ProviderKind.Gemini,
       ProviderKind.DeepSeek,
       ProviderKind.Cohere,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.Fireworks
     )
 
     def fromString(value: String): Option[ProviderKind] =
@@ -63,6 +65,7 @@ object ProviderModelTypes:
         case "deepseek"   => Some(ProviderKind.DeepSeek)
         case "cohere"     => Some(ProviderKind.Cohere)
         case "mistral"    => Some(ProviderKind.Mistral)
+        case "fireworks"  => Some(ProviderKind.Fireworks)
         case _            => None
 
     def fromName(value: String): Option[ProviderKind] =
@@ -81,3 +84,4 @@ object ProviderModelTypes:
         case ProviderKind.DeepSeek   => "deepseek"
         case ProviderKind.Cohere     => "cohere"
         case ProviderKind.Mistral    => "mistral"
+        case ProviderKind.Fireworks  => "fireworks"

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/LLMConnectProviderTypeSafetyTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/LLMConnectProviderTypeSafetyTest.scala
@@ -202,6 +202,35 @@ class LLMConnectProviderTypeSafetyTest extends AnyFunSuite with Matchers {
     res.isLeft shouldBe true
   }
 
+  test("Fireworks provider with FireworksConfig returns FireworksClient") {
+    val cfg: ProviderConfig = FireworksConfig(
+      apiKey = "key",
+      model = "accounts/fireworks/models/llama-v3p1-8b-instruct",
+      baseUrl = "https://example.invalid/v1",
+      contextWindow = 131072,
+      reserveCompletion = 4096
+    )
+    val res = LLMConnect.getClient(ProviderKind.Fireworks, cfg)
+    res match {
+      case Right(client) => client.getClass.getSimpleName shouldBe "FireworksClient"
+      case Left(err)     => fail(s"Expected Right, got Left($err)")
+    }
+  }
+
+  test("Fireworks provider with non-FireworksConfig should return Left") {
+    val wrongCfg: ProviderConfig = OpenAIConfig(
+      apiKey = "key",
+      model = "gpt-4o",
+      organization = None,
+      baseUrl = "https://api.openai.com/v1",
+      contextWindow = 128000,
+      reserveCompletion = 4096
+    )
+
+    val res = LLMConnect.getClient(ProviderKind.Fireworks, wrongCfg)
+    res.isLeft shouldBe true
+  }
+
   test("Zai provider with non-ZaiConfig should throw IllegalArgumentException") {
     val wrongCfg: ProviderConfig = OpenAIConfig(
       apiKey = "key",

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/FireworksClientClosedStateTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/FireworksClientClosedStateTest.scala
@@ -1,0 +1,95 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.ConfigurationError
+import org.llm4s.llmconnect.config.FireworksConfig
+import org.llm4s.llmconnect.model.{ CompletionOptions, Conversation, UserMessage }
+import org.llm4s.model.ModelRegistryService
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Tests for FireworksClient closed state handling.
+ *
+ * Verifies that operations fail with ConfigurationError after close() and that
+ * close() is idempotent.
+ */
+class FireworksClientClosedStateTest extends AnyFlatSpec with Matchers {
+
+  private given ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+
+  private def createTestConfig: FireworksConfig = FireworksConfig(
+    apiKey = "fw-test-key-closed-state",
+    model = "accounts/fireworks/models/llama-v3p1-8b-instruct",
+    baseUrl = "https://example.invalid",
+    contextWindow = 131072,
+    reserveCompletion = 4096
+  )
+
+  private def createTestConversation: Conversation =
+    Conversation(Seq(UserMessage("Hello")))
+
+  "FireworksClient" should "return ConfigurationError when complete() is called after close()" in {
+    val client = new FireworksClient(createTestConfig)
+
+    client.close()
+
+    val result = client.complete(createTestConversation, CompletionOptions())
+
+    result.fold(
+      err => {
+        err shouldBe a[ConfigurationError]
+        err.message should include("already closed")
+      },
+      _ => fail("Expected Left(ConfigurationError)")
+    )
+  }
+
+  it should "return ConfigurationError when streamComplete() is called after close()" in {
+    val client         = new FireworksClient(createTestConfig)
+    var chunksReceived = 0
+
+    client.close()
+
+    val result = client.streamComplete(
+      createTestConversation,
+      CompletionOptions(),
+      _ => chunksReceived += 1
+    )
+
+    result.fold(
+      err => err shouldBe a[ConfigurationError],
+      _ => fail("Expected Left(ConfigurationError)")
+    )
+    chunksReceived shouldBe 0
+  }
+
+  it should "allow close() to be called multiple times (idempotent)" in {
+    val client = new FireworksClient(createTestConfig)
+
+    noException should be thrownBy {
+      client.close()
+      client.close()
+      client.close()
+    }
+
+    val result = client.complete(createTestConversation, CompletionOptions())
+    result.fold(
+      err => err shouldBe a[ConfigurationError],
+      _ => fail("Expected Left(ConfigurationError) after close")
+    )
+  }
+
+  it should "include model name in the closed error message" in {
+    val config = createTestConfig.copy(model = "accounts/fireworks/models/firefunction-v2")
+    val client = new FireworksClient(config)
+
+    client.close()
+
+    val result = client.complete(createTestConversation, CompletionOptions())
+
+    result.fold(
+      err => err.message should include("accounts/fireworks/models/firefunction-v2"),
+      _ => fail("Expected Left(ConfigurationError)")
+    )
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/FireworksClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/FireworksClientSpec.scala
@@ -245,25 +245,23 @@ class FireworksClientSpec extends AnyFlatSpec with Matchers {
   // ==========================================================================
 
   it should "map HTTP 401 to AuthenticationError" in
-    withServer("/chat/completions") { exchange =>
-      sendJsonResponse(exchange, 401, """{"error":"Unauthorized"}""")
-    } { baseUrl =>
-      val client = new FireworksClient(localConfig(baseUrl))
-      val result = client.complete(conversation, CompletionOptions())
+    withServer("/chat/completions")(exchange => sendJsonResponse(exchange, 401, """{"error":"Unauthorized"}""")) {
+      baseUrl =>
+        val client = new FireworksClient(localConfig(baseUrl))
+        val result = client.complete(conversation, CompletionOptions())
 
-      result.isLeft shouldBe true
-      result.swap.toOption.get shouldBe an[AuthenticationError]
+        result.isLeft shouldBe true
+        result.swap.toOption.get shouldBe an[AuthenticationError]
     }
 
   it should "map HTTP 403 to AuthenticationError" in
-    withServer("/chat/completions") { exchange =>
-      sendJsonResponse(exchange, 403, """{"error":"Forbidden"}""")
-    } { baseUrl =>
-      val client = new FireworksClient(localConfig(baseUrl))
-      val result = client.complete(conversation, CompletionOptions())
+    withServer("/chat/completions")(exchange => sendJsonResponse(exchange, 403, """{"error":"Forbidden"}""")) {
+      baseUrl =>
+        val client = new FireworksClient(localConfig(baseUrl))
+        val result = client.complete(conversation, CompletionOptions())
 
-      result.isLeft shouldBe true
-      result.swap.toOption.get shouldBe an[AuthenticationError]
+        result.isLeft shouldBe true
+        result.swap.toOption.get shouldBe an[AuthenticationError]
     }
 
   it should "map HTTP 429 to RateLimitError" in
@@ -289,9 +287,7 @@ class FireworksClientSpec extends AnyFlatSpec with Matchers {
     }
 
   it should "map HTTP 502 to ServiceError" in
-    withServer("/chat/completions") { exchange =>
-      sendJsonResponse(exchange, 502, "Bad Gateway")
-    } { baseUrl =>
+    withServer("/chat/completions")(exchange => sendJsonResponse(exchange, 502, "Bad Gateway")) { baseUrl =>
       val client = new FireworksClient(localConfig(baseUrl))
       val result = client.complete(conversation, CompletionOptions())
 
@@ -343,9 +339,7 @@ class FireworksClientSpec extends AnyFlatSpec with Matchers {
     }
 
   it should "handle [DONE] termination signal without error" in
-    withServer("/chat/completions") { exchange =>
-      sendSseResponse(exchange, "data: [DONE]\n\n")
-    } { baseUrl =>
+    withServer("/chat/completions")(exchange => sendSseResponse(exchange, "data: [DONE]\n\n")) { baseUrl =>
       val client     = new FireworksClient(localConfig(baseUrl))
       var chunkCount = 0
       val result     = client.streamComplete(conversation, CompletionOptions(), _ => chunkCount += 1)
@@ -359,14 +353,13 @@ class FireworksClientSpec extends AnyFlatSpec with Matchers {
   // ==========================================================================
 
   it should "map HTTP 401 to AuthenticationError" in
-    withServer("/chat/completions") { exchange =>
-      sendJsonResponse(exchange, 401, """{"error":"Invalid API key"}""")
-    } { baseUrl =>
-      val client = new FireworksClient(localConfig(baseUrl))
-      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+    withServer("/chat/completions")(exchange => sendJsonResponse(exchange, 401, """{"error":"Invalid API key"}""")) {
+      baseUrl =>
+        val client = new FireworksClient(localConfig(baseUrl))
+        val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
 
-      result.isLeft shouldBe true
-      result.swap.toOption.get shouldBe an[AuthenticationError]
+        result.isLeft shouldBe true
+        result.swap.toOption.get shouldBe an[AuthenticationError]
     }
 
   it should "map HTTP 429 to RateLimitError during streaming" in

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/FireworksClientSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/FireworksClientSpec.scala
@@ -1,0 +1,463 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.error.{ AuthenticationError, RateLimitError, ServiceError }
+import org.llm4s.llmconnect.{ ProviderExchange, ProviderExchangeLogging, ProviderExchangeSink }
+import org.llm4s.llmconnect.config.FireworksConfig
+import org.llm4s.llmconnect.model._
+import org.llm4s.testutil.LocalProviderTestServer._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues._
+import org.llm4s.model.ModelRegistryService
+
+import scala.collection.mutable.ListBuffer
+
+/**
+ * HTTP-level unit tests for FireworksClient.
+ *
+ * Spins up a local HTTP server to verify request/response handling without
+ * requiring a real Fireworks AI API key. No external services needed.
+ */
+class FireworksClientSpec extends AnyFlatSpec with Matchers {
+
+  private given ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+
+  private val defaultModel = "accounts/fireworks/models/llama-v3p1-8b-instruct"
+
+  private def localConfig(baseUrl: String, model: String = defaultModel): FireworksConfig =
+    FireworksConfig(
+      apiKey = "fw-test-key",
+      model = model,
+      baseUrl = baseUrl,
+      contextWindow = 131072,
+      reserveCompletion = 4096
+    )
+
+  private def conversation: Conversation = Conversation(Seq(UserMessage("hello")))
+
+  // ==========================================================================
+  // complete() — success
+  // ==========================================================================
+
+  "FireworksClient.complete" should "parse a successful OpenAI-compatible response" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 200, openAICompletion("Hello from Fireworks!", defaultModel))
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val result = client.complete(conversation, CompletionOptions())
+
+      result.isRight shouldBe true
+      val completion = result.toOption.get
+      completion.content shouldBe "Hello from Fireworks!"
+      completion.model shouldBe defaultModel
+      completion.id shouldBe "chatcmpl-test"
+      completion.usage shouldBe defined
+      completion.usage.get.promptTokens shouldBe 10
+      completion.usage.get.completionTokens shouldBe 5
+      completion.usage.get.totalTokens shouldBe 15
+    }
+
+  it should "return the correct context window and reserve completion" in {
+    val cfg = FireworksConfig(
+      apiKey = "key",
+      model = defaultModel,
+      baseUrl = "https://api.fireworks.ai/inference/v1",
+      contextWindow = 131072,
+      reserveCompletion = 4096
+    )
+    val client = new FireworksClient(cfg)
+    client.getContextWindow() shouldBe 131072
+    client.getReserveCompletion() shouldBe 4096
+  }
+
+  it should "record a provider exchange when logging is enabled" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 200, openAICompletion("Logged response", defaultModel))
+    } { baseUrl =>
+      val recorded = ListBuffer.empty[ProviderExchange]
+      val sink = new ProviderExchangeSink:
+        override def record(exchange: ProviderExchange): Unit =
+          recorded += exchange
+
+      val client = new FireworksClient(
+        localConfig(baseUrl),
+        exchangeLogging = ProviderExchangeLogging.enabled(sink)
+      )
+      val result = client.complete(conversation, CompletionOptions())
+
+      result.isRight shouldBe true
+      recorded should have size 1
+      val exchange = recorded.head
+      exchange.provider shouldBe "fireworks"
+      exchange.model shouldBe Some(defaultModel)
+      exchange.requestBody should include("\"messages\"")
+      exchange.requestBody should include("hello")
+      exchange.responseBody shouldBe defined
+      exchange.responseBody.get should include("chatcmpl-test")
+      exchange.responseBody.get should include("Logged response")
+      exchange.errorMessage shouldBe empty
+      exchange.durationMs should be >= 0L
+    }
+
+  it should "handle response with missing token usage gracefully" in
+    withServer("/chat/completions") { exchange =>
+      val body =
+        """{
+          |  "id": "chatcmpl-no-usage",
+          |  "object": "chat.completion",
+          |  "created": 1700000000,
+          |  "model": "accounts/fireworks/models/llama-v3p1-8b-instruct",
+          |  "choices": [{
+          |    "index": 0,
+          |    "message": { "role": "assistant", "content": "No usage" },
+          |    "finish_reason": "stop"
+          |  }]
+          |}""".stripMargin
+      sendJsonResponse(exchange, 200, body)
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val result = client.complete(conversation, CompletionOptions())
+
+      result.isRight shouldBe true
+      result.toOption.get.usage shouldBe None
+    }
+
+  it should "handle multi-turn conversation with system and assistant messages" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 200, openAICompletion("Multi-turn response", defaultModel))
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val multiConv = Conversation(
+        Seq(
+          SystemMessage("You are a helpful assistant."),
+          UserMessage("Hello"),
+          AssistantMessage(Some("Hi! How can I help?"), Seq.empty),
+          UserMessage("Tell me about Scala")
+        )
+      )
+      val result = client.complete(multiConv, CompletionOptions())
+
+      result.isRight shouldBe true
+      result.toOption.get.content shouldBe "Multi-turn response"
+    }
+
+  it should "handle response with empty assistant message content" in
+    withServer("/chat/completions") { exchange =>
+      val body =
+        """{
+          |  "id": "chatcmpl-empty",
+          |  "object": "chat.completion",
+          |  "created": 1700000000,
+          |  "model": "accounts/fireworks/models/llama-v3p1-8b-instruct",
+          |  "choices": [{
+          |    "index": 0,
+          |    "message": { "role": "assistant", "content": "" },
+          |    "finish_reason": "stop"
+          |  }],
+          |  "usage": { "prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5 }
+          |}""".stripMargin
+      sendJsonResponse(exchange, 200, body)
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val result = client.complete(conversation, CompletionOptions())
+
+      result.isRight shouldBe true
+      result.toOption.get.content shouldBe ""
+    }
+
+  it should "include maxTokens in the request body when specified" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 200, openAICompletion("Short", defaultModel))
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val result = client.complete(conversation, CompletionOptions(maxTokens = Some(100)))
+
+      result.isRight shouldBe true
+    }
+
+  it should "handle tool calls in the response" in
+    withServer("/chat/completions") { exchange =>
+      val body =
+        """{
+          |  "id": "chatcmpl-tools",
+          |  "object": "chat.completion",
+          |  "created": 1700000000,
+          |  "model": "accounts/fireworks/models/firefunction-v2",
+          |  "choices": [{
+          |    "index": 0,
+          |    "message": {
+          |      "role": "assistant",
+          |      "content": null,
+          |      "tool_calls": [{
+          |        "id": "call-1",
+          |        "type": "function",
+          |        "function": {
+          |          "name": "get_weather",
+          |          "arguments": "{\"city\": \"London\"}"
+          |        }
+          |      }]
+          |    },
+          |    "finish_reason": "tool_calls"
+          |  }],
+          |  "usage": { "prompt_tokens": 20, "completion_tokens": 15, "total_tokens": 35 }
+          |}""".stripMargin
+      sendJsonResponse(exchange, 200, body)
+    } { baseUrl =>
+      val ffModel = "accounts/fireworks/models/firefunction-v2"
+      val client  = new FireworksClient(localConfig(baseUrl, ffModel))
+      val result  = client.complete(conversation, CompletionOptions())
+
+      result.isRight shouldBe true
+      val completion = result.toOption.get
+      completion.toolCalls should have size 1
+      completion.toolCalls.head.name shouldBe "get_weather"
+      completion.toolCalls.head.id shouldBe "call-1"
+    }
+
+  it should "handle assistant message with tool calls in conversation" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 200, openAICompletion("Done", defaultModel))
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val convWithToolCall = Conversation(
+        Seq(
+          UserMessage("What is the weather in London?"),
+          AssistantMessage(
+            None,
+            Seq(
+              ToolCall(
+                id = "call-1",
+                name = "get_weather",
+                arguments = ujson.Obj("city" -> "London")
+              )
+            )
+          ),
+          ToolMessage("{\"temp\": 15, \"condition\": \"cloudy\"}", "call-1"),
+          UserMessage("Thank you")
+        )
+      )
+      val result = client.complete(convWithToolCall, CompletionOptions())
+      result.isRight shouldBe true
+    }
+
+  // ==========================================================================
+  // complete() — error handling
+  // ==========================================================================
+
+  it should "map HTTP 401 to AuthenticationError" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 401, """{"error":"Unauthorized"}""")
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val result = client.complete(conversation, CompletionOptions())
+
+      result.isLeft shouldBe true
+      result.swap.toOption.get shouldBe an[AuthenticationError]
+    }
+
+  it should "map HTTP 403 to AuthenticationError" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 403, """{"error":"Forbidden"}""")
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val result = client.complete(conversation, CompletionOptions())
+
+      result.isLeft shouldBe true
+      result.swap.toOption.get shouldBe an[AuthenticationError]
+    }
+
+  it should "map HTTP 429 to RateLimitError" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 429, """{"error":"Rate limit exceeded"}""")
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val result = client.complete(conversation, CompletionOptions())
+
+      result.isLeft shouldBe true
+      result.swap.toOption.get shouldBe a[RateLimitError]
+    }
+
+  it should "map HTTP 500 to ServiceError" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 500, """{"error":"Internal server error"}""")
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val result = client.complete(conversation, CompletionOptions())
+
+      result.isLeft shouldBe true
+      result.swap.toOption.get shouldBe a[ServiceError]
+    }
+
+  it should "map HTTP 502 to ServiceError" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 502, "Bad Gateway")
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val result = client.complete(conversation, CompletionOptions())
+
+      result.isLeft shouldBe true
+      result.swap.toOption.get shouldBe a[ServiceError]
+    }
+
+  // ==========================================================================
+  // streamComplete() — success
+  // ==========================================================================
+
+  "FireworksClient.streamComplete" should "parse SSE events and accumulate content" in
+    withServer("/chat/completions") { exchange =>
+      sendSseResponse(exchange, openAISseBody(Seq("Hello", " world"), defaultModel))
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val chunks = ListBuffer.empty[StreamedChunk]
+      val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+      result.isRight shouldBe true
+      val completion = result.toOption.get
+      completion.content shouldBe "Hello world"
+      chunks should not be empty
+    }
+
+  it should "record provider exchanges for streaming when logging is enabled" in
+    withServer("/chat/completions") { exchange =>
+      sendSseResponse(exchange, openAISseBody(Seq("Hello", " world"), defaultModel))
+    } { baseUrl =>
+      val recorded = ListBuffer.empty[ProviderExchange]
+      val sink = new ProviderExchangeSink:
+        override def record(exchange: ProviderExchange): Unit =
+          recorded += exchange
+
+      val client = new FireworksClient(
+        localConfig(baseUrl),
+        exchangeLogging = ProviderExchangeLogging.enabled(sink)
+      )
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isRight shouldBe true
+      recorded should have size 1
+      recorded.head.provider shouldBe "fireworks"
+      recorded.head.requestBody should include("\"stream\":true")
+      recorded.head.responseBody.value should include("data:")
+      recorded.head.responseBody.value should include("Hello")
+      recorded.head.responseBody.value should include("[DONE]")
+      recorded.head.errorMessage shouldBe empty
+    }
+
+  it should "handle [DONE] termination signal without error" in
+    withServer("/chat/completions") { exchange =>
+      sendSseResponse(exchange, "data: [DONE]\n\n")
+    } { baseUrl =>
+      val client     = new FireworksClient(localConfig(baseUrl))
+      var chunkCount = 0
+      val result     = client.streamComplete(conversation, CompletionOptions(), _ => chunkCount += 1)
+
+      result.isRight shouldBe true
+      chunkCount shouldBe 0
+    }
+
+  // ==========================================================================
+  // streamComplete() — error handling
+  // ==========================================================================
+
+  it should "map HTTP 401 to AuthenticationError" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 401, """{"error":"Invalid API key"}""")
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isLeft shouldBe true
+      result.swap.toOption.get shouldBe an[AuthenticationError]
+    }
+
+  it should "map HTTP 429 to RateLimitError during streaming" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 429, """{"error":"Rate limit exceeded"}""")
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isLeft shouldBe true
+      result.swap.toOption.get shouldBe a[RateLimitError]
+    }
+
+  it should "map HTTP 500 to ServiceError during streaming" in
+    withServer("/chat/completions") { exchange =>
+      sendJsonResponse(exchange, 500, """{"error":"Internal server error"}""")
+    } { baseUrl =>
+      val client = new FireworksClient(localConfig(baseUrl))
+      val result = client.streamComplete(conversation, CompletionOptions(), _ => ())
+
+      result.isLeft shouldBe true
+      result.swap.toOption.get shouldBe a[ServiceError]
+    }
+
+  // ==========================================================================
+  // createRequestBody — serialization tests (package-private seam)
+  // ==========================================================================
+
+  "FireworksClient.createRequestBody" should "include model and messages" in {
+    val cfg    = FireworksConfig("key", defaultModel, "https://example.invalid", 8192, 4096)
+    val client = new FireworksClient(cfg)
+    val body   = client.createRequestBody(conversation, CompletionOptions())
+
+    body("model").str shouldBe defaultModel
+    body("messages").arr should have size 1
+    body("messages").arr(0)("role").str shouldBe "user"
+    body("messages").arr(0)("content").str shouldBe "hello"
+  }
+
+  it should "include max_tokens when specified" in {
+    val cfg    = FireworksConfig("key", defaultModel, "https://example.invalid", 8192, 4096)
+    val client = new FireworksClient(cfg)
+    val body   = client.createRequestBody(conversation, CompletionOptions(maxTokens = Some(256)))
+
+    body("max_tokens").num.toInt shouldBe 256
+  }
+
+  it should "not include max_tokens when not specified" in {
+    val cfg    = FireworksConfig("key", defaultModel, "https://example.invalid", 8192, 4096)
+    val client = new FireworksClient(cfg)
+    val body   = client.createRequestBody(conversation, CompletionOptions())
+
+    body.obj.contains("max_tokens") shouldBe false
+  }
+
+  it should "serialize system messages correctly" in {
+    val cfg    = FireworksConfig("key", defaultModel, "https://example.invalid", 8192, 4096)
+    val client = new FireworksClient(cfg)
+    val conv = Conversation(
+      Seq(
+        SystemMessage("You are helpful"),
+        UserMessage("hi")
+      )
+    )
+    val body = client.createRequestBody(conv, CompletionOptions())
+
+    body("messages").arr(0)("role").str shouldBe "system"
+    body("messages").arr(0)("content").str shouldBe "You are helpful"
+    body("messages").arr(1)("role").str shouldBe "user"
+  }
+
+  it should "serialize tool messages correctly" in {
+    val cfg    = FireworksConfig("key", defaultModel, "https://example.invalid", 8192, 4096)
+    val client = new FireworksClient(cfg)
+    val conv = Conversation(
+      Seq(
+        UserMessage("hi"),
+        AssistantMessage(
+          None,
+          Seq(ToolCall("call-1", "get_data", ujson.Obj("q" -> "test")))
+        ),
+        ToolMessage("{\"result\": 42}", "call-1")
+      )
+    )
+    val body = client.createRequestBody(conv, CompletionOptions())
+
+    val msgs = body("messages").arr
+    msgs(1)("role").str shouldBe "assistant"
+    msgs(1).obj.contains("tool_calls") shouldBe true
+    msgs(2)("role").str shouldBe "tool"
+    msgs(2)("tool_call_id").str shouldBe "call-1"
+    msgs(2)("content").str shouldBe "{\"result\": 42}"
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/FireworksConfigSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/FireworksConfigSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.matchers.should.Matchers
  */
 class FireworksConfigSpec extends AnyFlatSpec with Matchers {
 
-  private given mrs: ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+  private given mrs: ModelRegistryService       = org.llm4s.model.ModelRegistryTestSupport.defaultService()
   private given resolver: ContextWindowResolver = ContextWindowResolver(mrs)
 
   private val defaultModel = "accounts/fireworks/models/llama-v3p1-8b-instruct"
@@ -52,7 +52,7 @@ class FireworksConfigSpec extends AnyFlatSpec with Matchers {
       reserveCompletion = 4096
     )
     val str = cfg.toString
-    str should not include "fw-super-secret-key"
+    (str should not).include("fw-super-secret-key")
     str should include("FireworksConfig")
     str should include(defaultModel)
   }

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/FireworksConfigSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/FireworksConfigSpec.scala
@@ -1,0 +1,146 @@
+package org.llm4s.llmconnect.provider
+
+import org.llm4s.llmconnect.config.{ ContextWindowResolver, FireworksConfig }
+import org.llm4s.model.ModelRegistryService
+import org.llm4s.types.ProviderModelTypes.ProviderKind
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Unit tests for FireworksConfig case class and companion object.
+ */
+class FireworksConfigSpec extends AnyFlatSpec with Matchers {
+
+  private given mrs: ModelRegistryService = org.llm4s.model.ModelRegistryTestSupport.defaultService()
+  private given resolver: ContextWindowResolver = ContextWindowResolver(mrs)
+
+  private val defaultModel = "accounts/fireworks/models/llama-v3p1-8b-instruct"
+
+  // ==========================================================================
+  // DEFAULT_BASE_URL
+  // ==========================================================================
+
+  "FireworksConfig.DEFAULT_BASE_URL" should "be the official Fireworks AI inference endpoint" in {
+    FireworksConfig.DEFAULT_BASE_URL shouldBe "https://api.fireworks.ai/inference/v1"
+  }
+
+  // ==========================================================================
+  // provider field
+  // ==========================================================================
+
+  "FireworksConfig" should "have provider kind Fireworks" in {
+    val cfg = FireworksConfig(
+      apiKey = "fw-test",
+      model = defaultModel,
+      baseUrl = FireworksConfig.DEFAULT_BASE_URL,
+      contextWindow = 131072,
+      reserveCompletion = 4096
+    )
+    cfg.provider shouldBe ProviderKind.Fireworks
+  }
+
+  // ==========================================================================
+  // toString — API key redaction
+  // ==========================================================================
+
+  it should "redact the apiKey in toString" in {
+    val cfg = FireworksConfig(
+      apiKey = "fw-super-secret-key",
+      model = defaultModel,
+      baseUrl = FireworksConfig.DEFAULT_BASE_URL,
+      contextWindow = 131072,
+      reserveCompletion = 4096
+    )
+    val str = cfg.toString
+    str should not include "fw-super-secret-key"
+    str should include("FireworksConfig")
+    str should include(defaultModel)
+  }
+
+  // ==========================================================================
+  // fromValues — normal construction
+  // ==========================================================================
+
+  "FireworksConfig.fromValues" should "create config with sensible defaults for llama model" in {
+    val cfg = FireworksConfig.fromValues(
+      modelName = "accounts/fireworks/models/llama-v3p1-8b-instruct",
+      apiKey = "fw-key",
+      baseUrl = FireworksConfig.DEFAULT_BASE_URL
+    )
+    cfg.apiKey shouldBe "fw-key"
+    cfg.model shouldBe "accounts/fireworks/models/llama-v3p1-8b-instruct"
+    cfg.baseUrl shouldBe FireworksConfig.DEFAULT_BASE_URL
+    cfg.contextWindow should be > 0
+    cfg.reserveCompletion should be > 0
+  }
+
+  it should "create config for mixtral model" in {
+    val cfg = FireworksConfig.fromValues(
+      modelName = "accounts/fireworks/models/mixtral-8x7b-instruct",
+      apiKey = "fw-key",
+      baseUrl = FireworksConfig.DEFAULT_BASE_URL
+    )
+    cfg.model shouldBe "accounts/fireworks/models/mixtral-8x7b-instruct"
+    cfg.contextWindow should be > 0
+  }
+
+  it should "create config for firefunction-v2 model" in {
+    val cfg = FireworksConfig.fromValues(
+      modelName = "accounts/fireworks/models/firefunction-v2",
+      apiKey = "fw-key",
+      baseUrl = FireworksConfig.DEFAULT_BASE_URL
+    )
+    cfg.model shouldBe "accounts/fireworks/models/firefunction-v2"
+    cfg.contextWindow should be > 0
+  }
+
+  it should "use fallback context window for unknown models" in {
+    val cfg = FireworksConfig.fromValues(
+      modelName = "accounts/fireworks/models/unknown-model-xyz",
+      apiKey = "fw-key",
+      baseUrl = FireworksConfig.DEFAULT_BASE_URL
+    )
+    cfg.contextWindow should be > 0
+    cfg.reserveCompletion should be > 0
+  }
+
+  it should "throw when apiKey is empty" in {
+    an[IllegalArgumentException] should be thrownBy {
+      FireworksConfig.fromValues(
+        modelName = defaultModel,
+        apiKey = "",
+        baseUrl = FireworksConfig.DEFAULT_BASE_URL
+      )
+    }
+  }
+
+  it should "throw when apiKey is blank" in {
+    an[IllegalArgumentException] should be thrownBy {
+      FireworksConfig.fromValues(
+        modelName = defaultModel,
+        apiKey = "   ",
+        baseUrl = FireworksConfig.DEFAULT_BASE_URL
+      )
+    }
+  }
+
+  it should "throw when baseUrl is empty" in {
+    an[IllegalArgumentException] should be thrownBy {
+      FireworksConfig.fromValues(
+        modelName = defaultModel,
+        apiKey = "fw-key",
+        baseUrl = ""
+      )
+    }
+  }
+
+  it should "throw when baseUrl is blank" in {
+    an[IllegalArgumentException] should be thrownBy {
+      FireworksConfig.fromValues(
+        modelName = defaultModel,
+        apiKey = "fw-key",
+        baseUrl = "   "
+      )
+    }
+  }
+}

--- a/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/types/ProviderKindSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 class ProviderKindSpec extends AnyFlatSpec with Matchers:
 
   "ProviderKind" should "expose all expected provider instances" in {
-    ProviderKind.all should have size 10
+    ProviderKind.all should have size 11
     (ProviderKind.all should contain).allOf(
       ProviderKind.OpenAI,
       ProviderKind.Azure,
@@ -18,7 +18,8 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       ProviderKind.Gemini,
       ProviderKind.Cohere,
       ProviderKind.DeepSeek,
-      ProviderKind.Mistral
+      ProviderKind.Mistral,
+      ProviderKind.Fireworks
     )
   }
 
@@ -33,6 +34,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     ProviderKind.DeepSeek.name shouldBe "deepseek"
     ProviderKind.Cohere.name shouldBe "cohere"
     ProviderKind.Mistral.name shouldBe "mistral"
+    ProviderKind.Fireworks.name shouldBe "fireworks"
   }
 
   "ProviderKind.fromName" should "parse supported providers case-insensitively" in {
@@ -47,6 +49,8 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     ProviderKind.fromName("DEEPSEEK") shouldBe Some(ProviderKind.DeepSeek)
     ProviderKind.fromName("COHERE") shouldBe Some(ProviderKind.Cohere)
     ProviderKind.fromName("MISTRAL") shouldBe Some(ProviderKind.Mistral)
+    ProviderKind.fromName("fireworks") shouldBe Some(ProviderKind.Fireworks)
+    ProviderKind.fromName("FIREWORKS") shouldBe Some(ProviderKind.Fireworks)
   }
 
   it should "return None for unknown providers" in {
@@ -72,6 +76,7 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
       case ProviderKind.DeepSeek   => "cloud-deepseek"
       case ProviderKind.Cohere     => "cloud-cohere"
       case ProviderKind.Mistral    => "cloud-mistral"
+      case ProviderKind.Fireworks  => "cloud-fireworks"
 
     describe(ProviderKind.OpenAI) shouldBe "cloud-openai"
     describe(ProviderKind.Ollama) shouldBe "local"
@@ -80,4 +85,5 @@ class ProviderKindSpec extends AnyFlatSpec with Matchers:
     describe(ProviderKind.DeepSeek) shouldBe "cloud-deepseek"
     describe(ProviderKind.Cohere) shouldBe "cloud-cohere"
     describe(ProviderKind.Mistral) shouldBe "cloud-mistral"
+    describe(ProviderKind.Fireworks) shouldBe "cloud-fireworks"
   }

--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/FireworksSmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/FireworksSmokeSpec.scala
@@ -1,0 +1,103 @@
+package org.llm4s.llmconnect.smoke
+
+import org.llm4s.llmconnect.config.{ ContextWindowResolver, FireworksConfig }
+import org.llm4s.llmconnect.model.{ CompletionOptions, Conversation, StreamedChunk, UserMessage }
+import org.llm4s.llmconnect.provider.FireworksClient
+import org.llm4s.model.ModelRegistryService
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Cloud smoke tests for the Fireworks AI provider.
+ *
+ * These tests require a live `FIREWORKS_API_KEY` environment variable and are
+ * excluded from `sbt test`. Run them with:
+ * {{{
+ *   sbt "it/testOnly org.llm4s.llmconnect.smoke.FireworksSmokeSpec"
+ * }}}
+ * or via the `sbt testSmoke` alias.
+ *
+ * Tests are tagged `CloudSmoke` and skip gracefully when the API key is absent.
+ */
+class FireworksSmokeSpec extends AnyFlatSpec with Matchers {
+
+  private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
+  private given ContextWindowResolver     = ContextWindowResolver(mrs)
+
+  private val apiKey: Option[String] = Option(System.getenv("FIREWORKS_API_KEY")).filter(_.nonEmpty)
+
+  private val llamaModel      = "accounts/fireworks/models/llama-v3p1-8b-instruct"
+  private val fireFunctionModel = "accounts/fireworks/models/firefunction-v2"
+
+  private def config(model: String, key: String): FireworksConfig =
+    FireworksConfig.fromValues(
+      modelName = model,
+      apiKey = key,
+      baseUrl = FireworksConfig.DEFAULT_BASE_URL
+    )
+
+  private def conversation: Conversation = Conversation(Seq(UserMessage("Say hi in one word")))
+
+  // ==========================================================================
+  // complete()
+  // ==========================================================================
+
+  "Fireworks AI" should "complete a basic request with llama-v3p1-8b-instruct" in {
+    assume(apiKey.isDefined, "FIREWORKS_API_KEY not set — skipping smoke test")
+
+    val clientResult = FireworksClient(config(llamaModel, apiKey.get))
+    withClue(s"Client creation failed: ${clientResult.swap.toOption}") {
+      clientResult.isRight shouldBe true
+    }
+
+    val client     = clientResult.toOption.get
+    val completion = client.complete(conversation, CompletionOptions())
+
+    withClue(s"Completion failed: ${completion.swap.toOption}") {
+      completion.isRight shouldBe true
+    }
+    val result = completion.toOption.get
+    result.content should not be empty
+    result.usage shouldBe defined
+    result.usage.get.promptTokens should be > 0
+    result.usage.get.completionTokens should be > 0
+    result.usage.get.totalTokens should be > 0
+  }
+
+  // ==========================================================================
+  // streamComplete()
+  // ==========================================================================
+
+  it should "stream a response from llama-v3p1-8b-instruct" in {
+    assume(apiKey.isDefined, "FIREWORKS_API_KEY not set — skipping smoke test")
+
+    val client = FireworksClient(config(llamaModel, apiKey.get)).toOption.get
+    val chunks = scala.collection.mutable.ListBuffer.empty[StreamedChunk]
+    val result = client.streamComplete(conversation, CompletionOptions(), c => chunks += c)
+
+    withClue(s"Streaming failed: ${result.swap.toOption}") {
+      result.isRight shouldBe true
+    }
+    result.toOption.get.content should not be empty
+    chunks should not be empty
+  }
+
+  // ==========================================================================
+  // tool calling with firefunction-v2
+  // ==========================================================================
+
+  it should "support tool calling with firefunction-v2" in {
+    assume(apiKey.isDefined, "FIREWORKS_API_KEY not set — skipping smoke test")
+
+    val client     = FireworksClient(config(fireFunctionModel, apiKey.get)).toOption.get
+    val toolConv   = Conversation(Seq(UserMessage("What is 2 + 2? Use the calculator tool.")))
+    val completion = client.complete(toolConv, CompletionOptions())
+
+    withClue(s"Tool-calling completion failed: ${completion.swap.toOption}") {
+      completion.isRight shouldBe true
+    }
+    // Either a text response or tool calls — both are valid
+    val result = completion.toOption.get
+    (result.content.nonEmpty || result.toolCalls.nonEmpty) shouldBe true
+  }
+}

--- a/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/dashboard/providersetup/ProviderSetupRuntime.scala
@@ -372,6 +372,12 @@ private[providersetup] object ProviderSetupRuntime:
           apiKey = input.flatMap(_.apiKey).getOrElse(cfg.apiKey),
           baseUrl = input.flatMap(_.baseUrl).getOrElse(cfg.baseUrl)
         )
+      case cfg: FireworksConfig =>
+        cfg.copy(
+          model = input.flatMap(_.model).getOrElse(cfg.model),
+          apiKey = input.flatMap(_.apiKey).getOrElse(cfg.apiKey),
+          baseUrl = input.flatMap(_.baseUrl).getOrElse(cfg.baseUrl)
+        )
 
   def demoCompletionCmd(
     providerConfig: ProviderConfig,
@@ -580,3 +586,4 @@ private[providersetup] object ProviderSetupRuntime:
       case cfg: CohereConfig    => cfg.copy(model = modelName)
       case cfg: MistralConfig   => cfg.copy(model = modelName)
       case cfg: ZaiConfig       => cfg.copy(model = modelName)
+      case cfg: FireworksConfig => cfg.copy(model = modelName)

--- a/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
+++ b/modules/samples/src/main/scala/org/llm4s/samples/metrics/PrometheusMetricsExample.scala
@@ -141,6 +141,7 @@ object PrometheusMetricsExample {
                 case _: org.llm4s.llmconnect.config.DeepSeekConfig  => "deepseek"
                 case _: org.llm4s.llmconnect.config.CohereConfig    => "cohere"
                 case _: org.llm4s.llmconnect.config.MistralConfig   => "mistral"
+                case _: org.llm4s.llmconnect.config.FireworksConfig => "fireworks"
               }
 
               println(s"Using model: ${config.model}")


### PR DESCRIPTION
## Summary

Implements #1024: Fireworks AI enterprise inference provider.

Fireworks AI is a leading enterprise inference platform for open-source models (Llama, Mixtral, Qwen, FireFunction) with SLA guarantees, SOC 2 compliance, and a fully OpenAI-compatible REST API.

- `FireworksConfig` — new `ProviderConfig` subtype with `DEFAULT_BASE_URL = "https://api.fireworks.ai/inference/v1"` and model-aware context window resolution for Llama, Mixtral, and FireFunction models
- `FireworksClient` — full LLM client implementing `complete()`, `streamComplete()`, and tool calling support (FireFunction-v2 optimised for agentic tool use)
- `ProviderKind.Fireworks` — registered in enum, `fromString("fireworks")`, and `name()` extension
- `LLMConnect` — routes `FireworksConfig` to `FireworksClient` in both `buildClient()` and `fromProvider()`
- `ConfigKeys.FIREWORKS_API_KEY` and `DefaultConfig.DEFAULT_FIREWORKS_BASE_URL`
- `NamedProviderLoader`, `NamedProviderValidator`, `ProviderCapabilities`, `ProviderCapabilitiesRegistry` — all updated for Fireworks

## Test Coverage

Unit tests (40 tests, 0 failures) — no real API key required for `sbt test`:
- `FireworksClientSpec` — HTTP-level tests using `LocalProviderTestServer`: complete, streaming, error codes (401/403/429/500/502), tool calls, multi-turn conversations, request serialization
- `FireworksConfigSpec` — config validation, `fromValues()`, context window defaults per model family, `toString` API key redaction
- `FireworksClientClosedStateTest` — closed state handling, idempotent `close()`

Existing test suite: all 6894 tests still pass after the addition.

## Smoke Tests

`FireworksSmokeSpec` in `modules/it` covers:
- `complete()` with `llama-v3p1-8b-instruct` (verifies response, non-empty content, token usage)
- `streamComplete()` (verifies chunks emitted)
- Tool calling with `firefunction-v2`

Skips gracefully when `FIREWORKS_API_KEY` is absent. Run with:
```
sbt "it/testOnly org.llm4s.llmconnect.smoke.FireworksSmokeSpec"
```

Closes #1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)