### PR TITLE
test: cover ProfanityFilter edge cases (#940)

### DIFF
--- a/modules/core/src/test/scala/org/llm4s/agent/guardrails/builtin/SimpleValidatorSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/agent/guardrails/builtin/SimpleValidatorSpec.scala
@@ -168,6 +168,38 @@ class SimpleValidatorSpec extends AnyFlatSpec with Matchers {
     filter.validate("this is forbiddenword").isLeft shouldBe true
   }
 
+  it should "detect custom bad words in case-sensitive mode" in {
+    val filter = ProfanityFilter.caseSensitive(Set("Forbidden"))
+    filter.validate("this is Forbidden").isLeft shouldBe true
+    filter.validate("this is forbidden") shouldBe Right("this is forbidden")
+  }
+
+  it should "behave like the default filter when given an empty custom set" in {
+    val filter = ProfanityFilter.withCustomWords(Set.empty)
+    filter.validate("badword here").isLeft shouldBe true
+    filter.validate("clean text here") shouldBe Right("clean text here")
+  }
+
+  it should "split on tabs and newlines as well as spaces" in {
+    val filter = new ProfanityFilter()
+    filter.validate("first\tbadword\tsecond").isLeft shouldBe true
+    filter.validate("first\nbadword\nsecond").isLeft shouldBe true
+  }
+
+  it should "detect a bad word after leading whitespace" in {
+    val filter = new ProfanityFilter()
+    // split("\\s+") yields an empty leading token; matching must still work
+    filter.validate("   badword").isLeft shouldBe true
+  }
+
+  it should "NOT detect bad words attached to punctuation (known limitation)" in {
+    val filter = new ProfanityFilter()
+    // Tokens are split on whitespace only, so trailing punctuation makes the
+    // token "badword." which is not an exact match against the word list.
+    filter.validate("that is a badword.") shouldBe Right("that is a badword.")
+    filter.validate("badword, indeed") shouldBe Right("badword, indeed")
+  }
+
   // -- Clean text --
 
   it should "pass through clean text unchanged" in {


### PR DESCRIPTION
## What does this PR do?

Adds edge-case tests for the `ProfanityFilter` guardrail.

While looking at #940 I found that `ProfanityFilter` already has coverage — it
lives in `SimpleValidatorSpec.scala` in the same package rather than a
standalone `ProfanityFilterSpec.scala`. (Same reason the issue's pointer to
`LengthCheckSpec.scala` 404s: `LengthCheck` is covered in that combined file
too.) Rather than duplicate the file, this adds the cases that weren't yet
covered:

- `caseSensitive` mode combined with `customBadWords` — previously untested together
- `withCustomWords(Set.empty)` falls back to default behaviour
- tab and newline separators (`split("\\s+")` handles these, but it wasn't asserted)
- a bad word after leading whitespace, where the split produces an empty first token
- punctuation-attached tokens — see below

**Known limitation documented, not fixed:** `validate` splits on whitespace
only, so `"badword."` and `"badword,"` don't match the word list. I've added a
test asserting current behaviour and labelled it a known limitation rather than
silently changing it. Happy to follow up with a fix (stripping punctuation, or a
word-boundary regex) if that's the preferred direction — it seemed like a
behaviour change that should be a maintainer call rather than folded into a
test-only PR.

Two items in #940's acceptance criteria also conflict with the implementation:
obfuscated variants (`"F*CK"`, `"f.u.c.k"`) aren't detectable given the
exact-token matching and two-word default list, and the error message
deliberately withholds the matched word for privacy — there's an existing test
asserting that.

## Related issue

Relates to #940

## How was this tested?

- `sbt "core/testOnly *SimpleValidatorSpec"` — passes
- `sbt scalafmtAll` — applied, no diff
- `sbt test` — full suite passes

## Checklist
- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt test` — tests pass on Scala 3
- [x] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"
- [ ] Updated `CHANGELOG.md` under `[Unreleased]` — N/A, tests only