### PR TITLE
ci: exempt bot accounts from DCO sign-off check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -17,6 +17,12 @@ jobs:
         uses: christophebedard/dco-check@0.5.0 # v0.5.0
         with:
           python-version: '3.12'
-          args: '--verbose'
+          # Exempt GitHub bot accounts (e.g. dependabot[bot]) from the DCO
+          # sign-off requirement: bots such as Dependabot cannot add
+          # Signed-off-by trailers to the commits they generate. Human
+          # contributors are still required to sign off.
+          args: >-
+            --verbose
+            --exclude-pattern "\[bot\]@users\.noreply\.github\.com$"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The DCO sign-off workflow (`.github/workflows/dco.yml`, added in 80c7d46c) uses `christophebedard/dco-check` to require a `Signed-off-by:` trailer on every commit in a PR. Dependabot does not add this trailer to the commits it generates, so **every** dependency-bump PR fails the "Check DCO sign-off" job — even though there is nothing a maintainer can do to "fix" a Dependabot commit's trailer.

This currently blocks four open Dependabot PRs, all green except for this one check:
- #1111
- #1113
- #1116
- #1124

Until this is fixed, every future dependency bump will land red as well.

## Fix

`dco-check` has its own built-in exemption mechanism for exactly this case: `--exclude-pattern <REGEX>`, which skips commits whose author email matches the given pattern (verified against the action's source at https://github.com/christophebedard/dco-check, tag `0.5.0`, which is the version already pinned in this workflow).

I used the action's own mechanism rather than a job-level `if:` guard on `github.actor`, because:
- It's the tool's supported, documented way to handle bot/service accounts, so it's more precise and self-documenting than skipping the whole job.
- It still runs the check on every PR (including bot PRs) and only ignores commits whose *author email* matches the bot pattern — so if a bot PR ever contained a mixed-authorship commit from a human, that commit would still be checked.

The pattern used is:

```
--exclude-pattern "\[bot\]@users\.noreply\.github\.com$"
```

This matches GitHub's standard bot-account email format (`<id>+<name>[bot]@users.noreply.github.com`), which covers `dependabot[bot]` (confirmed against PR #1111's commit author: `49699333+dependabot[bot]@users.noreply.github.com`) as well as any other `*[bot]` account (e.g. `github-actions[bot]`, `renovate[bot]`), per the task's "ideally any `*[bot]` account" goal.

## Human sign-off is still enforced

The regex is anchored to the `[bot]@users.noreply.github.com` suffix, so it does **not** match ordinary human commit-author emails (including personal `@users.noreply.github.com` addresses that lack the `[bot]` marker). A human PR with an unsigned commit will still fail this check exactly as before — I verified the pattern against sample bot and human emails locally before committing.

## Diff

Only `.github/workflows/dco.yml` changed — the `args` input passed to the `dco-check` action now includes `--exclude-pattern "\[bot\]@users\.noreply\.github\.com$"` alongside the existing `--verbose`.

Part of #1127 (slice 0, lane B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128YP9UhueHHpCRa8dyGyVC