### PR TITLE
Add LFX Mentorship 2026 project ideas

### DIFF
--- a/LFX Mentorship/Project Ideas/2026.md
+++ b/LFX Mentorship/Project Ideas/2026.md
@@ -1,0 +1,77 @@
+# LLM4S — LFX Mentorship Project Ideas (2026)
+
+Repository: https://github.com/llm4s/llm4s · Website: https://llm4s.org/
+
+### LLM4S
+
+#### Multi-Provider Failover & Request Hedging
+
+LLM4S: Multi-Provider Failover & Request Hedging (2026 Term)
+
+- Description: Production LLM apps need graceful degradation when a provider is slow, rate-limited, or down. LLM4S already has `ReliableClient` (retry, circuit breaker, deadlines), but does not yet offer a first-class multi-provider failover and hedging layer. This mentorship builds typed routing policies: primary → secondary failover on classified errors, latency-based hedging (race a backup after a timeout), sticky session affinity when needed, and clear attribution of which provider served each request. Policies must compose with existing `Result` error types and tracing so operators can see failover decisions in logs and OpenTelemetry spans.
+- Expected Outcome:
+  - Failover router with ordered provider chains and error-class based switching
+  - Optional request hedging (backup raced after configurable delay; first success wins; cancel loser)
+  - Circuit-breaker aware routing that skips open providers
+  - Per-request metadata: winning provider, attempts, hedge win/loss, latency
+  - Sample + docs for chat and agent runs under failover/hedge policies
+  - Tests with fake providers covering timeout, 429, 5xx, and partial stream failure
+- Recommended Skills: Scala, HTTP clients, resilience patterns, testing; OpenTelemetry familiarity helpful
+- Mentor(s):
+  - TBD (@github, email)
+- Upstream Issue: TBD
+- LFX URL: TBD
+
+#### Persistent Agent Session Store (Redis & Postgres)
+
+LLM4S: Persistent Agent Session Store — Redis & Postgres (2026 Term)
+
+- Description: Session serialization exists for agent state, but production services need pluggable durable stores so conversations and in-flight agent runs can be resumed across processes and restarts without a full workflow engine. This mentorship adds a `SessionStore` abstraction with Redis and Postgres backends: save/load agent sessions by id, TTL/expiry, optimistic concurrency, and optional snapshotting of conversation + tool history. It should integrate with existing session serialization and support a simple “continue conversation after restart” sample.
+- Expected Outcome:
+  - `SessionStore` API (get, put, delete, list/query by metadata) with `Result` errors
+  - Redis backend (TTL, atomic compare-and-set)
+  - Postgres backend (schema migration, indexes, optimistic locking)
+  - Integration with existing agent session serialization formats
+  - Sample service that resumes an agent mid-run after process restart
+  - Tests (Testcontainers or embedded) and docs for ops (retention, size limits)
+- Recommended Skills: Scala, Redis and/or SQL/Postgres, API design, testing
+- Mentor(s):
+  - TBD (@github, email)
+- Upstream Issue: TBD
+- LFX URL: TBD
+
+#### Voice-Native Agent Loop (STT → Agent → TTS)
+
+LLM4S: Voice-Native Agent Loop (2026 Term)
+
+- Description: LLM4S has multimodal speech APIs (STT/TTS), but there is no first-class voice agent loop in core that wires microphone/audio input → speech-to-text → agent/tool turn → text-to-speech response with barge-in and turn-taking. This mentorship builds a reusable voice session API and sample: stream or chunk audio in, run an agent turn (with tools), speak the reply, and handle cancel/interrupt. Provider speech backends should plug into existing clients where available, with a clear local-dev path.
+- Expected Outcome:
+  - Voice session API: start turn, stream audio, finalize utterance, run agent, synthesize reply
+  - Barge-in / interrupt support (stop TTS and accept new user speech)
+  - Integration with existing agent streaming events for tool-call status during a voice turn
+  - At least one STT and one TTS provider path wired end-to-end
+  - Sample CLI or local demo plus docs on latency, chunking, and privacy of audio
+  - Tests with mocked STT/TTS backends
+- Recommended Skills: Scala, audio/streaming basics, LLM agent APIs, testing
+- Mentor(s):
+  - TBD (@github, email)
+- Upstream Issue: TBD
+- LFX URL: TBD
+
+#### Web Knowledge Ingestion: Sitemaps, Concurrent Crawl & JS Rendering
+
+LLM4S: Web Knowledge Ingestion — Sitemaps, Concurrent Crawl & JS Rendering (2026 Term)
+
+- Description: The `WebCrawlerLoader` design for RAG ingestion is largely implemented (BFS crawl, robots.txt, rate limits, HTML extraction), but planned work remains: sitemap.xml discovery, concurrent/async crawling, and JavaScript-rendered pages. This mentorship finishes production-ready web knowledge ingestion for LLM4S RAG: parse sitemaps as seed sources, crawl concurrently with bounded parallelism, optionally render JS pages via a headless browser hook, and emit clean documents into the existing chunk/embed pipeline—with benchmarks and safety limits for large sites.
+- Expected Outcome:
+  - Sitemap.xml parser integrated as a seed source for `WebCrawlerLoader`
+  - Concurrent crawl with configurable parallelism, rate limits, and backpressure
+  - Optional JS-rendering backend (pluggable headless browser) for selected URL patterns
+  - Memory/perf improvements and limits for large crawls (documented thresholds)
+  - End-to-end sample: crawl docs site → chunk → embed → query
+  - Tests for sitemap parsing, concurrency bounds, and robots/exclusion rules
+- Recommended Skills: Scala, web crawling/HTTP, concurrency, RAG basics; Playwright/Puppeteer or similar helpful
+- Mentor(s):
+  - TBD (@github, email)
+- Upstream Issue: TBD
+- LFX URL: TBD


### PR DESCRIPTION
## What does this PR do?

Adds 4 LFX Mentorship 2026 project ideas for LLM4S in `LFX Mentorship/Project Ideas/2026.md`:

1. Multi-Provider Failover & Request Hedging
2. Persistent Agent Session Store (Redis & Postgres)
3. Voice-Native Agent Loop (STT → Agent → TTS)
4. Web Knowledge Ingestion (Sitemaps, Concurrent Crawl & JS Rendering)

These are formatted for the LFX Mentorship portal and are distinct from the existing GSoC 2026 idea list.

## Related issue

N/A (docs-only addition)

## How was this tested?

Docs-only change — no code or tests required.

## Checklist

- [x] I have read the [contributing guide](https://llm4s.org/reference/contributing)
- [x] This PR is focused (one concern) — or I explained why not
- [x] Code is formatted (`sbt scalafmtAll`) — N/A docs-only
- [x] Tests pass on Scala 3 (`sbt test`) — N/A docs-only
- [x] New tests added for new behavior — N/A docs-only
- [x] Branch is up to date with `main` (or rebased)
- [x] Commit messages are clear
- [ ] `CHANGELOG.md` updated (user-facing change) — optional for mentorship idea docs