### PR TITLE
Add ESoC 2026 project ideas for LLM4S

### DIFF
--- a/European Summer of Code/Project Ideas/2026.md
+++ b/European Summer of Code/Project Ideas/2026.md
@@ -1,0 +1,188 @@
+# LLM4S — European Summer of Code (ESoC) Project Ideas (2026)
+
+In this document, you can find project ideas proposed by the LLM4S Organization for [European Summer of Code 2026](https://github.com/european-summer-of-code/esoc2026).
+
+Repository: https://github.com/llm4s/llm4s · Website: https://llm4s.org/
+
+## Application
+
+Our mentors are spread across the globe. You can connect with someone who works in your timezone while building a global network and exploring opportunities at international firms.
+
+If you are interested in becoming a contributor on any idea, please **join the [Discord community](https://discord.com/invite/DjPMufnhG6)** and meet mentors at **Dev Hour**:
+
+- **When**: Every Sunday 9am London time
+- **Link**: [LLM4S Dev Hours (Luma calendar)](https://luma.com/calendar/cal-Zd9BLb5jbZewxLA)
+- **Subscribe**: [Add all 2026 Dev Hour events to your Google Calendar](https://api2.luma.com/ics/get?entity=calendar&id=cal-Zd9BLb5jbZewxLA)
+
+**Do NOT reach out to potential mentors using their project email.** Follow the stepwise instructions below instead.
+
+You can also read the official ESoC 2026 information and applicant guide: [european-summer-of-code/esoc2026](https://github.com/european-summer-of-code/esoc2026).
+
+---
+
+## Stepwise Instructions to prepare for ESoC 2026 with LLM4S
+
+1. [Join our Discord community.](https://discord.com/invite/DjPMufnhG6)
+2. Introduce yourself in the `#introduce-yourself` Discord channel.
+3. Read the [ESoC 2026 applicant guide and project list](https://github.com/european-summer-of-code/esoc2026) so you understand timelines, batches, and how to apply.
+4. Attend LLM4S Dev Hour:
+   - We meet every Sunday 9am London time! (Weekly changing link for [LLM4S Dev Hours](https://luma.com/calendar/cal-Zd9BLb5jbZewxLA))
+   - [Subscribe to add all 2026 Dev Hour events to your Google Calendar.](https://api2.luma.com/ics/get?entity=calendar&id=cal-Zd9BLb5jbZewxLA)
+   - Show up regularly. Speak. Ask crisp questions. Clear your doubts. Discuss your ideas.
+5. Work in a pair-programming setup to enhance learning and productivity.
+   - Find a pair within the community if you don't already have one, and actively collaborate. Ask questions on Discord about any problems or findings. Every week pairs are shuffled to a new pair. If you cannot find a pair, request one in Dev Hour, we really appreciate working in pair in this community so we all can learn from each other and credits for 2 people working on a ticket goes to both of them.
+6. Update your LinkedIn experience to add that you are "AI Engineer (OSS Developer) @ LLM4S Foundation. Ensure your Discord profile contains both GitHub and LinkedIn links, and use a professional photo so everyone in the global virtual community can identify you.
+   - Post your project contributions in form of code and other initiatives on LinkedIn and tag `@LLM4S Foundation`.
+7. Those who take initiative and help other aspirants in the community are given significant advantage for selection.
+8. Read the resources and understand LLM4S via this site: https://llm4s.org/
+9. Do not wait for permissions to create issues or raise PRs. Pick up "Good First Issues" or take inspiration from the production roadmap to create issues proactively. Also review the codebase — even if you find a small bug, create an issue and raise a PR for it.
+10. After raising a PR, make sure to ping maintainers in the Discord `#pr-review` channel.
+11. After raising issues, make sure to ping maintainers in the Discord `#creating-github-issues` channel. If the issue involves major fixes or enhancements, also discuss in `#design-discussions`.
+12. For the Production Roadmap, check out:
+    - [docs/reference/roadmap.md](../../docs/reference/roadmap.md)
+    - [docs/roadmap/llm4s-hardware-design-roadmap.md](../../docs/roadmap/llm4s-hardware-design-roadmap.md)
+13. Pick one of the ESoC project ideas below, read its description and recommended skills, and start making small related contributions before applications open.
+14. When the LLM4S ESoC project is accepting applications, follow the application steps listed for that project on [ESoC 2026](https://github.com/european-summer-of-code/esoc2026). Upload any required materials (resume, cover letter, prior PRs, proposal).
+15. For more discussions and ESoC-related questions, ask in the `#european-summer-of-code` Discord channel.
+16. **How to write a strong application**: Keep a work log, blog your learning journey, propose a clear timeline with milestones, and highlight merged PRs and Discord engagement. Read [Kannupriya Kalra's LinkedIn post on crafting a standout proposal](https://www.linkedin.com/posts/kannupriyakalra_googlesummerofcode-scala-gsoc-activity-7312659294762528769-nD5H?utm_source=share&utm_medium=member_desktop&rcm=ACoAAGOxmUkBXpbq_rJHiHkgGe_SPZ0l_-4rV_w)—the same habits help for ESoC.
+17. In every Dev Hour, show what you did the entire week, ask questions, seek help, that's the best place to unblock you, maintainers are making time to meet you every week, use it wisely.
+
+Looking forward to your contributions to LLM4S!
+
+---
+
+## Project Ideas
+
+### LLM4S
+
+#### 1. Durable Agent Workflows with Temporal
+
+LLM4S: Durable Agent Workflows with Temporal (ESoC 2026)
+
+- Description: LLM4S agents can run multi-step tool loops, but long-running work still fails on process crashes, timeouts, and restarts. The agent framework roadmap calls out durable execution and Temporal-style workflow integration as an open production gap. This project adds a Temporal-backed durable runner for LLM4S agents: checkpoint agent state across activities, resume after failure, support human approval steps as Temporal signals, and keep the existing immutable `AgentState` / `Result` model as the source of truth inside activities.
+- Expected Outcome:
+  - Temporal worker integration that runs LLM4S agent steps as durable activities
+  - Checkpoint / resume of serialized agent session state across retries and restarts
+  - Human-in-the-loop approval via Temporal signals (pause, approve, reject, amend)
+  - Idempotent tool-call handling guidance and helpers for safe retries
+  - Sample durable agent workflow with docs for local Temporal dev
+  - Tests covering crash recovery, replay of completed activities, and signal-driven resume
+- Recommended Skills: Scala, Temporal (or strong distributed workflow experience), agent/tool APIs, testing
+- Mentor(s):
+  - Rory Graves (@rorygraves, rory.graves@fieldmark.co.uk / rory@llm4s.org)
+  - Vamshi Salagala (@pavanvamsi3, pavanvamsi3@gmail.com)
+- Upstream Issue: TBD
+- ESoC URL: TBD
+
+#### 2. TermFlow Streaming Chat TUI
+
+LLM4S: TermFlow Streaming Chat TUI (ESoC 2026)
+
+- Description: LLM4S already depends on TermFlow for terminal UI samples, and there is a detailed handover spec for a production-feeling streaming chat client hosted in `llm4s`. This project implements that killer demo: a single-conversation TUI with streaming tokens, tool-call visualization, scrollback, theming, recoverable errors, and a stub-client test path. The result should be a README-ready sample users can run with an API key in under a minute.
+- Expected Outcome:
+  - Streaming chat TUI sample under `modules/samples` following the TermFlow chat demo spec
+  - Live token streaming, tool call start/complete rendering, scrollback and auto-tail
+  - Theme toggle, help overlay, clear-transcript, and clean quit/cancel behavior
+  - Deterministic tests using a stub LLM client and TermFlow test driver
+  - Docs: run instructions, keybindings, and screenshot suitable for linking from TermFlow
+- Recommended Skills: Scala, TUI / terminal apps, streaming APIs, testing; TermFlow or similar TUI experience helpful
+- Mentor(s):
+  - Dmitry Mamonov (@dmamonov, dmitry.s.mamonov@gmail.com)
+  - Iyad M Issa (iyadissa@gmail.com)
+- Upstream Issue: TBD
+- ESoC URL: TBD
+
+#### 3. Computer Use Tool for Agents
+
+LLM4S: Computer Use Tool for Agents (ESoC 2026)
+
+- Description: Leading agent SDKs ship a “computer use” style tool for screenshot, mouse, and keyboard control so agents can operate GUIs. LLM4S has a strong built-in tool library and workspace isolation, but no first-class computer-use capability. This project designs a safe, policy-gated computer-use tool surface (screenshot, click/type/scroll, optional window targeting) with strict allowlists, confirmation hooks for destructive actions, and Docker/workspace sandboxing where possible.
+- Expected Outcome:
+  - Computer-use tool API integrated with `ToolRegistry` (screenshot, click, type, scroll, wait)
+  - Safety model: default-deny, allowlisted targets, optional human confirmation for risky actions
+  - Sandbox / workspace guidance so agents cannot freely control the host by default
+  - One end-to-end sample agent completing a simple GUI workflow
+  - Tests with mocked display/input backends; docs covering threat model and setup
+- Recommended Skills: Scala, OS automation or UI testing APIs, security-conscious API design, agent tooling
+- Mentor(s):
+  - Vitthal Mirji (@vim89, vitthalmirji@gmail.com)
+  - Atul S Khot (@atulkhot, atulkhot@gmail.com)
+- Upstream Issue: TBD
+- ESoC URL: TBD
+
+#### 4. Agent-to-Agent (A2A) Protocol Interop
+
+LLM4S: Agent-to-Agent (A2A) Protocol Interop (ESoC 2026)
+
+- Description: LLM4S already supports handoffs and DAG multi-agent plans inside one process, but agents in other runtimes cannot call or be called using a shared wire protocol. Agent-to-Agent (A2A) is emerging as an interoperability standard for remote agent discovery, task delegation, and streaming status. This project adds A2A client and server support so a Scala agent can advertise skills, accept remote tasks, stream progress events, and delegate to external A2A agents—mapping cleanly onto existing handoff and streaming-event APIs.
+- Expected Outcome:
+  - A2A server that exposes an LLM4S agent (skill card, task create/status, streaming updates)
+  - A2A client used from LLM4S for remote delegation (alongside or instead of in-process handoff)
+  - Mapping between A2A task lifecycle and LLM4S agent streaming events / `AgentState`
+  - Auth and network binding safeguards consistent with MCP hardening practices
+  - Sample: two agents (local + remote stub) completing a delegated task
+  - Docs and contract tests for the supported A2A subset
+- Recommended Skills: Scala, HTTP/JSON APIs, protocol design, multi-agent systems, testing
+- Mentor(s):
+  - Giovanni Ruggiero (@gruggiero, giovanni.ruggiero@gmail.com)
+  - Kannupriya Kalra (@kannupriyakalra, kannupriyakalra@gmail.com / kannupriya@llm4s.org)
+- Upstream Issue: TBD
+- ESoC URL: TBD
+
+#### 5. Provider Capability Matrix & Fake-Provider Contract Tests
+
+LLM4S: Provider Capability Matrix & Fake-Provider Contract Tests (ESoC 2026)
+
+- Description: LLM4S supports many providers, but feature parity is uneven and hard to document accurately. Users cannot tell at a glance which providers support streaming, tools, structured output, reasoning modes, embeddings, multimodal, usage/cost reporting, or consistent timeout/retry behavior. This project builds a machine-readable provider capability model, fake-provider contract servers for the main protocol families, and generated docs that stay aligned with CI.
+- Expected Outcome:
+  - Typed capability model covering chat, streaming, tools, structured output, reasoning, embeddings, multimodal, timeouts/retries, usage/cost, and raw exchange logging
+  - Fake-provider contract servers (or fixtures) for at least OpenAI-compatible and Anthropic-style protocol families
+  - Automated contract test suite in CI that asserts declared capabilities against fake servers
+  - Generated provider capability matrix published in docs (and optionally as JSON for tooling)
+  - Sample showing how a new provider declares capabilities and gains contract coverage
+  - Documentation of limitations and how live smoke tests relate to fake-provider contracts
+- Recommended Skills: Scala, HTTP/JSON APIs, testing (ScalaTest), CI/CD, interest in LLM provider APIs
+- Mentor(s):
+  - Rory Graves (@rorygraves, rory.graves@fieldmark.co.uk / rory@llm4s.org)
+  - Atul S Khot (@atulkhot, atulkhot@gmail.com)
+- Upstream Issue: TBD
+- ESoC URL: TBD
+
+#### 6. MCP & Tool Security Hardening
+
+LLM4S: MCP & Tool Security Hardening (ESoC 2026)
+
+- Description: Tools and MCP (Model Context Protocol) are a production security boundary. LLM4S already has MCP client/server primitives, Streamable HTTP, HTTP+SSE, bearer-token auth, and public-bind protections, but production adopters need default-deny policies, allowlists, capability scoping, audit logs, and mitigations for prompt injection and tool poisoning. This project hardens the tool/MCP stack so agents start from safe defaults.
+- Expected Outcome:
+  - Default-deny policy model for tools, workspace/shell, file/network access, and MCP servers
+  - Allowlists and capability scoping (e.g., read-only tools, named MCP servers, network destinations)
+  - Structured audit logging for tool invocations and MCP sessions (success, failure, denied)
+  - Guardrails/guidance for prompt-injection and tool-poisoning scenarios (tests + docs)
+  - Sample: sandboxed tool-calling agent with MCP under explicit policy
+  - Threat-model section covering tools, MCP, RAG, workspace, and provider-log risks
+- Recommended Skills: Scala, security mindset, HTTP/auth basics, testing; familiarity with MCP or agent tool calling preferred
+- Mentor(s):
+  - Vamshi Salagala (@pavanvamsi3, pavanvamsi3@gmail.com)
+  - Iyad M Issa (iyadissa@gmail.com)
+- Upstream Issue: TBD
+- ESoC URL: TBD
+
+#### 7. Unified Cost & Token Telemetry
+
+LLM4S: Unified Cost & Token Telemetry (ESoC 2026)
+
+- Description: Production LLM applications need predictable spend. LLM4S has metrics, reliability wrappers, and tracing (console, Langfuse-style, OpenTelemetry), but cost and token accounting is not yet a single consistent story across chat completions, agent loops, embeddings, RAG retrieval, and multimodal operations. This project designs a unified usage/cost model that providers can populate, aggregates it at request/agent/session/RAG boundaries, and exports it through existing observability channels.
+- Expected Outcome:
+  - Shared usage/cost types spanning requests, agent runs, sessions, embeddings, RAG, and multimodal ops
+  - Provider adapters that normalize token/cost fields (and document gaps when providers omit them)
+  - Aggregation APIs for agent loops and RAG pipelines (per-step and total)
+  - OpenTelemetry/Prometheus-friendly metrics for latency, tokens, estimated cost, retries, and tool duration
+  - Optional cost budgets/limits hooks (warn or fail when session budget exceeded)
+  - Sample + docs showing how to attribute cost to a user/session and export to OTel
+  - Tests with fake providers asserting aggregation correctness
+- Recommended Skills: Scala, OpenTelemetry or Prometheus metrics, REST APIs, testing; interest in FinOps/LLM ops helpful
+- Mentor(s):
+  - Dmitry Mamonov (@dmamonov, dmitry.s.mamonov@gmail.com)
+  - Vitthal Mirji (@vim89, vitthalmirji@gmail.com)
+- Upstream Issue: TBD
+- ESoC URL: TBD


### PR DESCRIPTION
## Summary
- Add `European Summer of Code/Project Ideas/2026.md` with 7 LLM4S ESoC 2026 project ideas (distinct from LFX)
- Include Application section, stepwise prep instructions, Discord `#european-summer-of-code`, and rotated mentor pairs
- Reuse community links aligned with the LFX 2026 ideas doc

## Test plan
- [x] Docs-only: skim mentor emails and project titles for accuracy
- [x] Confirm Discord/Dev Hour/ESoC links open correctly
- [x] Confirm DCO check passes (`Signed-off-by` on commit)