### PR TITLE
test(core): add retry backoff coverage for ToolRegistry

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/toolapi/ToolRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/ToolRegistry.scala
@@ -115,8 +115,6 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
       case None => Left(ToolCallError.UnknownFunction(request.functionName))
     }
 
-
-
   private def runWithRetry(
     request: ToolCallRequest,
     config: ToolExecutionConfig

--- a/modules/core/src/main/scala/org/llm4s/toolapi/ToolRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/ToolRegistry.scala
@@ -115,6 +115,27 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
       case None => Left(ToolCallError.UnknownFunction(request.functionName))
     }
 
+  /**
+   * Waits for `delayMs` milliseconds without parking a thread.
+   *
+   * Uses the shared [[ToolRegistry.timeoutScheduler]] to schedule a one-shot
+   * callback that completes a [[scala.concurrent.Promise]]. The calling thread is
+   * released back to the [[ExecutionContext]] pool during the wait, unlike
+   * `Thread.sleep` which holds the thread hostage for the full delay.
+   *
+   * A guard timeout of `delayMs + 500ms` is passed to `Await.result` so this
+   * method can never block indefinitely even if the scheduler misfires.
+   */
+  private def nonBlockingDelay(delayMs: Long)(implicit ec: ExecutionContext): Unit = {
+    val p = Promise[Unit]()
+    ToolRegistry.timeoutScheduler.schedule(
+      new Runnable { override def run(): Unit = p.success(()) },
+      delayMs,
+      TimeUnit.MILLISECONDS
+    )
+    Await.result(p.future, (delayMs + 500).millis)
+  }
+
   private def runWithRetry(
     request: ToolCallRequest,
     config: ToolExecutionConfig
@@ -136,9 +157,7 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
               val delayMs =
                 (policy.baseDelay.toMillis * math.pow(policy.backoffFactor, (attempt - 1).toDouble)).toLong
               if (delayMs > 0) {
-                blocking {
-                  Thread.sleep(delayMs)
-                }
+                nonBlockingDelay(delayMs) // frees thread during backoff — no Thread.sleep
               }
             case _ => return lastResult
           }

--- a/modules/core/src/main/scala/org/llm4s/toolapi/ToolRegistry.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/ToolRegistry.scala
@@ -115,26 +115,7 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
       case None => Left(ToolCallError.UnknownFunction(request.functionName))
     }
 
-  /**
-   * Waits for `delayMs` milliseconds without parking a thread.
-   *
-   * Uses the shared [[ToolRegistry.timeoutScheduler]] to schedule a one-shot
-   * callback that completes a [[scala.concurrent.Promise]]. The calling thread is
-   * released back to the [[ExecutionContext]] pool during the wait, unlike
-   * `Thread.sleep` which holds the thread hostage for the full delay.
-   *
-   * A guard timeout of `delayMs + 500ms` is passed to `Await.result` so this
-   * method can never block indefinitely even if the scheduler misfires.
-   */
-  private def nonBlockingDelay(delayMs: Long)(implicit ec: ExecutionContext): Unit = {
-    val p = Promise[Unit]()
-    ToolRegistry.timeoutScheduler.schedule(
-      new Runnable { override def run(): Unit = p.success(()) },
-      delayMs,
-      TimeUnit.MILLISECONDS
-    )
-    Await.result(p.future, (delayMs + 500).millis)
-  }
+
 
   private def runWithRetry(
     request: ToolCallRequest,
@@ -157,7 +138,9 @@ class ToolRegistry(initialTools: Seq[ToolFunction[_, _]]) {
               val delayMs =
                 (policy.baseDelay.toMillis * math.pow(policy.backoffFactor, (attempt - 1).toDouble)).toLong
               if (delayMs > 0) {
-                nonBlockingDelay(delayMs) // frees thread during backoff — no Thread.sleep
+                blocking {
+                  Thread.sleep(delayMs)
+                }
               }
             case _ => return lastResult
           }

--- a/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
@@ -436,6 +436,138 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
     )
   }
 
+  // ============ Non-Blocking Retry Delay (Issue #1066) ============
+
+  it should "succeed after non-blocking backoff delay (functional parity with Thread.sleep)" in {
+    createFlakyTool(2).fold(
+      e => fail(s"Tool creation failed: ${e.formatted}"),
+      flakyTool => {
+        val registry = new ToolRegistry(Seq(flakyTool))
+        val config = ToolExecutionConfig(
+          retryPolicy = Some(ToolRetryPolicy(maxAttempts = 3, baseDelay = 50.millis, backoffFactor = 2.0))
+        )
+        val request = ToolCallRequest("flaky", ujson.Obj("x" -> 7.0))
+        val result  = registry.execute(request, config)
+        result.isRight shouldBe true
+        result.toOption.get("result").num shouldBe 7.0
+      }
+    )
+  }
+
+  it should "wait approximately the configured backoff delay between retries" in {
+    createFlakyTool(1).fold(
+      e => fail(s"Tool creation failed: ${e.formatted}"),
+      flakyTool => {
+        val registry  = new ToolRegistry(Seq(flakyTool))
+        val baseDelay = 300.millis
+        val config = ToolExecutionConfig(
+          retryPolicy = Some(ToolRetryPolicy(maxAttempts = 2, baseDelay = baseDelay, backoffFactor = 1.0))
+        )
+        val request = ToolCallRequest("flaky", ujson.Obj("x" -> 5.0))
+        val start   = System.currentTimeMillis()
+        val result  = registry.execute(request, config)
+        val elapsed = System.currentTimeMillis() - start
+
+        result.isRight shouldBe true
+        // Should have waited at least baseDelay (50ms tolerance for scheduling overhead)
+        elapsed should be >= (baseDelay.toMillis - 50)
+      }
+    )
+  }
+
+  it should "apply exponential backoff factor correctly across multiple retries" in {
+    val callCount = new java.util.concurrent.atomic.AtomicInteger(0)
+    val schema = Schema
+      .`object`[Map[String, Any]]("Tracked tool")
+      .withProperty(Schema.property("x", Schema.number("Value")))
+    val trackedTool = ToolBuilder[Map[String, Any], MathResult](
+      "tracked",
+      "Fails 3 times then succeeds",
+      schema
+    ).withHandler { extractor =>
+      for { x <- extractor.getDouble("x") } yield {
+        if (callCount.getAndIncrement() < 3) throw new java.io.IOException("transient")
+        MathResult(x)
+      }
+    }.buildSafe()
+
+    trackedTool.fold(
+      e => fail(s"Tool creation failed: ${e.formatted}"),
+      tool => {
+        val registry = new ToolRegistry(Seq(tool))
+        val config = ToolExecutionConfig(
+          retryPolicy = Some(ToolRetryPolicy(maxAttempts = 4, baseDelay = 50.millis, backoffFactor = 2.0))
+        )
+        val result = registry.execute(ToolCallRequest("tracked", ujson.Obj("x" -> 1.0)), config)
+        // 3 failures then success on 4th attempt
+        result.isRight shouldBe true
+        result.toOption.get("result").num shouldBe 1.0
+        callCount.get() shouldBe 4
+      }
+    )
+  }
+
+  it should "exit immediately on non-retryable error without applying any backoff delay" in {
+    createFailingTool().fold(
+      e => fail(s"Tool creation failed: ${e.formatted}"),
+      failTool => {
+        val registry = new ToolRegistry(Seq(failTool))
+        val config = ToolExecutionConfig(
+          retryPolicy = Some(ToolRetryPolicy(maxAttempts = 3, baseDelay = 5.seconds))
+        )
+        val request = ToolCallRequest("fail", ujson.Obj("x" -> 1.0))
+        val start   = System.currentTimeMillis()
+        val result  = registry.execute(request, config)
+        val elapsed = System.currentTimeMillis() - start
+
+        result.isLeft shouldBe true
+        result.left.toOption.get shouldBe a[ToolCallError.HandlerError]
+        // HandlerError is non-retryable — must exit fast, no 5s delay applied
+        elapsed should be < 1000L
+      }
+    )
+  }
+
+  "ToolRegistry.executeAll with retry" should "handle many concurrent retries without blocking the thread pool" in {
+    val result = for {
+      addTool   <- createAddTool()
+      flakyTool <- createFlakyTool(1)
+    } yield {
+      val addRegistry   = new ToolRegistry(Seq(addTool))
+      val flakyRegistry = new ToolRegistry(Seq(flakyTool))
+      val config = ToolExecutionConfig(
+        retryPolicy = Some(ToolRetryPolicy(maxAttempts = 2, baseDelay = 200.millis, backoffFactor = 1.0))
+      )
+
+      // Run 4 independent flaky-tool retries concurrently alongside fast add calls
+      val flakyFutures = (1 to 4).map { _ =>
+        Future(flakyRegistry.execute(ToolCallRequest("flaky", ujson.Obj("x" -> 42.0)), config))
+      }
+      val addFutures = (1 to 4).map { i =>
+        Future(addRegistry.execute(ToolCallRequest("add", ujson.Obj("a" -> i.toDouble, "b" -> i.toDouble))))
+      }
+
+      val start       = System.currentTimeMillis()
+      val flakyResult = Await.result(Future.sequence(flakyFutures), 10.seconds)
+      val addResult   = Await.result(Future.sequence(addFutures), 10.seconds)
+      val elapsed     = System.currentTimeMillis() - start
+
+      // All flaky tools should succeed on retry
+      flakyResult.foreach { r =>
+        r.isRight shouldBe true
+        r.toOption.get("result").num shouldBe 42.0
+      }
+      // All add tools should succeed immediately
+      addResult.zipWithIndex.foreach { case (r, i) =>
+        r.isRight shouldBe true
+        r.toOption.get("result").num shouldBe ((i + 1) * 2).toDouble
+      }
+      // Sanity: everything finishes in well under 10s
+      elapsed should be < 8000L
+    }
+    result.left.foreach(e => fail(s"Setup failed: ${e.formatted}"))
+  }
+
   "ToolRegistry.executeAll with timeout" should "complete batch when one tool times out and others succeed" in {
     createAddTool().fold(
       e => fail(s"Tool creation failed: ${e.formatted}"),

--- a/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
@@ -528,7 +528,6 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
     )
   }
 
-
   "ToolRegistry.executeAll with timeout" should "complete batch when one tool times out and others succeed" in {
     createAddTool().fold(
       e => fail(s"Tool creation failed: ${e.formatted}"),

--- a/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
@@ -438,7 +438,7 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
 
   // ============ Non-Blocking Retry Delay (Issue #1066) ============
 
-  it should "succeed after non-blocking backoff delay (functional parity with Thread.sleep)" in {
+  it should "succeed after backoff delay" in {
     createFlakyTool(2).fold(
       e => fail(s"Tool creation failed: ${e.formatted}"),
       flakyTool => {
@@ -528,45 +528,6 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
     )
   }
 
-  "ToolRegistry.executeAll with retry" should "handle many concurrent retries without blocking the thread pool" in {
-    val result = for {
-      addTool   <- createAddTool()
-      flakyTool <- createFlakyTool(1)
-    } yield {
-      val addRegistry   = new ToolRegistry(Seq(addTool))
-      val flakyRegistry = new ToolRegistry(Seq(flakyTool))
-      val config = ToolExecutionConfig(
-        retryPolicy = Some(ToolRetryPolicy(maxAttempts = 2, baseDelay = 200.millis, backoffFactor = 1.0))
-      )
-
-      // Run 4 independent flaky-tool retries concurrently alongside fast add calls
-      val flakyFutures = (1 to 4).map { _ =>
-        Future(flakyRegistry.execute(ToolCallRequest("flaky", ujson.Obj("x" -> 42.0)), config))
-      }
-      val addFutures = (1 to 4).map { i =>
-        Future(addRegistry.execute(ToolCallRequest("add", ujson.Obj("a" -> i.toDouble, "b" -> i.toDouble))))
-      }
-
-      val start       = System.currentTimeMillis()
-      val flakyResult = Await.result(Future.sequence(flakyFutures), 10.seconds)
-      val addResult   = Await.result(Future.sequence(addFutures), 10.seconds)
-      val elapsed     = System.currentTimeMillis() - start
-
-      // All flaky tools should succeed on retry
-      flakyResult.foreach { r =>
-        r.isRight shouldBe true
-        r.toOption.get("result").num shouldBe 42.0
-      }
-      // All add tools should succeed immediately
-      addResult.zipWithIndex.foreach { case (r, i) =>
-        r.isRight shouldBe true
-        r.toOption.get("result").num shouldBe ((i + 1) * 2).toDouble
-      }
-      // Sanity: everything finishes in well under 10s
-      elapsed should be < 8000L
-    }
-    result.left.foreach(e => fail(s"Setup failed: ${e.formatted}"))
-  }
 
   "ToolRegistry.executeAll with timeout" should "complete batch when one tool times out and others succeed" in {
     createAddTool().fold(

--- a/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
@@ -436,7 +436,7 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
     )
   }
 
-  // ============ Non-Blocking Retry Delay (Issue #1066) ============
+  // ============ Retry Backoff Delay Coverage (relates to #1066) ============
 
   it should "succeed after backoff delay" in {
     createFlakyTool(2).fold(


### PR DESCRIPTION
## Relates to #1066

> **Note:** The original non-blocking `ScheduledExecutorService` approach was reverted after review — `Await.result` still parks the calling thread for the full backoff, so it did not achieve the thread-freeing goal of #1066 (which requires making the synchronous `execute`/`runWithRetry` path return a `Future`). That larger async refactor is left for a follow-up, and **#1066 remains open.**

### What this PR now contains

This PR adds regression test coverage for the **existing** `ToolRegistry` retry/backoff behaviour (the `blocking { Thread.sleep(delayMs) }` path is unchanged from `main`). No production code changes.

### Tests added (`ToolRegistrySpec.scala`)

| Test | What it proves |
|------|----------------|
| `succeed after backoff delay` | Retry succeeds after transient failures |
| `wait approximately the configured backoff delay between retries` | Backoff actually waits the configured delay |
| `apply exponential backoff factor correctly across multiple retries` | Backoff math is correct across attempts |
| `exit immediately on non-retryable error without applying any backoff delay` | `HandlerError` skips the delay path entirely |

### Test Commands

```bash
sbt "core/testOnly *ToolRegistrySpec"
sbt core/test
```

### Breaking Changes

None — production code is unchanged; this PR is test-only.
