### PR TITLE
build: allow sbt to load inside linked git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ target/
 .metals
 .vscode
 **/.claude/settings.local.json
+# Agent worktrees are created inside the repo by Claude Code's worktree isolation.
+# They are working copies, never content to commit.
+**/.claude/worktrees/
 .DS_Store
 .log
 .scala-build

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,16 @@ import scoverage.ScoverageKeys._
 import Common._
 import Coverage.{ coverageDisabled, coverageFloor, coveragePolicy }
 
+// sbt-git arrives transitively via sbt-ci-release, and its buildSettings eagerly evaluate
+// `gitUncommittedChanges` through JGit. JGit cannot read a *linked git worktree* -- there
+// `.git` is a file pointing into the main repo, and JGit raises
+// "NoWorkTreeException: Bare Repository" -- so sbt fails to load in any worktree, which
+// blocks running agents or parallel builds in worktrees. sbt-git labels the underlying key
+// its "Git worktree workaround". Shelling out to the git CLI for read-only ops is correct
+// everywhere and costs nothing here: the build reads no `git.*` settings, and versioning
+// goes through sbt-dynver, which already uses the git CLI.
+useReadableConsoleGit
+
 inThisBuild(
   List(
     scalaVersion       := scala3,


### PR DESCRIPTION
Part of #1127. Unblocks the agent-driven execution model the carve slices in #1126 depend on.

## Problem

`sbt` cannot load at all inside a linked git worktree in this repo:

```
org.eclipse.jgit.errors.NoWorkTreeException: Bare Repository has neither a working tree, nor an index
	at com.github.sbt.git.JGit.hasUncommittedChanges(JGit.scala:92)
	at com.github.sbt.git.SbtGit$.$anonfun$buildSettings$22(GitPlugin.scala:125)
```

In a linked worktree `.git` is a *file* pointing into the main repository, and JGit reads that as a bare repo.

`sbt-git` is not declared in `project/plugins.sbt` — it arrives transitively via `sbt-ci-release`, and its `buildSettings` eagerly evaluate `gitUncommittedChanges`. So a plugin the build never uses prevents the build from loading.

## Fix

`useReadableConsoleGit`, which sbt-git provides for exactly this case — it labels the underlying `useConsoleForROGit` key its *"Git worktree workaround"*, and `ReadableGit.scala` notes JGit "doesn't currently work with git worktrees".

Shelling out to the git CLI for read-only operations is safe here: the build reads no `git.*` settings, and versioning goes through `sbt-dynver`, which already uses the git CLI.

## Verified

- Main checkout: `sbt "print version"` → `0.3.4+102b7c4ae13-SNAPSHOT` (dynver unaffected)
- Linked worktree, before: fails to load with the exception above
- Linked worktree, after: `sbt "print version"` → `0.3.4+1036150d93b-SNAPSHOT`

## Why it matters now

Every carve slice in #1126 is sbt-heavy, and worktree isolation is how parallel agents avoid colliding on the same tree. Without this, any agent doing build work in a worktree has to hand-patch the build first — which one already had to do while preparing #1137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128YP9UhueHHpCRa8dyGyVC