### PR TITLE
Fill LFX mentorship project mentor contacts

### DIFF
--- a/LFX Mentorship/Project Ideas/2026.md
+++ b/LFX Mentorship/Project Ideas/2026.md
@@ -18,7 +18,8 @@ LLM4S: Multi-Provider Failover & Request Hedging (2026 Term)
   - Tests with fake providers covering timeout, 429, 5xx, and partial stream failure
 - Recommended Skills: Scala, HTTP clients, resilience patterns, testing; OpenTelemetry familiarity helpful
 - Mentor(s):
-  - TBD (@github, email)
+  - Rory Graves (@rorygraves, rory.graves@fieldmark.co.uk)
+  - Vamshi Salagala (@pavanvamsi3, pavanvamsi3@gmail.com)
 - Upstream Issue: TBD
 - LFX URL: TBD
 
@@ -36,7 +37,8 @@ LLM4S: Persistent Agent Session Store — Redis & Postgres (2026 Term)
   - Tests (Testcontainers or embedded) and docs for ops (retention, size limits)
 - Recommended Skills: Scala, Redis and/or SQL/Postgres, API design, testing
 - Mentor(s):
-  - TBD (@github, email)
+  - Atul S Khot (@atulkhot, atulkhot@gmail.com)
+  - Vitthal Mirji (@vim89, vitthalmirji@gmail.com)
 - Upstream Issue: TBD
 - LFX URL: TBD
 
@@ -54,7 +56,8 @@ LLM4S: Voice-Native Agent Loop (2026 Term)
   - Tests with mocked STT/TTS backends
 - Recommended Skills: Scala, audio/streaming basics, LLM agent APIs, testing
 - Mentor(s):
-  - TBD (@github, email)
+  - Giovanni Ruggiero (@gruggiero, giovanni.ruggiero@gmail.com)
+  - Debarshi Kundu (@debarshikundu, debarshi.iiest@gmail.com)
 - Upstream Issue: TBD
 - LFX URL: TBD
 
@@ -72,6 +75,7 @@ LLM4S: Web Knowledge Ingestion — Sitemaps, Concurrent Crawl & JS Rendering (20
   - Tests for sitemap parsing, concurrency bounds, and robots/exclusion rules
 - Recommended Skills: Scala, web crawling/HTTP, concurrency, RAG basics; Playwright/Puppeteer or similar helpful
 - Mentor(s):
-  - TBD (@github, email)
+  - Kannupriya Kalra (@kannupriyakalra, kannupriyakalra@gmail.com)
+  - Debarshi Kundu (@debarshikundu, debarshi.iiest@gmail.com)
 - Upstream Issue: TBD
 - LFX URL: TBD


### PR DESCRIPTION
## What does this PR do?

Fills mentor names, GitHub handles, and emails on the 4 LFX Mentorship 2026 project ideas in `LFX Mentorship/Project Ideas/2026.md` (replacing TBD placeholders):

1. Multi-Provider Failover & Request Hedging — Rory Graves, Vamshi Salagala
2. Persistent Agent Session Store (Redis & Postgres) — Atul S Khot, Vitthal Mirji
3. Voice-Native Agent Loop (STT → Agent → TTS) — Giovanni Ruggiero, Debarshi Kundu
4. Web Knowledge Ingestion — Kannupriya Kalra, Debarshi Kundu

## Related issue

Follow-up to #1107

## How was this tested?

Docs-only change — no code or tests required.

## Checklist

- [x] I have read the [contributing guide](https://llm4s.org/reference/contributing)
- [x] This PR is focused (one concern) — or I explained why not
- [x] Code is formatted (`sbt scalafmtAll`) — N/A docs-only
- [x] Tests pass on Scala 3 (`sbt test`) — N/A docs-only
- [x] New tests added for new behavior — N/A docs-only
- [x] Branch is up to date with `main` (or rebased)
- [x] Commit messages are clear
- [x] Commits are DCO signed-off (`Signed-off-by`)
- [ ] `CHANGELOG.md` updated (user-facing change) — optional for mentorship idea docs