### PR TITLE
[ENHANCEMENT] Add DCO sign-off check to CI

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,22 @@
+name: DCO
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  check_dco:
+    name: Check DCO sign-off
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run dco-check
+        uses: christophebedard/dco-check@0.5.0 # v0.5.0
+        with:
+          python-version: '3.12'
+          args: '--verbose'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,22 @@ Thank you for your interest in contributing to LLM4S!
 
 This project follows our [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold these standards.
 
+## Developer Certificate of Origin (DCO)
+
+All commits must be signed off to certify you have the right to submit the code under the project's [MIT license](LICENSE), per the [Developer Certificate of Origin](https://developercertificate.org/). Add the `Signed-off-by` trailer by committing with `-s`:
+
+```bash
+git commit -s -m "[FEATURE] Add my change"
+```
+
+If you forget, sign off your most recent commit with:
+
+```bash
+git commit --amend -s --no-edit
+```
+
+Pull requests are checked for DCO sign-off automatically in CI.
+
 ## Getting Started as a Contributor
 
 ### 1. Prerequisites checklist


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dco.yml`, running `christophebedard/dco-check` on every PR to `main` to verify all commits carry a valid `Signed-off-by:` trailer (Developer Certificate of Origin).
- Documents the sign-off requirement in `CONTRIBUTING.md`, including how to sign off and how to fix a forgotten sign-off (`git commit --amend -s --no-edit`).

## Why
Part of preparing LLM4S's [LF AI & Data project proposal](https://github.com/lfai/proposing-projects/pull/106), which asks whether DCO is enforced on the repo. The official GitHub "DCO" Marketplace app requires an org owner to interactively click install on https://github.com/apps/dco/installations/new — that step still needs to happen separately. This PR adds an equivalent, git-native CI check in the meantime (and works alongside the app if it's installed later).

## Test plan
- [ ] CI run on this PR itself exercises the new `DCO` workflow
- [ ] Confirm the check fails on an unsigned commit and passes once signed off