### PR TITLE
feat(core): improve ToolCallError.UnknownFunction message with availa…

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/mcp/MCPToolRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/mcp/MCPToolRegistry.scala
@@ -89,7 +89,7 @@ class MCPToolRegistry(
             }.flatten
           case None =>
             logger.warn(s"Tool ${request.functionName} not found in any registry (local or MCP)")
-            Left(ToolCallError.UnknownFunction(request.functionName))
+            Left(ToolCallError.UnknownFunction(request.functionName, getAllTools.map(_.name)))
         }
     }
   }

--- a/modules/core/src/main/scala/org/llm4s/toolapi/ToolParameterError.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/ToolParameterError.scala
@@ -130,8 +130,14 @@ object ToolCallError {
   /**
    * Tool function doesn't exist
    */
-  case class UnknownFunction(toolName: String) extends ToolCallError {
-    def getMessage: String = "is not a recognized tool"
+  case class UnknownFunction(
+    toolName: String,
+    availableTools: Seq[String] = Seq.empty
+  ) extends ToolCallError {
+    def getMessage: String = {
+      val toolsInfo = if (availableTools.nonEmpty) s" Available tools: [${availableTools.mkString(", ")}]." else ""
+      s"is not a recognized tool.$toolsInfo Check the tool name matches exactly (case-sensitive)."
+    }
   }
 
   /**
@@ -298,7 +304,7 @@ object ToolCallErrorJson {
     )
 
     error match {
-      case ToolCallError.UnknownFunction(_) =>
+      case ToolCallError.UnknownFunction(_, _) =>
         base("errorType") = "unknown_function"
         base
 

--- a/modules/core/src/main/scala/org/llm4s/toolapi/ToolRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/ToolRegistry.scala
@@ -112,7 +112,7 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
           case scala.util.Success(Left(e))  => Left(e)
           case scala.util.Failure(t)        => Left(ToolCallError.ExecutionError(request.functionName, t))
         }
-      case None => Left(ToolCallError.UnknownFunction(request.functionName))
+      case None => Left(ToolCallError.UnknownFunction(request.functionName, tools.map(_.name)))
     }
 
   private def runWithRetry(

--- a/modules/core/src/test/scala/org/llm4s/agent/AgentToolFailureTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/AgentToolFailureTest.scala
@@ -538,7 +538,7 @@ class AgentToolFailureTest extends AnyFlatSpec with Matchers with MockFactory {
     json("isError").bool shouldBe true
     json("toolName").str shouldBe "nonexistent_tool"
     json("errorType").str shouldBe "unknown_function"
-    json("message").str shouldBe "is not a recognized tool"
+    json("message").str should include("is not a recognized tool")
     json("error").str should include("Tool call 'nonexistent_tool'")
     json.obj.get("parameterErrors") shouldBe None
   }

--- a/modules/core/src/test/scala/org/llm4s/toolapi/EnhancedErrorMessagesTest.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/EnhancedErrorMessagesTest.scala
@@ -172,7 +172,7 @@ class EnhancedErrorMessagesTest extends AnyFlatSpec with Matchers {
   "ToolCallError messages" should "have consistent format" in {
     // Test UnknownFunction
     val unknown = ToolCallError.UnknownFunction("foo_bar")
-    unknown.getFormattedMessage shouldBe "Tool call 'foo_bar' is not a recognized tool"
+    unknown.getFormattedMessage should include("Tool call 'foo_bar' is not a recognized tool")
 
     // Test NullArguments
     val nullArgs = ToolCallError.NullArguments("process_data")

--- a/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
@@ -166,7 +166,7 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
     )
   }
 
-  it should "return error for unknown function" in {
+  it should "return error for unknown function and suggest available tools" in {
     createAddTool().fold(
       e => fail(s"Tool creation failed: ${e.formatted}"),
       addTool => {
@@ -174,9 +174,10 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
         val request  = ToolCallRequest("unknown_function", ujson.Obj())
         val result   = registry.execute(request)
         result.isLeft shouldBe true
-        result.fold(identity, v => fail(s"Expected Left but got Right: $v")).getMessage should include(
-          "not a recognized tool"
-        )
+        val errorMsg = result.fold(identity, v => fail(s"Expected Left but got Right: $v")).getMessage
+        errorMsg should include("not a recognized tool")
+        errorMsg should include("Available tools: [add]")
+        errorMsg should include("case-sensitive")
       }
     )
   }


### PR DESCRIPTION
Resolves #962

## Description
Improves the error messages when an unknown tool is invoked by the LLM. Rather than returning a terse message (`is not a recognized tool`), the `ToolRegistry` now passes the list of registered tools to `ToolCallError.UnknownFunction`. This allows the error message to explicitly list the available tools to help developers debug configurations faster.

---

## Changes

### 📄 ToolParameterError.scala
* Added an optional `availableTools: Seq[String]` parameter to `UnknownFunction`.
* Updated `getMessage` logic to include a formatted list of available tools and a case-sensitivity hint.

### 📄 ToolCallErrorJson.scala
* Updated the pattern matching for serialization backwards-compatibility to handle `case ToolCallError.UnknownFunction(_, _)`.

### 📄 ToolRegistry.scala
* Updated `ToolRegistry.runOneAttempt` to pass `tools.map(_.name)` when no matching tool is found.

### 📄 ToolRegistrySpec.scala
* Replaced the existing test case with the specified acceptance criteria assertion to test for the `available tools:` string and case-sensitive substrings.

---

## Verification
* Tested with `ToolRegistrySpec` directly matching the Acceptance Criteria in the issue.