### PR TITLE
chore(build): update dependencies and fix Docker image apt-key removal

### DIFF
--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
@@ -587,18 +587,38 @@ curl https://api.anthropic.com/v1/messages \
   private def serializeStreamEvent(event: RawMessageStreamEvent): String =
     ObjectMappers.jsonMapper().writeValueAsString(event)
 
-  // NOTE: anthropic-java 2.42 deprecated `temperature` entirely — models released after
-  // Claude Opus 4.6 reject any value other than 1.0 with a 400 error. We still set it for the
-  // older models that do support it, so the (unavoidable) deprecation warning is suppressed here.
-  // TODO: gate temperature on model capability and drop this once legacy models are unsupported.
+  // anthropic-java 2.42 deprecated `temperature`: models released after Claude Opus 4.6
+  // reject any value other than 1.0 with a 400 error. We omit the parameter entirely for
+  // those models so that even a default `CompletionOptions()` (temperature 0.7) works;
+  // models that still accept it receive the configured value. The deprecation warning is
+  // unavoidable on the supported-model path, hence the suppression.
+  //
+  // Anthropic rejects some requests that specify both temperature and top_p, so we prefer
+  // temperature as the single sampling control for our default path.
   @scala.annotation.nowarn("cat=deprecation")
   private def applySamplingParameters(
     builder: MessageCreateParams.Builder,
     options: CompletionOptions
   ): Unit =
-    // Anthropic rejects some requests that specify both temperature and top_p.
-    // Prefer temperature as the single sampling control for our default path.
-    builder.temperature(options.temperature.doubleValue())
+    if (modelSupportsTemperature)
+      builder.temperature(options.temperature.doubleValue())
+
+  /**
+   * Whether `config.model` accepts the (deprecated) `temperature` sampling parameter.
+   *
+   * A model-registry capability override (`disallowedParams` containing `"temperature"`)
+   * takes precedence; otherwise we fall back to a name-based check for the Anthropic models
+   * that dropped sampling support (Claude Opus 4.7 and newer).
+   */
+  private def modelSupportsTemperature: Boolean = {
+    val disallowedByRegistry =
+      registryService
+        .lookup(config.model)
+        .toOption
+        .flatMap(_.capabilities.disallowedParams)
+        .exists(_.contains("temperature"))
+    !disallowedByRegistry && !AnthropicClient.rejectsSamplingTemperature(config.model)
+  }
 
   override protected def releaseResources(): Unit =
     client.close()
@@ -628,6 +648,37 @@ curl https://api.anthropic.com/v1/messages \
 
 object AnthropicClient {
   import org.llm4s.types.TryOps
+
+  /**
+   * Whether an Anthropic model rejects the deprecated `temperature` sampling parameter.
+   *
+   * anthropic-java 2.42 deprecated `temperature`: models released after Claude Opus 4.6
+   * accept only `1.0` and return a 400 for any other value. We detect those models by name
+   * (Claude Opus 4.7+ and any Opus 5+) so the parameter can be omitted; this mirrors the
+   * name-based handling of O-series models in [[org.llm4s.model.DefaultRequestTransformer]].
+   * Other models can be flagged via a registry `disallowedParams = ["temperature"]` override.
+   *
+   * Model identifiers may carry a provider prefix and/or a date suffix
+   * (e.g. `anthropic/claude-opus-4-8`, `claude-opus-4-1-20250805`); only short (1-2 digit)
+   * leading segments after `opus-` are treated as version numbers so date suffixes such as
+   * `claude-opus-4-20250514` (Opus 4.0) and legacy names like `claude-3-opus-20240229` are
+   * not misread as high versions.
+   */
+  private[provider] def rejectsSamplingTemperature(model: String): Boolean = {
+    val normalized = model.toLowerCase
+    val marker     = "opus-"
+    val idx        = normalized.indexOf(marker)
+    if (idx < 0) false
+    else {
+      val parts = normalized.substring(idx + marker.length).split("-")
+      def shortVersion(s: String): Option[Int] =
+        if (s.length <= 2 && s.nonEmpty && s.forall(_.isDigit)) s.toIntOption else None
+      parts.headOption.flatMap(shortVersion).exists { major =>
+        val minor = parts.lift(1).flatMap(shortVersion).getOrElse(0)
+        major > 4 || (major == 4 && minor >= 7)
+      }
+    }
+  }
 
   /**
    * Constructs an [[AnthropicClient]], wrapping any construction-time

--- a/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
+++ b/modules/core/src/main/scala/org/llm4s/llmconnect/provider/AnthropicClient.scala
@@ -587,13 +587,18 @@ curl https://api.anthropic.com/v1/messages \
   private def serializeStreamEvent(event: RawMessageStreamEvent): String =
     ObjectMappers.jsonMapper().writeValueAsString(event)
 
+  // NOTE: anthropic-java 2.42 deprecated `temperature` entirely — models released after
+  // Claude Opus 4.6 reject any value other than 1.0 with a 400 error. We still set it for the
+  // older models that do support it, so the (unavoidable) deprecation warning is suppressed here.
+  // TODO: gate temperature on model capability and drop this once legacy models are unsupported.
+  @scala.annotation.nowarn("cat=deprecation")
   private def applySamplingParameters(
     builder: MessageCreateParams.Builder,
     options: CompletionOptions
   ): Unit =
     // Anthropic rejects some requests that specify both temperature and top_p.
     // Prefer temperature as the single sampling control for our default path.
-    builder.temperature(options.temperature.floatValue())
+    builder.temperature(options.temperature.doubleValue())
 
   override protected def releaseResources(): Unit =
     client.close()

--- a/modules/core/src/main/scala/org/llm4s/rag/loader/s3/S3DocumentSource.scala
+++ b/modules/core/src/main/scala/org/llm4s/rag/loader/s3/S3DocumentSource.scala
@@ -75,7 +75,7 @@ final case class S3DocumentSource(
     val builder = S3Client
       .builder()
       .region(Region.of(region))
-      .credentialsProvider(credentials.getOrElse(DefaultCredentialsProvider.create()))
+      .credentialsProvider(credentials.getOrElse(DefaultCredentialsProvider.builder().build()))
 
     endpointOverride.foreach { endpoint =>
       builder.endpointOverride(URI.create(endpoint))

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/search/BraveSearchTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/search/BraveSearchTool.scala
@@ -417,7 +417,7 @@ object BraveSearchTool {
             // Restore interrupt flag for proper thread shutdown and timeout semantics
             restoreInterrupt()
             Left("Response parsing was cancelled or interrupted.")
-          case _: ujson.ParseException =>
+          case e if isJsonParseFailure(e) =>
             Left("Failed to parse search results. The response format may be invalid.")
           case NonFatal(_) =>
             // Catch all other non-fatal exceptions

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/search/DuckDuckGoSearchTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/search/DuckDuckGoSearchTool.scala
@@ -223,7 +223,7 @@ object DuckDuckGoSearchTool {
             // Restore interrupt flag for proper thread shutdown and timeout semantics
             restoreInterrupt()
             Left("Response parsing was cancelled or interrupted.")
-          case _: ujson.ParseException =>
+          case e if isJsonParseFailure(e) =>
             Left("Failed to parse search results. The response format may be invalid.")
           case NonFatal(_) =>
             // Catch all other non-fatal exceptions

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/search/ExaSearchTool.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/search/ExaSearchTool.scala
@@ -462,7 +462,7 @@ object ExaSearchTool {
             // Restore interrupt flag for proper thread shutdown and timeout semantics
             restoreInterrupt()
             Left("Response parsing was cancelled or interrupted.")
-          case _: ujson.ParseException =>
+          case e if isJsonParseFailure(e) =>
             Left("Failed to parse search results. The response format may be invalid.")
           case NonFatal(_) =>
             // Catch all other non-fatal exceptions

--- a/modules/core/src/main/scala/org/llm4s/toolapi/builtin/search/package.scala
+++ b/modules/core/src/main/scala/org/llm4s/toolapi/builtin/search/package.scala
@@ -117,4 +117,20 @@ package org.llm4s.toolapi.builtin
  * }
  * }}}
  */
-package object search {}
+package object search {
+
+  /**
+   * Detects whether a thrown exception represents malformed JSON.
+   *
+   * upickle/ujson 4.4 routes reads through a tracing visitor, so a parse failure surfaces
+   * as `upickle.core.TraceVisitor$TraceException` with the original `ujson.ParseException`
+   * (or `ujson.IncompleteParseException`) as its cause rather than being thrown directly.
+   * Walking the cause chain for the shared `ujson.ParsingFailedException` interface keeps
+   * malformed-JSON detection working regardless of how the failure is wrapped.
+   */
+  private[search] def isJsonParseFailure(t: Throwable): Boolean =
+    Iterator
+      .iterate(t)(_.getCause)
+      .takeWhile(_ != null)
+      .exists(_.isInstanceOf[ujson.ParsingFailedException])
+}

--- a/modules/core/src/test/scala/org/llm4s/agent/AgentStateSerializationSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/AgentStateSerializationSpec.scala
@@ -73,16 +73,16 @@ class AgentStateSerializationSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  // upickle 4.4 routes reads through a tracing visitor, so the reader's
+  // IllegalArgumentException surfaces as the cause of the thrown exception.
   it should "throw on invalid string" in {
-    an[IllegalArgumentException] should be thrownBy {
-      read[ReasoningEffort](ujson.Str("invalid"))
-    }
+    val ex = intercept[Exception](read[ReasoningEffort](ujson.Str("invalid")))
+    ex.getCause shouldBe an[IllegalArgumentException]
   }
 
   it should "throw on non-string value" in {
-    an[IllegalArgumentException] should be thrownBy {
-      read[ReasoningEffort](ujson.Num(42))
-    }
+    val ex = intercept[Exception](read[ReasoningEffort](ujson.Num(42)))
+    ex.getCause shouldBe an[IllegalArgumentException]
   }
 
   // ==========================================================================

--- a/modules/core/src/test/scala/org/llm4s/llmconnect/provider/AnthropicTemperatureGatingSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/llmconnect/provider/AnthropicTemperatureGatingSpec.scala
@@ -1,0 +1,48 @@
+package org.llm4s.llmconnect.provider
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+/**
+ * Tests for [[AnthropicClient.rejectsSamplingTemperature]].
+ *
+ * anthropic-java 2.42 deprecated `temperature`: models released after Claude Opus 4.6
+ * reject any value other than 1.0 with a 400, so the client must omit the parameter for
+ * those models (Claude Opus 4.7+ and any Opus 5+) while still sending it for models that
+ * support it. See PR #1072 review feedback.
+ */
+class AnthropicTemperatureGatingSpec extends AnyFlatSpec with Matchers with TableDrivenPropertyChecks {
+
+  private val rejecting = Table(
+    "model",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-opus-4-8-20260101",
+    "anthropic/claude-opus-4-8",
+    "claude-opus-4-10",       // 4.10 > 4.6
+    "claude-opus-5",          // major bump
+    "claude-opus-5-20260101", // major bump with date suffix
+    "claude-opus-10-2"        // double-digit major
+  )
+
+  private val accepting = Table(
+    "model",
+    "claude-opus-4-6", // 4.6 still supports temperature ("after Opus 4.6")
+    "claude-opus-4-1", // older minor
+    "claude-opus-4-1-20250805",
+    "claude-opus-4-20250514", // Opus 4.0 with date suffix, NOT version 4.20250514
+    "claude-3-opus-20240229", // legacy naming: "opus-<date>", not a high version
+    "claude-sonnet-4-6",      // non-Opus models are not name-gated here
+    "claude-haiku-4-5",
+    "claude-opus-latest" // no parseable version
+  )
+
+  "rejectsSamplingTemperature" should "be true for Opus models that dropped sampling support" in {
+    forAll(rejecting)(model => AnthropicClient.rejectsSamplingTemperature(model) shouldBe true)
+  }
+
+  it should "be false for Opus 4.6 and earlier, date-suffixed base versions, and other models" in {
+    forAll(accepting)(model => AnthropicClient.rejectsSamplingTemperature(model) shouldBe false)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,44 +7,49 @@ object Dependencies {
 
 object Versions {
   val cats     = "2.13.0"
-  val upickle  = "4.2.1"
-  val logback  = "1.5.18"
-  val log4j    = "2.24.3"
+  val upickle  = "4.4.3"
+  val logback  = "1.5.34"
+  val log4j    = "2.26.0"
   val monocle  = "3.3.0"
   val termflow = "0.4.0"
-  val scalatest               = "3.2.19"
-  val scalamock               = "7.4.2"
+  val scalatest               = "3.2.20"
+  val scalamock               = "7.5.5"
   val scalatestplusScalacheck = "3.2.19.0"
-  val fansi    = "0.5.0"
-  val postgres = "42.7.3"
-  val sqlite   = "3.45.3.0"
-  val config   = "1.4.3"
+  val fansi    = "0.5.1"
+  val postgres = "42.7.11"
+  val sqlite   = "3.53.2.0"
+  val config   = "1.4.9"
+  // NOTE: HikariCP 7.x is available but is a 2-major jump (5->6->7) with a higher
+  // JDK baseline; held for separate review.
   val hikariCP = "5.1.0"
-  val pureconfig = "0.17.6"
+  val pureconfig = "0.17.10"
 
   val azureOpenAI = "1.0.0-beta.16"
-  val anthropic   = "2.11.1"
+  val anthropic   = "2.42.0"
   val jtokkit     = "1.1.0"
   val websocket   = "1.6.0"
-  val ujson       = "4.2.1"
-  val pdfbox      = "3.0.5"
-  val commonsIO   = "2.18.0"
-  val tika        = "3.2.1"
-  val poi         = "5.4.1"
-  val jsoup       = "1.21.1"
-  val jna         = "5.13.0"
+  val ujson       = "4.4.3"
+  val pdfbox      = "3.0.7"
+  val commonsIO   = "2.22.0"
+  val tika        = "3.3.1"
+  val poi         = "5.5.1"
+  val jsoup       = "1.22.2"
+  val jna         = "5.19.1"
   val vosk        = "0.3.45"
 
+  // NOTE: cask 0.11.x is available but 0.x minor bumps can be breaking; held for review.
   val cask       = "0.10.2"
 
   // AWS SDK
-  val awsSdk     = "2.29.51"
-  val opentelemetry = "1.34.1"
+  val awsSdk     = "2.46.14"
+  val opentelemetry = "1.63.0"
 
   // Prometheus (1.x stable)
-  val prometheus = "1.4.3"
+  val prometheus = "1.8.0"
 
   // Neo4j
+  // NOTE: neo4j-java-driver 6.x is available but is a major bump; held for separate
+  // review alongside the existing neo4j-harness/Netty compatibility constraint.
   val neo4j = "5.27.0"
 }
 

--- a/project/WorkspaceRunnerDocker.scala
+++ b/project/WorkspaceRunnerDocker.scala
@@ -15,13 +15,16 @@ object WorkspaceRunnerDocker {
   val devToolingCommands: Seq[CmdLike] = Seq(
     Cmd("USER", "root"),
     Cmd("RUN", "apt-get update && apt-get install -y curl gnupg apt-transport-https ca-certificates zip unzip"),
+    // Use the modern signed-by keyring approach. `apt-key` was deprecated long ago and
+    // is no longer present in recent base images (Ubuntu 24.04+/temurin), so piping the
+    // key into `apt-key add` fails with "apt-key: not found".
     Cmd(
       "RUN",
-      "echo 'deb https://repo.scala-sbt.org/scalasbt/debian all main' | tee /etc/apt/sources.list.d/sbt.list"
+      "curl -sL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823' | gpg --dearmor -o /usr/share/keyrings/scalasbt-keyring.gpg"
     ),
     Cmd(
       "RUN",
-      "curl -sL 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823' | apt-key add"
+      "echo 'deb [signed-by=/usr/share/keyrings/scalasbt-keyring.gpg] https://repo.scala-sbt.org/scalasbt/debian all main' | tee /etc/apt/sources.list.d/sbt.list"
     ),
     Cmd("RUN", "apt-get update && apt-get install -y sbt"),
     Cmd("RUN", "curl -s 'https://get.sdkman.io' | bash"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.0
+sbt.version=1.12.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"        % "2.5.4")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"        % "2.6.1")
 // Maven deployment
 addSbtPlugin("com.github.sbt" % "sbt-pgp"        % "2.3.1")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 addSbtPlugin("com.github.sbt" % "sbt-dynver"     % "5.1.1")
 // Cross-compilation support
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
@@ -10,7 +10,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
 addSbtPlugin("org.jmotor.sbt" % "sbt-dependency-updates" % "1.2.9")
 
 // Test coverage
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.12")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
 
 // Scalafix for linting and rewrites
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")


### PR DESCRIPTION
## Summary

Dependency updates plus a fix for the Docker image build failure that broke the 0.3.3 release.

### Dependency updates
Routine bumps across the build, plus `anthropic-java` 2.11.1 → **2.42.0**. Scala stays on **3.7.1**.

- **sbt** 1.11.0 → 1.12.12; plugins: scalafmt 2.6.1, ci-release 1.11.2, scoverage 2.3.1
- **anthropic-java** 2.42.0, upickle/ujson 4.4.3, logback 1.5.34, log4j 2.26.0, config 1.4.9, pureconfig 0.17.10, postgresql 42.7.11, sqlite 3.53.2.0, fansi 0.5.1, scalatest 3.2.20, scalamock 7.5.5, pdfbox 3.0.7, commons-io 2.22.0, tika 3.3.1, poi 5.5.1, jsoup 1.22.2, jna 5.19.1, AWS SDK 2.46.14, OpenTelemetry 1.63.0, Prometheus 1.8.0

**Deliberately held for separate review** (with inline notes in `Dependencies.scala`): HikariCP 7 (2-major jump + JDK baseline), neo4j-java-driver 6 (major), cask 0.11 (0.x breaking), and the scalafix pair 0.12 → 0.14 (new lint rules may fail CI). sbt 2.0.0 is also a deliberate future migration, not included.

### Source changes forced by the bumps
- **AWS SDK 2.46**: `DefaultCredentialsProvider.create()` → `.builder().build()` (the static factory is deprecated).
- **anthropic-java 2.42** deprecated `temperature` outright — *"models released after Claude Opus 4.6 reject any value other than 1.0 with a 400 error."* There is no non-deprecated replacement, so the call is suppressed with `@nowarn("cat=deprecation")` and a `TODO`. ⚠️ **Follow-up needed**: the client still always sends temperature and will 400 on the newest models; it should be gated on model capability.
- **upickle 4.4** now routes reads through a tracing visitor, so parse/reader failures surface as `upickle.core.TraceVisitor$TraceException` with the original (`ujson.ParseException` / `IllegalArgumentException`) as the cause. Added a shared `isJsonParseFailure` helper (walks the cause chain for `ujson.ParsingFailedException`) used by the Brave/DuckDuckGo/Exa search tools, and updated `AgentStateSerializationSpec` accordingly.

### Docker fix (resolves the 0.3.3 release failure)
The base image (`eclipse-temurin:21-jdk`, now Ubuntu 26.04-based) **removed the deprecated `apt-key`**, so the sbt-repo key step failed with `apt-key: not found` (exit 127). Switched to the modern keyring approach: `gpg --dearmor` into `/usr/share/keyrings/scalasbt-keyring.gpg` referenced via `signed-by=` in the sources list.

## Verification
- `core/compile` clean under `-Werror`.
- `core/test`: **6852 passed, 0 failed** (2 env-gated cancels).
- `scalafmtAll` applied; pre-commit hook passed.
- Docker fix verified with a full local `workspaceRunner/Docker/publishLocal` — built all 11 steps and tagged the image.