### PR TITLE
build: per-module coverage floors with an explicit-decision CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,13 @@ jobs:
 
       - name: Run Scalafix
         run: sbt scalafixAll
-      
+
+      # Fails when any module declares neither a coverage floor nor an explicit opt-out.
+      # Coverage floors are per-module and never inherited, so a new (e.g. carved-out)
+      # module must make the decision visible in build.sbt rather than pick up a default.
+      - name: Check coverage policy is declared for every module
+        run: sbt coveragePolicyCheck
+
       - name: Compile
         run: sbt compile
 
@@ -156,14 +162,22 @@ jobs:
           PGVECTOR_PASSWORD: postgres
           PGVECTOR_TEST_USER: postgres
           PGVECTOR_TEST_PASSWORD: postgres
-        # Run coverage only for core to keep signal focused and CI fast
-        run: sbt coverage core/test coverageAggregate
+        # Run coverage only for core to keep signal focused and CI fast.
+        # `core/coverageReport` is what enforces core's per-module floor (build.sbt:
+        # coverageFloor(70)) - the aggregate report is informational only, since a
+        # build-wide average is not a meaningful gate. Each additional module that
+        # should be gated in CI adds its own `<module>/test <module>/coverageReport`.
+        run: sbt coverage core/test core/coverageReport coverageAggregate
 
+      # Tagged with the `core` flag because this job measures core only. A carve slice that
+      # starts measuring another module adds a separate upload step with that module's flag
+      # (and the matching flag definition in codecov.yml).
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/scala-3.7.1/scoverage-report/scoverage.xml,modules/*/target/scala-3.7.1/scoverage-report/scoverage.xml
+          flags: core
           slug: llm4s/llm4s
           fail_ci_if_error: false
           verbose: true

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import sbt.Keys._
 import scoverage.ScoverageKeys._
 import Common._
+import Coverage.{ coverageDisabled, coverageFloor, coveragePolicy }
 
 inThisBuild(
   List(
@@ -44,8 +45,11 @@ inThisBuild(
           "0.0.0-UNKNOWN"
       }
     },
-    ThisBuild / coverageMinimumStmtTotal := 50,
-    ThisBuild / coverageFailOnMinimum    := true,
+    // Coverage floors are per-module, never inherited: every project must declare either
+    // `coverageFloor(n)` or `coverageDisabled` (see project/Dependencies.scala -> Coverage).
+    // This build-level default is the "no decision made" marker that `coveragePolicyCheck`
+    // fails on, so a newly carved module cannot silently inherit somebody else's threshold.
+    ThisBuild / coveragePolicy           := Coverage.Policy.Undeclared,
     ThisBuild / coverageHighlighting     := true,
     ThisBuild / coverageExcludedPackages := Seq(
       "org\\.llm4s\\.runner\\..*",
@@ -125,6 +129,17 @@ lazy val commonSettings = Seq(
   )
 )
 
+// `coveragePolicy` is read reflectively by `coveragePolicyCheck` (via Project.extract),
+// so sbt's unused-setting lint cannot see the use.
+Global / excludeLintKeys += coveragePolicy
+
+// ---- coverage policy check ----
+// Fails the build when a module has neither a coverage floor nor an explicit opt-out.
+// The absence of a decision must be an error, not a silent default.
+lazy val coveragePolicyCheck = taskKey[Unit](
+  "Fail the build if any module has not explicitly declared a coverage floor or opt-out"
+)
+
 // ---- projects ----
 lazy val llm4s = (project in file("."))
   .aggregate(
@@ -140,13 +155,45 @@ lazy val llm4s = (project in file("."))
     benchmarks
   )
   .settings(
-    publish / skip := true
+    publish / skip := true,
+    // Root is an aggregator with no sources of its own. `coverageAggregate` runs here, and
+    // the per-module floors are enforced by each module's own `coverageReport`, so the
+    // aggregate number is reported but not gated (a build-wide average is exactly the kind
+    // of misleading single threshold this change removes).
+    coverageDisabled,
+    coveragePolicyCheck / aggregate := false,
+    coveragePolicyCheck := {
+      val log       = streams.value.log
+      val extracted = Project.extract(state.value)
+      val rows = extracted.structure.allProjectRefs
+        .map(ref => ref.project -> extracted.getOpt(ref / coveragePolicy).getOrElse(Coverage.Policy.Undeclared))
+        .sortBy(_._1)
+      val width = rows.map(_._1.length).max
+      log.info("Coverage policy per module:")
+      rows.foreach { case (id, policy) =>
+        log.info(s"  ${id.padTo(width, ' ')}  ${Coverage.describe(policy)}")
+      }
+      val undeclared = rows.collect { case (id, Coverage.Policy.Undeclared) => id }
+      if (undeclared.nonEmpty)
+        throw new MessageOnlyException(
+          s"""No coverage policy declared for: ${undeclared.mkString(", ")}
+             |Every module must make an explicit decision in build.sbt - coverage floors are
+             |never inherited. Add ONE of the following to the project's .settings(...):
+             |  coverageFloor(<pct>)  // measured statement coverage rounded DOWN to nearest 5
+             |  coverageDisabled      // with a comment saying why it is not measured
+             |Also add a codecov flag for the module in codecov.yml in the same commit.""".stripMargin
+        )
+    }
   )
 
 lazy val core = (project in file("modules/core"))
   .settings(
     name := "core",
     commonSettings,
+    // Measured 72.42% statement coverage (53,499 statements, 7004 tests) on main @ 5a62e2ac.
+    // Floor is the measured value rounded down to the nearest 5. Ratchet it up as the
+    // module is carved apart; never lower it.
+    coverageFloor(70),
     Test / fork := true,
     Test / javaOptions ++= Seq(
       "-Xmx2g", "-Xms512m",
@@ -209,7 +256,9 @@ lazy val workspaceShared = (project in file("modules/workspace/workspaceShared")
     name := "workspaceShared",
     commonSettings,
     Compile / discoveredMainClasses := Seq.empty,
-    coverageEnabled := false
+    // Not measured: excluded via ThisBuild / coverageExcludedPackages (org.llm4s.workspace.*)
+    // and exercised only by containerised integration tests.
+    coverageDisabled
   )
 
 lazy val workspaceClient = (project in file("modules/workspace/workspaceClient"))
@@ -218,7 +267,9 @@ lazy val workspaceClient = (project in file("modules/workspace/workspaceClient")
     name := "workspaceClient",
     commonSettings,
     Compile / discoveredMainClasses := Seq.empty,
-    coverageEnabled := false,
+    // Not measured: excluded via ThisBuild / coverageExcludedPackages (org.llm4s.workspace.*)
+    // and exercised only by containerised integration tests.
+    coverageDisabled,
     libraryDependencies ++= Seq(
       Deps.azureOpenAI,
       Deps.anthropic,
@@ -254,7 +305,9 @@ lazy val workspaceRunner = (project in file("modules/workspace/workspaceRunner")
       Deps.hikariCP
     ),
     publish / skip := true,
-    coverageEnabled := false
+    // Not measured: Docker entry point, excluded via ThisBuild / coverageExcludedPackages
+    // (org.llm4s.runner.*) and exercised only by containerised integration tests.
+    coverageDisabled
   )
   .settings(WorkspaceRunnerDocker.settings)
 
@@ -264,7 +317,9 @@ lazy val samples = (project in file("modules//samples"))
     name := "samples",
     commonSettings,
     publish / skip := true,
-    coverageEnabled := false,
+    // Not measured: unpublished example code, excluded via ThisBuild / coverageExcludedPackages
+    // (org.llm4s.samples.*). Samples are compile-checked, not covered.
+    coverageDisabled,
     libraryDependencies += Deps.termflow
   )
 
@@ -274,7 +329,9 @@ lazy val configPolicy = (project in file("modules/config-policy"))
     name := "llm4s-config-policy",
     commonSettings,
     publish / skip := true,
-    coverageEnabled := false,
+    // Not measured: unpublished CLI tooling, verified end-to-end by the
+    // config-policy-check CI job rather than by unit-test coverage.
+    coverageDisabled,
     // Env-var-based engine CLI (EnvCheckPolicies) calls sys.exit, so its runMain
     // is forked. Keep the forked working directory at the repo root so the
     // catalog engine's relative --config paths (CheckPolicies) still resolve.
@@ -292,7 +349,8 @@ lazy val workspaceSamples = (project in file("modules/workspace/workspaceSamples
     name := "workspaceSamples",
     commonSettings,
     publish / skip := true,
-    coverageEnabled := false
+    // Not measured: unpublished example code for the workspace modules.
+    coverageDisabled
   )
 
 lazy val traceOpentelemetry = (project in file("modules/trace-opentelemetry"))
@@ -300,6 +358,12 @@ lazy val traceOpentelemetry = (project in file("modules/trace-opentelemetry"))
   .settings(
     name := "trace-opentelemetry",
     commonSettings,
+    // Measured 0.00% statement coverage (`sbt coverage traceOpentelemetry/test
+    // traceOpentelemetry/coverageReport`): the module has no in-module tests at all, its
+    // only suite is modules/it/.../OpenTelemetryTracingSpec, which needs a live collector.
+    // Floor is the measured value rounded down to the nearest 5, i.e. 0 - measurement stays
+    // ON so the number is visible, and the floor ratchets up as soon as unit tests land here.
+    coverageFloor(0),
     libraryDependencies ++= Seq(
       Deps.opentelemetryApi,
       Deps.opentelemetrySdk,
@@ -317,10 +381,9 @@ lazy val knowledgegraphNeo4j = (project in file("modules/knowledgegraph-neo4j"))
       Deps.neo4jDriver,
       Deps.scalatest % Test
     ),
-    // Enforce ≥80% statement coverage when running with `sbt coverage test`
-    // for the unit-test suite that ships with this module.
-    coverageMinimumStmtTotal := 80,
-    coverageFailOnMinimum    := true
+    // Enforce >=80% statement coverage when running with `sbt coverage test`
+    // for the unit-test suite that ships with this module. Pre-existing gate, unchanged.
+    coverageFloor(80)
   )
 
 lazy val it = (project in file("modules/it"))
@@ -329,6 +392,11 @@ lazy val it = (project in file("modules/it"))
     name := "it",
     commonSettings,
     publish / skip := true,
+    // Not measured: `modules/it` has no src/main at all - it is a test-only host for
+    // integration/smoke suites that exercise the OTHER modules' code, so its own
+    // statement count is zero and any floor would be meaningless. It gets a real
+    // policy (and a codecov flag) when it is populated with sources in a later slice.
+    coverageDisabled,
     Test / fork := true,
     libraryDependencies ++= Seq(
       Deps.scalatest % Test
@@ -342,6 +410,12 @@ lazy val benchmarks = (project in file("modules/benchmarks"))
     name           := "benchmarks",
     commonSettings,
     publish / skip := true,
+    // Measured 100.00% statement/branch coverage (`sbt coverage benchmarks/test
+    // benchmarks/coverageReport`): BenchmarkSmokeTest deliberately instantiates and runs
+    // every JMH benchmark. Floor is the measured value rounded down to the nearest 5, i.e.
+    // 100, which encodes exactly that policy - a new benchmark must be added to the smoke
+    // test. (Codecov ignores modules/benchmarks; this is a build-side gate only.)
+    coverageFloor(100),
     libraryDependencies ++= Seq(
       Deps.scalatest % Test
     )

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,17 +12,63 @@ coverage:
         target: 90%
         threshold: 5%
 
-# Coverage flags for per-module tracking
-# Only track main source code (not tests or resources)
+# Coverage flags: one flag per sbt module, mirroring the per-module coverage floors
+# declared in build.sbt (see `coverageFloor` / `coverageDisabled` there).
+#
+# REQUIRED WHEN CARVING A MODULE OUT OF core:
+#   every carve slice MUST add the new module's flag here in the same commit that adds
+#   the module to build.sbt. Codecov only attributes a file to a flag whose `paths`
+#   contain it - a path covered by no flag is silently untracked rather than failing,
+#   so a missing flag makes carved-out code disappear from per-module reporting instead
+#   of turning red. The build-side equivalent (`sbt coveragePolicyCheck`) fails loudly
+#   when a module declares no coverage floor; this file has no such guard, so it is on
+#   the carve PR to keep the two in step.
+#
+# Only main source code is tracked (not tests or resources).
+# `carryforward: true` keeps the last known coverage for a flag when a CI run does not
+# upload that module (CI currently runs coverage for `core` only).
 flags:
   core:
     paths:
       - modules/core/src/main/scala
     carryforward: true
-  workspace:
+  knowledgegraph-neo4j:
     paths:
-      - modules/workspace/*/src/main/scala
+      - modules/knowledgegraph-neo4j/src/main/scala
     carryforward: true
+  trace-opentelemetry:
+    paths:
+      - modules/trace-opentelemetry/src/main/scala
+    carryforward: true
+  # Modules below declare `coverageDisabled` in build.sbt (unpublished tooling, samples,
+  # or containerised workspace code). Flags are declared anyway so that any coverage that
+  # does get uploaded is attributed to the right module rather than going untracked.
+  config-policy:
+    paths:
+      - modules/config-policy/src/main/scala
+    carryforward: true
+  samples:
+    paths:
+      - modules/samples/src/main/scala
+    carryforward: true
+  workspace-shared:
+    paths:
+      - modules/workspace/workspaceShared/src/main/scala
+    carryforward: true
+  workspace-client:
+    paths:
+      - modules/workspace/workspaceClient/src/main/scala
+    carryforward: true
+  workspace-runner:
+    paths:
+      - modules/workspace/workspaceRunner/src/main/scala
+    carryforward: true
+  workspace-samples:
+    paths:
+      - modules/workspace/workspaceSamples/src/main/scala
+    carryforward: true
+  # modules/it has no src/main today (test-only host for integration suites); it gets a
+  # flag when it is populated with sources. modules/benchmarks is ignored above.
 
 # PR comment configuration
 comment:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -125,3 +125,64 @@ object Common {
   def scalacOptionsForVersion(scalaVersion: String): Seq[String] =
     scala3CompilerOptions
 }
+
+/**
+ * Per-module coverage policy.
+ *
+ * Every project in the build must make an explicit decision: either a statement-coverage
+ * floor (`coverageFloor(n)`) or an explicit opt-out (`coverageDisabled`). There is
+ * deliberately no inherited default - `ThisBuild / coveragePolicy` is `Undeclared`, and
+ * the root `coveragePolicyCheck` task fails the build for any project still sitting on it.
+ * That way a newly carved module cannot silently inherit somebody else's threshold.
+ *
+ * Floors are set from a measured baseline rounded DOWN to the nearest 5, so a module has
+ * headroom for normal churn. Floors ratchet upward over time; they are never lowered.
+ */
+object Coverage {
+  import scoverage.ScoverageKeys
+
+  sealed trait Policy
+  object Policy {
+
+    /** No decision has been made for this project - `coveragePolicyCheck` treats this as an error. */
+    case object Undeclared extends Policy
+
+    /** Statement coverage must stay at or above `pct` percent. */
+    final case class Floor(pct: Int) extends Policy
+
+    /** Coverage is deliberately not measured for this project. */
+    case object Disabled extends Policy
+  }
+
+  val coveragePolicy: SettingKey[Policy] =
+    settingKey[Policy]("Explicit per-module coverage policy (floor or deliberate opt-out)")
+
+  /**
+   * Require at least `pct`% statement coverage for this module, failing the build below it.
+   * A floor of 0 is a legitimate (measured) declaration for a module whose tests live
+   * elsewhere - it keeps coverage measured and reported, and is ratcheted up once the
+   * module grows its own tests.
+   */
+  def coverageFloor(pct: Int): Seq[Def.Setting[_]] = {
+    require(pct >= 0 && pct <= 100, s"coverage floor must be in 0..100, got $pct")
+    Seq(
+      coveragePolicy                         := Policy.Floor(pct),
+      ScoverageKeys.coverageMinimumStmtTotal := pct.toDouble,
+      ScoverageKeys.coverageFailOnMinimum    := true
+    )
+  }
+
+  /** Deliberately exclude this module from coverage measurement. */
+  val coverageDisabled: Seq[Def.Setting[_]] = Seq(
+    coveragePolicy                      := Policy.Disabled,
+    ScoverageKeys.coverageEnabled       := false,
+    ScoverageKeys.coverageFailOnMinimum := false
+  )
+
+  /** Human-readable rendering used by the `coveragePolicyCheck` report. */
+  def describe(policy: Policy): String = policy match {
+    case Policy.Floor(pct) => s"floor ${pct}%"
+    case Policy.Disabled   => "disabled"
+    case Policy.Undeclared => "UNDECLARED"
+  }
+}


### PR DESCRIPTION
## Why the inherited floor was misleading

`build.sbt` set `ThisBuild / coverageMinimumStmtTotal := 50` and `ThisBuild / coverageFailOnMinimum := true`. That reads like project-wide policy, but it has never behaved as one:

- `workspaceShared`, `workspaceClient`, `workspaceRunner`, `samples`, `configPolicy` and `workspaceSamples` all opted out with `coverageEnabled := false`;
- `knowledgegraphNeo4j` overrode the floor to 80;
- CI only ever ran coverage for `core`.

So the "50% project floor" was in practice a single gate on one module, and nobody has ever tuned it. `modules/core` (84k lines) is about to be split into ~8 modules, at which point that untuned number would silently start governing all of them. Small modules have volatile percentages and would fail on noise — `vectorstore` inside core currently sits at 50.6%, i.e. 0.6pp above the old floor.

This PR removes the inherited defaults and makes every module state its own decision, with a build-side check that fails when a module states nothing at all.

## Module table

Floors are the measured statement-coverage value **rounded DOWN to the nearest 5**. Floors ratchet upward over time and are never lowered.

| Module | Policy | Measured | Notes |
| --- | --- | --- | --- |
| `core` | floor **70** | 72.42% stmt / 64.52% branch (53,499 statements, 7004 tests, main @ 5a62e2ac) | Floor moves up as the module is carved apart |
| `knowledgegraphNeo4j` | floor **80** | pre-existing gate | Unchanged, just expressed via the helper |
| `benchmarks` | floor **100** | 100.00% stmt / 100.00% branch (measured in this PR) | See "judgement calls" below |
| `traceOpentelemetry` | floor **0** | 0.00% (measured in this PR) | No in-module tests; see below |
| `llm4s` (root) | `coverageDisabled` | n/a | Aggregator with no sources; `coverageAggregate` runs here and stays informational |
| `it` | `coverageDisabled` | n/a | No `src/main` at all today — test-only host for integration/smoke suites. Gets a real policy (and a codecov flag) when it is populated in a later slice |
| `samples` | `coverageDisabled` | n/a | Unpublished examples, already in `coverageExcludedPackages` |
| `configPolicy` | `coverageDisabled` | n/a | Unpublished CLI tooling, verified end-to-end by the `config-policy-check` CI job |
| `workspaceShared` | `coverageDisabled` | n/a | Excluded package, exercised only by containerised integration tests |
| `workspaceClient` | `coverageDisabled` | n/a | Same |
| `workspaceRunner` | `coverageDisabled` | n/a | Docker entry point, excluded package |
| `workspaceSamples` | `coverageDisabled` | n/a | Unpublished examples |

The six previously-disabled modules keep coverage disabled — but now via the explicit `coverageDisabled` helper with a comment, so the decision is visible rather than inherited.

### Judgement calls

- **`traceOpentelemetry` → floor 0.** Measured with `sbt coverage traceOpentelemetry/test traceOpentelemetry/coverageReport`: **0.00%**. The module has no in-module tests at all; its only suite is `modules/it/.../OpenTelemetryTracingSpec`, which needs a live collector. Rounded down to the nearest 5 that is 0. I deliberately kept measurement **enabled** (floor 0 rather than `coverageDisabled`) so the number stays visible in reports and the floor can ratchet the moment unit tests land in the module.
- **`benchmarks` → floor 100 (not disabled).** Measured **100.00%** statement and branch. It does have a meaningful test: `BenchmarkSmokeTest` deliberately instantiates and runs every JMH benchmark. Rounding 100 down to the nearest 5 is 100, and that floor encodes exactly the policy the smoke test already implements — a new benchmark must be added to the smoke test. Nothing in CI runs `benchmarks/coverageReport` today (the benchmarks workflow runs `benchmarks/test` and JMH), and codecov still ignores `modules/benchmarks`, so this is a build-side gate only.

## The missing-floor CI check

`project/Dependencies.scala` gains a `Coverage` object with:

- `coverageFloor(pct)` → sets `coverageMinimumStmtTotal := pct`, `coverageFailOnMinimum := true`, and a `coveragePolicy` marker;
- `coverageDisabled` → sets `coverageEnabled := false` and the marker;
- `coveragePolicy`, a setting whose **build-level default is `Undeclared`**.

A new root task, `sbt coveragePolicyCheck`, walks `allProjectRefs` (including non-aggregated projects such as `it`), prints the policy table, and fails when any project is still `Undeclared`. It cannot be satisfied by inheritance: the only way to pass is for the project itself to declare a floor or an opt-out. It is wired into the `quick-checks` CI job so it fails fast.

Passing output:

```
[info] Coverage policy per module:
[info]   benchmarks           floor 100%
[info]   configPolicy         disabled
[info]   core                 floor 70%
[info]   it                   disabled
[info]   knowledgegraphNeo4j  floor 80%
[info]   llm4s                disabled
[info]   samples              disabled
[info]   traceOpentelemetry   floor 0%
[info]   workspaceClient      disabled
[info]   workspaceRunner      disabled
[info]   workspaceSamples     disabled
[info]   workspaceShared      disabled
```

**Verified that it actually fails.** I temporarily removed `coverageDisabled` from the `samples` project and re-ran the task: sbt exited **1** with a message-only (no stack trace) error, then I restored the setting and confirmed the check passes again:

```
[error] (coveragePolicyCheck) No coverage policy declared for: samples
[error] Every module must make an explicit decision in build.sbt - coverage floors are
[error] never inherited. Add ONE of the following to the project's .settings(...):
[error]   coverageFloor(<pct>)  // measured statement coverage rounded DOWN to nearest 5
[error]   coverageDisabled      // with a comment saying why it is not measured
[error] Also add a codecov flag for the module in codecov.yml in the same commit.
```

One related CI fix: the coverage job previously ran `sbt coverage core/test coverageAggregate`, and the gate came from the aggregate report picking up the `ThisBuild` floor. With floors now per-module, the job runs `core/coverageReport` as well — that is what enforces `coverageFloor(70)`. The aggregate report is still produced and uploaded, but is informational: a build-wide average is exactly the kind of misleading single threshold this PR removes.

## codecov: a flag per module, required on every carve

`codecov.yml` moves from two flags (`core` pinned to `modules/core/src/main/scala`, `workspace` to `modules/workspace/*/src/main/scala`) to one flag per module, all with `carryforward: true`. Project/patch targets are unchanged (project `auto`/1%, patch 90%/5%), and `modules/benchmarks` stays ignored.

The file carries an explicit note: **every carve slice must add its new module's flag in the same commit that adds the module to `build.sbt`.** Codecov only attributes a file to a flag whose `paths` contain it, and a path covered by no flag is silently untracked rather than failing — so a missing flag makes carved-out code quietly disappear from per-module reporting instead of turning the build red. The build-side half of this (`coveragePolicyCheck`) does fail loudly; `codecov.yml` has no such guard, which is why the requirement is written down where the flags live. The Codecov upload step is now tagged `flags: core`, matching what the job actually measures; a slice that starts measuring another module adds its own upload step with that module's flag.

## Verification

- `sbt scalafmtCheckAll` — passes.
- `sbt compile` — passes.
- `sbt coveragePolicyCheck` — passes; verified it fails (exit 1) with a module's declaration removed, then restored.
- Coverage measured only where needed (`traceOpentelemetry`, `benchmarks`); no full-suite coverage run.
- No Scala source under `modules/*/src` was touched.

Part of #1127 (slice 0, lane C2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128YP9UhueHHpCRa8dyGyVC
