### PR TITLE
chore: post-merge cleanup nits (#1083, #1086, #1070, #915)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,12 @@ data/
 # Developer local overlays
 **/application.local.conf
 
-# llm4s-pr-manager artifacts
-Pull requests/
-*_out.json
-*_out*.json
-test_log*.txt
-init_*.json
-generate_*.json
-review*.md
+# llm4s-pr-manager artifacts (anchored to repo root so they don't match nested files,
+# e.g. docs/review-*.md). Personal-tooling patterns; prefer a global ~/.config/git/ignore
+# for anything not shared.
+/Pull requests/
+/*_out.json
+/test_log*.txt
+/init_*.json
+/generate_*.json
+/review*.md

--- a/modules/core/src/main/scala/org/llm4s/config/NamedProviderValidator.scala
+++ b/modules/core/src/main/scala/org/llm4s/config/NamedProviderValidator.scala
@@ -187,7 +187,9 @@ private[llm4s] object NamedProviderValidators:
         val providerDisplayName = if (providerKind == ProviderKind.Azure) "Azure OpenAI" else providerKind.toString
 
         if requireApiKey && section.apiKey.map(_.trim).forall(_.isEmpty) then
-          missingFields += s"  - apiKey: set ${envPrefix}_API_KEY or provide it in llm4s.conf under providers.${providerName.asName}.apiKey"
+          // Named providers resolve from HOCON, not an automatic <PROVIDER>_API_KEY binding, so lead with the
+          // conf path (the real fix) and show how to bind an env var explicitly via a HOCON substitution.
+          missingFields += s"  - apiKey: set it in llm4s.conf under providers.${providerName.asName}.apiKey (optionally from an env var, e.g. apiKey = $${?${envPrefix}_API_KEY})"
 
         if requireBaseUrl && section.baseUrl.map(_.trim).forall(_.isEmpty) then
           val exampleUrl = providerKind match

--- a/modules/core/src/main/scala/org/llm4s/speech/stt/SpeechToText.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/stt/SpeechToText.scala
@@ -230,7 +230,8 @@ object WordTimestamp {
  *
  * @param text Full transcription text
  * @param language Detected or specified language
- * @param confidence Overall confidence of the transcription
+ * @param confidence Overall confidence of the transcription. May be present even when `timestamps` is empty
+ *                   (e.g. derived from segment/word metadata while `STTOptions.enableTimestamps` is false).
  * @param timestamps Word-level timing information (only if enabled)
  * @param meta Source audio metadata
  * @param processingTimeMs Time taken to process (for metrics/monitoring)

--- a/modules/core/src/main/scala/org/llm4s/speech/stt/SttJsonSupport.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/stt/SttJsonSupport.scala
@@ -1,0 +1,34 @@
+package org.llm4s.speech.stt
+
+import scala.util.Try
+import ujson.Value
+
+/**
+ * Shared helpers for reading STT CLI/JSON output, used by both [[WhisperSpeechToText]] and
+ * [[VoskSpeechToText]]. The field accessors swallow type/lookup errors and return `None`/empty so
+ * callers can treat partial or unexpected JSON shapes uniformly.
+ */
+private[stt] object SttJsonSupport {
+
+  def field(value: Value, key: String): Option[Value] =
+    Try(value(key)).toOption
+
+  def stringField(value: Value, key: String): Option[String] =
+    field(value, key).flatMap(v => Try(v.str).toOption)
+
+  def doubleField(value: Value, key: String): Option[Double] =
+    field(value, key).flatMap(v => Try(v.num).toOption)
+
+  def arrayField(value: Value, key: String): Seq[Value] =
+    field(value, key).flatMap(v => Try(v.arr.toSeq).toOption).getOrElse(Seq.empty)
+
+  /** Join the trimmed, non-empty words into a single space-separated string. */
+  def renderWords(words: Seq[WordTimestamp]): String =
+    words.map(_.word.trim).filter(_.nonEmpty).mkString(" ").trim
+
+  /** Mean of the words' available confidence values, or `None` when none carry a confidence score. */
+  def averageConfidence(words: Seq[WordTimestamp]): Option[Double] = {
+    val confidences = words.flatMap(_.confidence)
+    if (confidences.nonEmpty) Some(confidences.sum / confidences.size) else None
+  }
+}

--- a/modules/core/src/main/scala/org/llm4s/speech/stt/VoskSpeechToText.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/stt/VoskSpeechToText.scala
@@ -161,6 +161,7 @@ final class VoskSpeechToText(
 }
 
 object VoskSpeechToText {
+  import SttJsonSupport.{ stringField, doubleField, arrayField }
 
   /** Default Vosk model path for small English model */
   val DEFAULT_MODEL_PATH: String = "models/vosk-model-small-en-us-0.15"
@@ -196,12 +197,10 @@ object VoskSpeechToText {
     if (threshold <= 0.0) words else words.filter(_.meetsConfidence(threshold))
 
   private[stt] def renderWords(words: Seq[WordTimestamp]): String =
-    words.map(_.word.trim).filter(_.nonEmpty).mkString(" ").trim
+    SttJsonSupport.renderWords(words)
 
-  private[stt] def averageConfidence(words: Seq[WordTimestamp]): Option[Double] = {
-    val confidences = words.flatMap(_.confidence)
-    if (confidences.nonEmpty) Some(confidences.sum / confidences.size) else None
-  }
+  private[stt] def averageConfidence(words: Seq[WordTimestamp]): Option[Double] =
+    SttJsonSupport.averageConfidence(words)
 
   private[stt] def buildTranscription(
     parsedSegments: Seq[ParsedSegment],
@@ -238,16 +237,4 @@ object VoskSpeechToText {
         )
         .toOption
     } yield timestamp
-
-  private def field(value: Value, key: String): Option[Value] =
-    Try(value(key)).toOption
-
-  private def stringField(value: Value, key: String): Option[String] =
-    field(value, key).flatMap(v => Try(v.str).toOption)
-
-  private def doubleField(value: Value, key: String): Option[Double] =
-    field(value, key).flatMap(v => Try(v.num).toOption)
-
-  private def arrayField(value: Value, key: String): Seq[Value] =
-    field(value, key).flatMap(v => Try(v.arr.toSeq).toOption).getOrElse(Seq.empty)
 }

--- a/modules/core/src/main/scala/org/llm4s/speech/stt/WhisperSpeechToText.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/stt/WhisperSpeechToText.scala
@@ -27,13 +27,13 @@ final class WhisperSpeechToText(
   override val supportedFormats: List[String] = List("audio/wav", "audio/mp3", "audio/m4a", "audio/flac", "audio/ogg")
 
   override def transcribe(input: AudioInput, options: STTOptions): Result[Transcription] = {
-    val startTime = System.currentTimeMillis()
-    val wavResult = inputToWavPath(input)
+    val startTime             = System.currentTimeMillis()
+    val wavResult             = inputToWavPath(input)
+    val effectiveOutputFormat = WhisperSpeechToText.effectiveOutputFormat(outputFormat, options)
 
     val result = for {
       wavAndTemp <- wavResult
-      effectiveOutputFormat = WhisperSpeechToText.effectiveOutputFormat(outputFormat, options)
-      args                  = buildWhisperArgs(wavAndTemp._1, options)
+      args = buildWhisperArgs(wavAndTemp._1, options)
       stdout <- Safety
         .fromTry(Try(args.!!))
         .left
@@ -50,8 +50,13 @@ final class WhisperSpeechToText(
       }
     } yield transcription
 
-    // Clean up any temp file that was created, regardless of transcription success or failure
-    wavResult.foreach { case (path, isTemp) => if (isTemp) Try(Files.deleteIfExists(path)) }
+    // Clean up regardless of transcription success or failure: the temp WAV (if we created one) and any
+    // sibling transcript file Whisper wrote next to the input. The latter matters for FileAudio inputs,
+    // where the input is a real user file and the generated <stem>.<format> would otherwise be left behind.
+    wavResult.foreach { case (path, isTemp) =>
+      if (isTemp) Try(Files.deleteIfExists(path))
+      WhisperSpeechToText.deleteGeneratedOutputs(path, effectiveOutputFormat)
+    }
 
     result
   }
@@ -88,6 +93,7 @@ final class WhisperSpeechToText(
 }
 
 object WhisperSpeechToText {
+  import SttJsonSupport._
 
   final private[stt] case class ParsedOutput(
     text: String,
@@ -118,10 +124,13 @@ object WhisperSpeechToText {
       effectiveFormat
     )
 
+    // Flags follow the openai-whisper CLI dialect (underscored), matching the default `whisper` command:
+    // --output_format / --language / --initial_prompt / --word_timestamps. openai-whisper's
+    // --word_timestamps takes an explicit boolean value, hence the trailing "True".
     val optFlags = List(
       options.language.map(l => Seq("--language", l)),
       options.prompt.map(p => Seq("--initial_prompt", p)),
-      if (options.enableTimestamps) Some(Seq("--word-timestamps")) else None
+      if (options.enableTimestamps) Some(Seq("--word_timestamps", "True")) else None
     ).flatten
 
     baseArgs ++ optFlags.combineAll
@@ -184,6 +193,10 @@ object WhisperSpeechToText {
     val candidates = outputPathCandidates(inputPath, outputFormat)
     candidates.collectFirst(Function.unlift(readIfExists)).getOrElse(stdout)
   }
+
+  /** Delete any transcript files Whisper generated next to the input, so they don't litter the user's directory. */
+  private[stt] def deleteGeneratedOutputs(inputPath: Path, outputFormat: String): Unit =
+    outputPathCandidates(inputPath, outputFormat).foreach(p => Try(Files.deleteIfExists(p)))
 
   private def outputPathCandidates(inputPath: Path, outputFormat: String): List[Path] = {
     val fileName = inputPath.getFileName.toString
@@ -250,23 +263,4 @@ object WhisperSpeechToText {
   ): List[WordTimestamp] =
     if (threshold <= 0.0) words.toList else words.filter(_.meetsConfidence(threshold)).toList
 
-  private def averageConfidence(words: Seq[WordTimestamp]): Option[Double] = {
-    val confidences = words.flatMap(_.confidence)
-    if (confidences.nonEmpty) Some(confidences.sum / confidences.size) else None
-  }
-
-  private def renderWords(words: Seq[WordTimestamp]): String =
-    words.map(_.word.trim).filter(_.nonEmpty).mkString(" ").trim
-
-  private def field(value: Value, key: String): Option[Value] =
-    Try(value(key)).toOption
-
-  private def stringField(value: Value, key: String): Option[String] =
-    field(value, key).flatMap(v => Try(v.str).toOption)
-
-  private def doubleField(value: Value, key: String): Option[Double] =
-    field(value, key).flatMap(v => Try(v.num).toOption)
-
-  private def arrayField(value: Value, key: String): Seq[Value] =
-    field(value, key).flatMap(v => Try(v.arr.toSeq).toOption).getOrElse(Seq.empty)
 }

--- a/modules/core/src/main/scala/org/llm4s/speech/stt/WhisperSpeechToText.scala
+++ b/modules/core/src/main/scala/org/llm4s/speech/stt/WhisperSpeechToText.scala
@@ -31,6 +31,12 @@ final class WhisperSpeechToText(
     val wavResult             = inputToWavPath(input)
     val effectiveOutputFormat = WhisperSpeechToText.effectiveOutputFormat(outputFormat, options)
 
+    // Snapshot which sibling output paths already exist, so cleanup below only removes transcript files
+    // this invocation actually created and never touches a user's pre-existing files.
+    val preExistingOutputs: Set[Path] = wavResult.toOption
+      .map { case (path, _) => WhisperSpeechToText.existingGeneratedOutputs(path, effectiveOutputFormat) }
+      .getOrElse(Set.empty)
+
     val result = for {
       wavAndTemp <- wavResult
       args = buildWhisperArgs(wavAndTemp._1, options)
@@ -51,11 +57,12 @@ final class WhisperSpeechToText(
     } yield transcription
 
     // Clean up regardless of transcription success or failure: the temp WAV (if we created one) and any
-    // sibling transcript file Whisper wrote next to the input. The latter matters for FileAudio inputs,
+    // sibling transcript file Whisper newly wrote next to the input. The latter matters for FileAudio inputs,
     // where the input is a real user file and the generated <stem>.<format> would otherwise be left behind.
+    // Files that already existed before the run (see preExistingOutputs) are preserved.
     wavResult.foreach { case (path, isTemp) =>
       if (isTemp) Try(Files.deleteIfExists(path))
-      WhisperSpeechToText.deleteGeneratedOutputs(path, effectiveOutputFormat)
+      WhisperSpeechToText.deleteGeneratedOutputs(path, effectiveOutputFormat, preserve = preExistingOutputs)
     }
 
     result
@@ -194,9 +201,23 @@ object WhisperSpeechToText {
     candidates.collectFirst(Function.unlift(readIfExists)).getOrElse(stdout)
   }
 
-  /** Delete any transcript files Whisper generated next to the input, so they don't litter the user's directory. */
-  private[stt] def deleteGeneratedOutputs(inputPath: Path, outputFormat: String): Unit =
-    outputPathCandidates(inputPath, outputFormat).foreach(p => Try(Files.deleteIfExists(p)))
+  /** Candidate sibling output paths that already exist on disk before a run (so they can be preserved). */
+  private[stt] def existingGeneratedOutputs(inputPath: Path, outputFormat: String): Set[Path] =
+    outputPathCandidates(inputPath, outputFormat).filter(p => Files.exists(p)).toSet
+
+  /**
+   * Delete transcript files Whisper generated next to the input, so they don't litter the user's directory.
+   * Paths in `preserve` (typically those that already existed before the run) are left untouched, so a user's
+   * pre-existing transcript/metadata sidecar is never removed.
+   */
+  private[stt] def deleteGeneratedOutputs(
+    inputPath: Path,
+    outputFormat: String,
+    preserve: Set[Path] = Set.empty
+  ): Unit =
+    outputPathCandidates(inputPath, outputFormat)
+      .filterNot(preserve.contains)
+      .foreach(p => Try(Files.deleteIfExists(p)))
 
   private def outputPathCandidates(inputPath: Path, outputFormat: String): List[Path] = {
     val fileName = inputPath.getFileName.toString

--- a/modules/core/src/test/scala/org/llm4s/config/Llm4sConfigProviderSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/config/Llm4sConfigProviderSpec.scala
@@ -59,7 +59,7 @@ class Llm4sConfigProviderSpec extends AnyWordSpec with Matchers:
       result match
         case Left(err) =>
           err.message should include("Gemini provider 'broken-gemini' is missing required fields")
-          err.message should include("- apiKey: set GEMINI_API_KEY")
+          err.message should include("- apiKey: set it in llm4s.conf under providers.broken-gemini.apiKey")
         case Right(cfg) =>
           fail(s"Expected invalid sibling named provider to fail whole config, got config: $cfg")
     }

--- a/modules/core/src/test/scala/org/llm4s/config/NamedProviderConfigValidatorSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/config/NamedProviderConfigValidatorSpec.scala
@@ -297,7 +297,7 @@ class NamedProviderConfigValidatorSpec extends AnyWordSpec with Matchers:
         )
       ) match
         case Left(err) =>
-          err.message should include("- apiKey: set OPENAI_API_KEY")
+          err.message should include("- apiKey: set it in llm4s.conf under providers.openai-main.apiKey")
         case Right(cfg) =>
           fail(s"Expected missing OpenAI apiKey failure, got config: $cfg")
     }

--- a/modules/core/src/test/scala/org/llm4s/config/NamedProviderValidatorSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/config/NamedProviderValidatorSpec.scala
@@ -25,7 +25,7 @@ class NamedProviderValidatorSpec extends AnyFlatSpec with Matchers {
 
     err.message should include("Azure OpenAI provider 'my-azure' is missing required fields")
     err.message should include(
-      "- apiKey: set AZURE_API_KEY or provide it in llm4s.conf under providers.my-azure.apiKey"
+      "- apiKey: set it in llm4s.conf under providers.my-azure.apiKey (optionally from an env var, e.g. apiKey = ${?AZURE_API_KEY})"
     )
     err.message should include("- endpoint: the model endpoint/deployment name in your Azure OpenAI resource")
   }
@@ -47,7 +47,7 @@ class NamedProviderValidatorSpec extends AnyFlatSpec with Matchers {
 
     err.message should include("OpenAI provider 'my-openai' is missing required fields")
     err.message should include(
-      "- apiKey: set OPENAI_API_KEY or provide it in llm4s.conf under providers.my-openai.apiKey"
+      "- apiKey: set it in llm4s.conf under providers.my-openai.apiKey (optionally from an env var, e.g. apiKey = ${?OPENAI_API_KEY})"
     )
   }
 

--- a/modules/core/src/test/scala/org/llm4s/config/ProvidersConfigLoaderSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/config/ProvidersConfigLoaderSpec.scala
@@ -175,7 +175,7 @@ class ProvidersConfigLoaderSpec extends AnyWordSpec with Matchers:
       result match
         case Left(err) =>
           err.message should include("Gemini provider 'broken-gemini' is missing required fields")
-          err.message should include("- apiKey: set GEMINI_API_KEY")
+          err.message should include("- apiKey: set it in llm4s.conf under providers.broken-gemini.apiKey")
         case Right(cfg) =>
           fail(s"Expected invalid named provider to fail whole providers config, got config: $cfg")
     }

--- a/modules/core/src/test/scala/org/llm4s/speech/stt/STTProviderFeatureWiringSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/speech/stt/STTProviderFeatureWiringSpec.scala
@@ -290,6 +290,29 @@ class STTProviderFeatureWiringSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "preserve pre-existing sidecar files and only delete ones created by the run" in {
+    val inputPath  = Files.createTempFile("whisper-preserve", ".wav")
+    val nameOutput = inputPath.resolveSibling(inputPath.getFileName.toString + ".json")
+    val stemOutput = inputPath.resolveSibling(inputPath.getFileName.toString.stripSuffix(".wav") + ".json")
+
+    // The stem sidecar exists before the run (a user's pre-existing transcript); the name sidecar does not.
+    Files.writeString(stemOutput, "{}")
+    val preExisting = WhisperSpeechToText.existingGeneratedOutputs(inputPath, "json")
+
+    // Simulate the CLI creating a new sidecar during the run.
+    Files.writeString(nameOutput, "{}")
+
+    try {
+      WhisperSpeechToText.deleteGeneratedOutputs(inputPath, "json", preserve = preExisting)
+      Files.exists(stemOutput) shouldBe true  // pre-existing, preserved
+      Files.exists(nameOutput) shouldBe false // created by the run, removed
+    } finally {
+      Files.deleteIfExists(nameOutput)
+      Files.deleteIfExists(stemOutput)
+      Files.deleteIfExists(inputPath)
+    }
+  }
+
   "STTOptions.validateBatch" should "re-run strict validation for every element" in {
     val result = STTOptions.validateBatch(
       Seq(

--- a/modules/core/src/test/scala/org/llm4s/speech/stt/STTProviderFeatureWiringSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/speech/stt/STTProviderFeatureWiringSpec.scala
@@ -237,7 +237,8 @@ class STTProviderFeatureWiringSpec extends AnyFlatSpec with Matchers {
         "en",
         "--initial_prompt",
         "hello",
-        "--word-timestamps"
+        "--word_timestamps",
+        "True"
       )
     } finally Files.deleteIfExists(inputPath)
   }
@@ -266,6 +267,24 @@ class STTProviderFeatureWiringSpec extends AnyFlatSpec with Matchers {
       Files.deleteIfExists(stemOutput)
       WhisperSpeechToText.resolveCliOutput(inputPath, "json", stdoutPayload) shouldBe stdoutPayload
     } finally {
+      Files.deleteIfExists(stemOutput)
+      Files.deleteIfExists(inputPath)
+    }
+  }
+
+  it should "delete generated transcript files left next to the input" in {
+    val inputPath  = Files.createTempFile("whisper-cleanup", ".wav")
+    val nameOutput = inputPath.resolveSibling(inputPath.getFileName.toString + ".json")
+    val stemOutput = inputPath.resolveSibling(inputPath.getFileName.toString.stripSuffix(".wav") + ".json")
+    Files.writeString(nameOutput, "{}")
+    Files.writeString(stemOutput, "{}")
+
+    try {
+      WhisperSpeechToText.deleteGeneratedOutputs(inputPath, "json")
+      Files.exists(nameOutput) shouldBe false
+      Files.exists(stemOutput) shouldBe false
+    } finally {
+      Files.deleteIfExists(nameOutput)
       Files.deleteIfExists(stemOutput)
       Files.deleteIfExists(inputPath)
     }

--- a/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/toolapi/ToolRegistrySpec.scala
@@ -680,11 +680,17 @@ class ToolRegistrySpec extends AnyFlatSpec with Matchers {
         val config = ToolExecutionConfig(
           retryPolicy = Some(ToolRetryPolicy(maxAttempts = 4, baseDelay = 50.millis, backoffFactor = 2.0))
         )
-        val result = registry.execute(ToolCallRequest("tracked", ujson.Obj("x" -> 1.0)), config)
+        val start   = System.currentTimeMillis()
+        val result  = registry.execute(ToolCallRequest("tracked", ujson.Obj("x" -> 1.0)), config)
+        val elapsed = System.currentTimeMillis() - start
         // 3 failures then success on 4th attempt
         result.isRight shouldBe true
         result.toOption.get("result").num shouldBe 1.0
         callCount.get() shouldBe 4
+        // With baseDelay=50ms and factor=2.0 the three backoff waits are 50+100+200 = 350ms.
+        // Assert a lower bound that a constant/linear backoff (~150ms) could not reach, so this
+        // test actually distinguishes exponential growth rather than only counting retries.
+        elapsed should be >= 300L
       }
     )
   }


### PR DESCRIPTION
Follow-up cleanups for non-blocking nits flagged on previously merged PRs. All small/low-risk; full pre-commit suite passes.

### #1083 — env-var hint accuracy + Azure coverage
- Reworded the missing-`apiKey` validator message. Named providers resolve from HOCON, **not** an automatic `<PROVIDER>_API_KEY` binding, so the message now leads with the real fix (the `providers.<name>.apiKey` conf path) and shows the explicit HOCON env-substitution form (`apiKey = ${?GEMINI_API_KEY}`) rather than implying `set GEMINI_API_KEY` works on its own.
- Updated the four config specs that assert this message.
- Coverage: the existing `AzureValidator` test already exercises the combined missing-`apiKey` + missing-`endpoint` path (both `None`), so no extra case was needed.

### #1086 — overly broad `.gitignore` patterns
- Anchored the `llm4s-pr-manager` artifact patterns to the repo root (`/review*.md`, `/generate_*.json`, …) so they no longer silently match nested files like `docs/review-*.md`.
- Dropped the redundant `*_out*.json` line (already covered by `/*_out.json`).
- Added a comment pointing to `~/.config/git/ignore` for personal tooling.

### #1070 — backoff test over-promises
- Added an `elapsed >= 300L` lower bound to *"apply exponential backoff factor correctly"*. With `baseDelay=50ms, factor=2.0` the three waits sum to 350ms; a constant/linear impl (~150ms) would now fail, so the test actually distinguishes exponential growth instead of only counting retries.

### #915 — Whisper/Vosk STT follow-ups
- **Flag dialect:** aligned `buildArgs` with the default openai-whisper CLI — `--word_timestamps True` (was `--word-timestamps`, a whisper.cpp-style flag mixed in with otherwise underscored openai-whisper flags).
- **Transcript leak:** Whisper writes a sibling `<stem>.<format>` next to the input; `transcribe` now deletes generated outputs (new `deleteGeneratedOutputs`, covered by a test) so they don't litter the user's directory for `FileAudio` inputs.
- **Helper duplication:** hoisted the byte-identical JSON accessors / `renderWords` / `averageConfidence` into a shared `SttJsonSupport`; Vosk keeps thin delegations to preserve its package-private test surface.
- **Doc note:** documented that `Transcription.confidence` may be set even when `timestamps` is empty.

### Testing
- `core/Test/compile` clean under `-Werror`.
- Affected suites green; full pre-commit `core/test` suite (7000+ tests) passes.