### PR TITLE
docs(core): add ScalaDoc to LLMCompressor and ContextManager (#950)

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/context/ContextManager.scala
+++ b/modules/core/src/main/scala/org/llm4s/context/ContextManager.scala
@@ -6,27 +6,70 @@ import org.llm4s.types.{ Result, TokenBudget, HeadroomPercent, ContextWindowSize
 import org.slf4j.LoggerFactory
 
 /**
- * Orchestrates a 4-step context management pipeline (early-exit if budget is met at any step):
+ * Orchestrates the 4-step context management pipeline for llm4s conversations.
  *
- * 1) ToolDeterministicCompaction
- *    - Run DeterministicCompressor.compressToCap() with compressToolOutputs first (subjective edits OFF).
- *    - Goal: shrink/cap tool outputs (JSON/logs/binary) without touching user/assistant text.
+ * `ContextManager` is the primary entry point for keeping a conversation within a
+ * model's token limit. Each step is applied in order of increasing cost; the pipeline
+ * exits early as soon as the conversation fits the requested budget.
  *
- * 2) HistoryCompression
- *    - Run HistoryCompressor.compressToDigest(...):
- *      • Keep last K semantic blocks as is (K = config.maxSemanticBlocks).
- *      • Replace older blocks with a deterministic [HISTORY_SUMMARY] digest capped to config.summaryTokenTarget.
+ * ==Compressor Comparison==
  *
- * 3) LLMHistorySqueeze
- *    - If still over budget AND LLM enabled:
- *      • Compress the digest string only to summaryTokenTarget via LLMCompressor.squeezeDigest().
- *      • No whole-conversation LLM compression.
+ * {{{
+ * Strategy                | Cost        | Quality | Latency | What it touches
+ * ------------------------|-------------|---------|---------|-------------------------
+ * DeterministicCompressor | Free        | Lower   | Fast    | Tool outputs only
+ * HistoryCompressor       | Free        | Medium  | Fast    | Older history → digest
+ * LLMCompressor           | 1 LLM call  | High    | Slow    | Digest messages only
+ * }}}
  *
- * 4) FinalTokenTrim
- *    - TokenWindow.trimToBudget() with headroom.
- *    - Pin [HISTORY_SUMMARY] so it’s never dropped; pack remaining messages newest-first.
+ * ==4-Step Pipeline==
+ *
+ * Each step exits immediately if the budget is already met:
+ *
+ *  1. '''ToolDeterministicCompaction''' ([[DeterministicCompressor]]):
+ *     Shrinks and caps tool outputs (JSON, logs, binary content) without modifying
+ *     user or assistant messages. No API calls; always runs first.
+ *
+ *  2. '''HistoryCompression''' ([[HistoryCompressor]]):
+ *     Keeps the last `config.maxSemanticBlocks` semantic blocks verbatim and
+ *     replaces older blocks with compact `[HISTORY_SUMMARY]` digests, capped to
+ *     `config.summaryTokenTarget` tokens. No API calls.
+ *
+ *  3. '''LLMHistorySqueeze''' ([[LLMCompressor]]):
+ *     If still over budget and `config.enableLLMCompression` is `true`, compresses
+ *     only the digest messages further via one LLM inference call per digest.
+ *
+ *  4. '''FinalTokenTrim''' ([[TokenWindow]]):
+ *     Hard-trims to `budget` tokens (with `config.headroomPercent`), always pinning
+ *     `[HISTORY_SUMMARY]` messages so they are never dropped.
+ *
+ * ==Usage==
+ *
+ * {{{
+ * // Quick setup with defaults:
+ * val manager = ContextManager.withDefaults(tokenCounter).getOrElse(???)
+ * val result  = manager.manageContext(conversation, budget = 8000)
+ * result.foreach(managed => println(managed.summary))
+ *
+ * // With an LLM client for Step 3:
+ * val manager = ContextManager.create(tokenCounter, ContextConfig.default, Some(llmClient))
+ *   .getOrElse(???)
+ * }}}
+ *
+ * @param tokenCounter  Token counter calibrated to the target model's tokenizer
+ * @param config        Pipeline configuration — controls headroom, semantic block count,
+ *                      and which steps are enabled
+ * @param llmClient     Optional LLM client; required for Step 3 (LLMHistorySqueeze);
+ *                      Step 3 is skipped if `None`
+ * @param artifactStore Optional store for externalized binary/large content from Step 1;
+ *                      defaults to an in-memory store if `None`
+ *
+ * @see [[DeterministicCompressor]] for Step 1 implementation
+ * @see [[HistoryCompressor]] for Step 2 implementation
+ * @see [[LLMCompressor]] for Step 3 implementation
+ * @see [[TokenWindow]] for Step 4 implementation
+ * @see [[ContextConfig]] for all configuration options
  */
-
 class ContextManager(
   tokenCounter: ConversationTokenCounter,
   config: ContextConfig,

--- a/modules/core/src/main/scala/org/llm4s/context/LLMCompressor.scala
+++ b/modules/core/src/main/scala/org/llm4s/context/LLMCompressor.scala
@@ -7,14 +7,46 @@ import org.llm4s.types.{ Result, CompressionRatio, TokenBudget }
 import org.slf4j.LoggerFactory
 
 /**
- * Implements digest-only compression for [HISTORY_SUMMARY] messages.
- * Replaces full LLM-powered compression with targeted digest compression.
+ * Applies LLM-powered compression to `[HISTORY_SUMMARY]` digest messages.
  *
- * This is step 3 in the new 4-stage context management pipeline:
- * 1. Tool deterministic compaction
- * 2. History compression
- * 3. LLM digest squeeze (this module)
- * 4. Final token trim
+ * This is Step 3 in the 4-stage context management pipeline. It targets only the
+ * structured digest messages produced by [[HistoryCompressor]] — it never touches
+ * user messages, assistant messages, or tool outputs directly.
+ *
+ * ==When to Use==
+ *
+ * Use `LLMCompressor` (via [[ContextManager]] with `enableLLMCompression = true`) when:
+ *  - The conversation is long-running and history digests have grown too large to fit
+ *    within the remaining token budget after [[HistoryCompressor]] has run.
+ *  - Preserving semantic fidelity in the digest is important — you cannot afford to
+ *    simply truncate or drop structured information (IDs, decisions, error codes).
+ *  - An extra LLM API call per compression event is acceptable (latency and cost).
+ *
+ * ==When NOT to Use==
+ *
+ * Prefer [[DeterministicCompressor]] or [[HistoryCompressor]] alone when:
+ *  - Latency is critical (e.g., interactive chatbots where each round-trip matters).
+ *  - Cost per token must be minimised — an extra inference call adds to compression cost.
+ *  - The conversation fits within budget after deterministic steps; `ContextManager`
+ *    skips this step automatically in that case.
+ *
+ * ==Cost==
+ *
+ * Each call to [[squeezeDigest]] that needs to act makes one LLM API call per
+ * `[HISTORY_SUMMARY]` message that exceeds the cap. Budget for this accordingly.
+ *
+ * ==Pipeline Position==
+ *
+ * {{{
+ * Step 1: DeterministicCompressor — free, fast, tool-output focused
+ * Step 2: HistoryCompressor       — free, fast, deterministic digest
+ * Step 3: LLMCompressor           — 1 LLM call per digest, slower, high quality  ← this object
+ * Step 4: TokenWindow.trimToBudget — free, last resort
+ * }}}
+ *
+ * @see [[HistoryCompressor]] for digest generation that this compressor further shrinks
+ * @see [[DeterministicCompressor]] for the cheaper alternative with no API calls
+ * @see [[ContextManager]] for the orchestrator that chooses when to invoke each step
  */
 object LLMCompressor {
   private val logger = LoggerFactory.getLogger(getClass)
@@ -27,8 +59,18 @@ object LLMCompressor {
 - Target 50% size reduction"""
 
   /**
-   * Apply digest-only LLM compression to [HISTORY_SUMMARY] messages only.
-   * Leaves other message types unchanged.
+   * Compresses `[HISTORY_SUMMARY]` digest messages using an LLM, leaving all other
+   * message types (user, assistant, tool) completely untouched.
+   *
+   * If no digest messages are found, or if their combined token count already fits
+   * within `capTokens`, the original messages are returned unchanged with no API call.
+   *
+   * @param messages     Full conversation message sequence (digests interleaved with others)
+   * @param tokenCounter Token counter calibrated to the target model's tokenizer
+   * @param llmClient    LLM client used to perform the compression inference call
+   * @param capTokens    Maximum allowed tokens for all digest messages combined
+   * @return             Compressed messages on success, or a
+   *                     [[org.llm4s.error.ContextError]] if the LLM call fails
    */
   def squeezeDigest(
     messages: Seq[Message],
@@ -316,7 +358,17 @@ object LLMCompressor {
 }
 
 /**
- * Result of LLM-powered compression process
+ * Result of a legacy full-conversation LLM compression operation.
+ *
+ * Produced by the deprecated [[LLMCompressor.compress]] method. Prefer
+ * [[LLMCompressor.squeezeDigest]] for the current pipeline.
+ *
+ * @param conversation     The compressed conversation
+ * @param originalTokens   Token count before compression
+ * @param compressedTokens Token count after compression
+ * @param compressionRatio `compressedTokens / originalTokens` (lower = more compressed)
+ * @param targetBudget     The token budget this compression was targeting
+ * @param budgetAchieved   `true` if `compressedTokens <= targetBudget` after compression
  */
 case class LLMCompressedConversation(
   conversation: Conversation,


### PR DESCRIPTION
## Fixes #950

### Overview

Added the missing ScalaDoc for context compression classes to make the 4-stage context management pipeline easier to understand for developers.

### Changes Made

**[LLMCompressor.scala](file:///c:/llm4s/modules/core/src/main/scala/org/llm4s/context/LLMCompressor.scala)**
- Replaced the minimal object comment with a comprehensive ScalaDoc covering:
  - **When to Use**: High quality, long-running conversations
  - **When NOT to Use**: Latency-critical or cost-sensitive paths
  - **Cost**: 1 LLM API call per digest message
  - **Pipeline Position**: Explicitly documented as Step 3 in the 4-stage pipeline
- Added missing `@param` tags to `squeezeDigest`
- Added missing `@param` tags to the legacy `LLMCompressedConversation` class

**[ContextManager.scala](file:///c:/llm4s/modules/core/src/main/scala/org/llm4s/context/ContextManager.scala)**
- Promoted the plain-text pipeline comment to a formal class-level ScalaDoc.
- Added a **Compressor Comparison** table detailing Cost, Quality, Latency, and exactly what each strategy modifies.
- Documented the 4-step pipeline explicitly, adding `[[...]]` cross-references to the respective compressor classes.
- Added a `==Usage==` example.

*(Note: `DeterministicCompressor.scala` and `HistoryCompressor.scala` were already well-documented and required no changes.)*

### Pre-submission Checklist

- [x] All 3 compressor classes have class-level ScalaDoc
- [x] Each explains when to use it vs the alternatives
- [x] Comparison table added to `ContextManager` ScalaDoc
- [x] `sbt doc` generates without warnings (all symbol references are valid)
- [x] Scalafmt applied to format the new ScalaDocs correctly
