### PR TITLE
[DOCS] Add MAINTAINERS, GOVERNANCE, and RELEASES docs

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,28 @@
+# Governance
+
+LLM4S is an open-source project developed in public on GitHub. This document describes the project's roles and how decisions are made.
+
+## Roles
+
+### Contributor
+Anyone who submits a pull request, issue, or discussion to the project. No special access is required.
+
+### Committer
+A contributor who has been granted write access to the repository to merge pull requests, triage issues, and manage labels/milestones. Committers are proposed by a maintainer and approved by consensus of the existing maintainers, based on a sustained track record of quality contributions.
+
+### Maintainer
+A committer with overall responsibility for the project's direction, releases, and final decisions on contested changes. Maintainers can add/remove committers and other maintainers. The current list is in [MAINTAINERS.md](MAINTAINERS.md).
+
+## Decision Making
+
+- Most day-to-day decisions (code review, small features, bug fixes) are made by lazy consensus among committers and maintainers.
+- Larger or contested decisions (breaking changes, new maintainers/committers, project direction) require agreement from a majority of maintainers.
+- Disagreements that cannot be resolved through discussion are decided by maintainer vote.
+
+## Code of Conduct
+
+All participants are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md). Reports are handled by the maintainers as described there.
+
+## Changes to This Document
+
+Changes to governance are proposed via pull request against this file and require approval from a majority of maintainers.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,14 @@
+# Maintainers
+
+This file lists the maintainers of LLM4S. See [GOVERNANCE.md](GOVERNANCE.md) for how roles are defined and how maintainers are added.
+
+## Maintainers
+
+| Name | GitHub | Organization |
+|------|--------|--------------|
+| Kannupriya Kalra | [@kannupriyakalra](https://github.com/kannupriyakalra) | Independent |
+| Rory Graves | [@rorygraves](https://github.com/rorygraves) | Independent |
+
+## Becoming a Maintainer
+
+See the "Maintainer" role definition in [GOVERNANCE.md](GOVERNANCE.md#roles). Consistent, high-quality contributions over time are the primary criterion; new maintainers are proposed and approved by existing maintainers.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,20 @@
+# Release Process
+
+LLM4S follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`), e.g. `v0.3.4`.
+
+## How a Release Is Cut
+
+1. A maintainer pushes a tag matching `v[0-9]*` (e.g. `v0.3.5`) to `main`.
+2. This triggers the [Release workflow](.github/workflows/release.yml), which:
+   - Runs the full CI suite ([`ci.yml`](.github/workflows/ci.yml)) and blocks the release if it fails.
+   - Publishes artifacts to [Sonatype Central Portal](https://central.sonatype.com/) via `sbt ci-release`, using [sbt-dynver](https://github.com/sbt/sbt-dynver) to derive the version from the tag and GPG-signing artifacts.
+   - Builds and pushes the workspace-runner Docker image to [GitHub Container Registry](https://github.com/llm4s/llm4s/pkgs/container/workspace-runner), tagged with both the release version and `latest`.
+
+## Versioning
+
+- Version numbers are derived automatically from git tags via `sbt-dynver` — there is no manually maintained version file.
+- Published artifacts are cross-built for Scala 2.13 and 3.x (`sbt +publish` semantics via `sbt-ci-release`).
+
+## Release Notes
+
+Release notes are maintained as GitHub Releases against each tag: https://github.com/llm4s/llm4s/releases


### PR DESCRIPTION
## Summary
- Adds `MAINTAINERS.md` listing current maintainers (Kannupriya Kalra, Rory Graves).
- Adds `GOVERNANCE.md` defining contributor/committer/maintainer roles and how decisions are made.
- Adds `RELEASES.md` documenting the existing tag-triggered release process (`.github/workflows/release.yml`: CI gate → Sonatype Central publish via `sbt-ci-release`/`sbt-dynver` → Docker image push to GHCR).

## Why
These were gaps flagged while completing LLM4S's [LF AI & Data project proposal](https://github.com/lfai/proposing-projects/pull/106), which explicitly asks for MAINTAINERS.md, GOVERNANCE.md, and RELEASES.md.

## Test plan
- [ ] Review role/decision-making descriptions in GOVERNANCE.md for accuracy
- [ ] Confirm RELEASES.md matches actual release workflow behavior