### PR TITLE
Update LFX 2026 ideas with mentors and prep guide

### DIFF
--- a/LFX Mentorship/Project Ideas/2026.md
+++ b/LFX Mentorship/Project Ideas/2026.md
@@ -1,6 +1,56 @@
 # LLM4S — LFX Mentorship Project Ideas (2026)
 
+In this document, you can find project ideas proposed by the LLM4S Organization for [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/).
+
 Repository: https://github.com/llm4s/llm4s · Website: https://llm4s.org/
+
+## Application
+
+Our mentors are spread across the globe. You can connect with someone who works in your timezone while building a global network and exploring opportunities at international firms.
+
+If you are interested in becoming a contributor on any idea, please **join the [Discord community](https://discord.gg/YXSmPjDp)** and meet mentors at **Dev Hour**:
+
+- **When**: Every Sunday 9am London time
+- **Link**: [LLM4S Dev Hours (Luma calendar)](https://luma.com/calendar/cal-Zd9BLb5jbZewxLA)
+- **Subscribe**: [Add all 2026 Dev Hour events to your Google Calendar](https://api2.luma.com/ics/get?entity=calendar&id=cal-Zd9BLb5jbZewxLA)
+
+**Do NOT reach out to potential mentors using their project email.** Follow the stepwise instructions below instead.
+
+You can also read the official LFX Mentorship mentee guidance: [LFX Mentee Guide](https://docs.linuxfoundation.org/lfx/mentorship/mentee-guide) and browse open programs on the [LFX Mentorship portal](https://mentorship.lfx.linuxfoundation.org/).
+
+---
+
+## Stepwise Instructions to prepare for LFX 2026 with LLM4S
+
+1. [Join our Discord community.](https://lnkd.in/e2ifVzPc)
+2. Introduce yourself in the `#introduce-yourself` Discord channel.
+3. Create an account on the [LFX Mentorship portal](https://mentorship.lfx.linuxfoundation.org/) and complete your mentee profile (skills, GitHub, LinkedIn, resume).
+4. Attend LLM4S Dev Hour:
+   - We meet every Sunday 9am London time! (Weekly changing link for [LLM4S Dev Hours](https://luma.com/calendar/cal-Zd9BLb5jbZewxLA))
+   - [Subscribe to add all 2026 Dev Hour events to your Google Calendar.](https://api2.luma.com/ics/get?entity=calendar&id=cal-Zd9BLb5jbZewxLA)
+   - Show up regularly. Speak. Ask crisp questions. Clear your doubts. Discuss your ideas.
+5. Work in a pair-programming setup to enhance learning and productivity.
+   - Find a pair within the community if you don't already have one, and actively collaborate. Ask questions on Discord about any problems or findings. Every week pairs are shuffled to a new pair.
+6. Update your LinkedIn experience. Ensure your Discord profile contains both GitHub and LinkedIn links, and use a professional photo.
+   - Post your project contributions on LinkedIn and tag `@LLM4S Foundation`.
+7. Those who take initiative and help other aspirants in the community are given significant advantage for selection.
+8. Read the resources and understand LLM4S via this site: https://llm4s.org/
+9. Do not wait for permissions to create issues or raise PRs. Take inspiration from the production roadmap to create issues proactively. Also review the codebase — even if you find a small bug, create an issue and raise a PR for it.
+10. After raising a PR, make sure to ping maintainers in the Discord `#pr-review` channel.
+11. After raising issues, make sure to ping maintainers in the Discord `#creating-github-issues` channel. If the issue involves major fixes or enhancements, also discuss in `#design-discussions`.
+12. For the Production Roadmap, check out:
+    - [docs/reference/roadmap.md](../../docs/reference/roadmap.md)
+    - [docs/roadmap/llm4s-hardware-design-roadmap.md](../../docs/roadmap/llm4s-hardware-design-roadmap.md)
+13. Pick one of the LFX project ideas below, read its description and recommended skills, and start making small related contributions before applications open.
+14. When the program is accepting applications on LFX, apply via the [LFX Mentorship portal](https://mentorship.lfx.linuxfoundation.org/) for the LLM4S project you want. Upload any required materials (resume, cover letter, prior PRs).
+15. For more discussions and LFX-related questions, ask in the `#lfx-mentorship-program` Discord channel.
+16. **How to write a strong application**: Keep a work log, blog your learning journey, propose a clear 12-week timeline with milestones, and highlight merged PRs and Discord engagement. Read [Kannupriya Kalra's LinkedIn post on crafting a standout proposal](https://www.linkedin.com/posts/kannupriyakalra_googlesummerofcode-scala-gsoc-activity-7312659294762528769-nD5H?utm_source=share&utm_medium=member_desktop&rcm=ACoAAGOxmUkBXpbq_rJHiHkgGe_SPZ0l_-4rV_w)—the same habits help for LFX.
+
+Looking forward to your contributions to LLM4S!
+
+---
+
+## Project Ideas
 
 ### LLM4S
 
@@ -18,7 +68,7 @@ LLM4S: Multi-Provider Failover & Request Hedging (2026 Term)
   - Tests with fake providers covering timeout, 429, 5xx, and partial stream failure
 - Recommended Skills: Scala, HTTP clients, resilience patterns, testing; OpenTelemetry familiarity helpful
 - Mentor(s):
-  - Rory Graves (@rorygraves, rory.graves@fieldmark.co.uk)
+  - Rory Graves (@rorygraves, rory.graves@fieldmark.co.uk / rory@llm4s.org)
   - Vamshi Salagala (@pavanvamsi3, pavanvamsi3@gmail.com)
 - Upstream Issue: TBD
 - LFX URL: TBD
@@ -57,7 +107,7 @@ LLM4S: Voice-Native Agent Loop (2026 Term)
 - Recommended Skills: Scala, audio/streaming basics, LLM agent APIs, testing
 - Mentor(s):
   - Giovanni Ruggiero (@gruggiero, giovanni.ruggiero@gmail.com)
-  - Debarshi Kundu (@debarshikundu, debarshi.iiest@gmail.com)
+  - Iyad M Issa (iyadissa@gmail.com)
 - Upstream Issue: TBD
 - LFX URL: TBD
 
@@ -75,7 +125,7 @@ LLM4S: Web Knowledge Ingestion — Sitemaps, Concurrent Crawl & JS Rendering (20
   - Tests for sitemap parsing, concurrency bounds, and robots/exclusion rules
 - Recommended Skills: Scala, web crawling/HTTP, concurrency, RAG basics; Playwright/Puppeteer or similar helpful
 - Mentor(s):
-  - Kannupriya Kalra (@kannupriyakalra, kannupriyakalra@gmail.com)
-  - Debarshi Kundu (@debarshikundu, debarshi.iiest@gmail.com)
+  - Kannupriya Kalra (@kannupriyakalra, kannupriyakalra@gmail.com / kannupriya@llm4s.org)
+  - Iyad M Issa (iyadissa@gmail.com)
 - Upstream Issue: TBD
 - LFX URL: TBD


### PR DESCRIPTION
## What does this PR do?

Updates `LFX Mentorship/Project Ideas/2026.md`:

- Adds Application section and Stepwise Instructions to prepare for LFX 2026 with LLM4S (mirrors GSoC prep flow; Discord channel `#lfx-mentorship-program`)
- Adds secondary emails for Rory (`rory@llm4s.org`) and Kannupriya (`kannupriya@llm4s.org`)
- Replaces Debarshi Kundu with Iyad M Issa on Voice and Web Knowledge projects

## Related issue

Follow-up to #1107

## How was this tested?

Docs-only change — no code or tests required.

## Checklist

- [x] I have read the [contributing guide](https://llm4s.org/reference/contributing)
- [x] This PR is focused (one concern) — or I explained why not
- [x] Code is formatted (`sbt scalafmtAll`) — N/A docs-only
- [x] Tests pass on Scala 3 (`sbt test`) — N/A docs-only
- [x] New tests added for new behavior — N/A docs-only
- [x] Branch is up to date with `main` (or rebased)
- [x] Commit messages are clear
- [x] Commits are DCO signed-off (`Signed-off-by`)
- [ ] `CHANGELOG.md` updated (user-facing change) — optional for mentorship idea docs