### PR TITLE
[TEST] Verify documented support matrix in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Check coverage policy is declared for every module
         run: sbt coveragePolicyCheck
 
+      - name: Check documented support matrix
+        run: python3 scripts/check-doc-support.py
+
       - name: Compile
         run: sbt compile
 

--- a/scripts/check-doc-support.py
+++ b/scripts/check-doc-support.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Check that the contributor-facing support claims match the build and CI."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def fail(message: str, failures: list[str]) -> None:
+    failures.append(message)
+
+
+def main(root: Path) -> int:
+    claude = (root / "CLAUDE.md").read_text(encoding="utf-8")
+    build = (root / "build.sbt").read_text(encoding="utf-8")
+    deps = (root / "project" / "Dependencies.scala").read_text(encoding="utf-8")
+    scope = (root / "docs" / "reference" / "v1-scope.md").read_text(encoding="utf-8")
+    ci = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    failures: list[str] = []
+
+    documented_scala = re.search(r"Scala 3 only \(([^)]+)\)", scope)
+    built_scala = re.search(r'val scala3\s*=\s*"([^"]+)"', deps)
+    if not documented_scala or not built_scala:
+        fail("could not locate the documented or configured Scala version", failures)
+    elif documented_scala.group(1) != built_scala.group(1):
+        fail(f"Scala version differs: docs={documented_scala.group(1)} build={built_scala.group(1)}", failures)
+
+    documented_jdk = re.search(r"JDK (\d+)", claude)
+    ci_jdks = set(re.findall(r"java-version:\s*['\"]?(\d+)", ci))
+    if not documented_jdk or documented_jdk.group(1) not in ci_jdks:
+        fail(f"JDK claim is not covered by CI: docs={documented_jdk.group(1) if documented_jdk else 'missing'} CI={sorted(ci_jdks)}", failures)
+
+    for module in re.findall(r"^│   ├── ([^/`\s]+/?)", claude, re.MULTILINE):
+        module = module.rstrip("/")
+        if not (root / "modules" / module).is_dir():
+            fail(f"documented module directory does not exist: modules/{module}", failures)
+        module_in_build = f'file("modules/{module}")' in build or f'file("modules//{module}")' in build
+        if not module_in_build and module != "workspace":
+            nested = f'file("modules/{module}/'
+            if nested not in build:
+                fail(f"documented module is not represented in build.sbt: modules/{module}", failures)
+
+    aliases = set(re.findall(r'addCommandAlias\("([^"]+)",', build))
+    tasks = set(re.findall(r"(?:lazy val|val)\s+([A-Za-z][A-Za-z0-9]*)\s*=\s*(?:taskKey|inputKey)", build))
+    known = aliases | tasks | {"compile", "test", "doc", "coverage", "scalafixAll", "scalafmtAll", "samples"}
+    for command in re.findall(r"^sbt[ \t]+[`\"]?([A-Za-z][A-Za-z0-9]*)", claude, re.MULTILINE):
+        if command not in known:
+            fail(f"documented sbt command is not a known alias or task: {command}", failures)
+
+    if failures:
+        print("Documentation support check failed:")
+        print("\n".join(f"- {failure}" for failure in failures))
+        return 1
+    print("Documentation support check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()))

--- a/scripts/test-check-doc-support.py
+++ b/scripts/test-check-doc-support.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("check-doc-support.py")
+
+
+class DocumentationSupportCheckTest(unittest.TestCase):
+    def test_current_repository_passes(self):
+        result = subprocess.run([sys.executable, str(SCRIPT), str(SCRIPT.parents[1])], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_stale_scala_claim_fails(self):
+        root = Path(tempfile.mkdtemp())
+        for directory in [root / "project", root / "docs/reference", root / ".github/workflows", root / "modules/core"]:
+            directory.mkdir(parents=True)
+        (root / "CLAUDE.md").write_text("**Tech Stack:** Scala 3.7.1, JDK 21\n├── modules/\n│   ├── core/\nsbt compile\n", encoding="utf-8")
+        (root / "build.sbt").write_text('lazy val core = (project in file("modules/core"))\n', encoding="utf-8")
+        (root / "project/Dependencies.scala").write_text('val scala3 = "3.6.0"\n', encoding="utf-8")
+        (root / "docs/reference/v1-scope.md").write_text("Scala 3 only (3.7.1)", encoding="utf-8")
+        (root / ".github/workflows/ci.yml").write_text("java-version: 21", encoding="utf-8")
+        result = subprocess.run([sys.executable, str(SCRIPT), str(root)], capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Scala version differs", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Related issue

Fixes #967

## Problem

The repository recently corrected several stale support claims, but nothing prevents the documented Scala/JDK matrix, module list, or contributor commands from drifting away from the build again.

## What changed

- Add `scripts/check-doc-support.py`, a dependency-free check for the canonical Scala version, JDK versions used by CI, documented module paths, and documented sbt commands.
- Add focused regression tests covering a passing repository and a stale Scala claim.
- Run the check in the existing `quick-checks` job.

The check validates support facts rather than trying to judge prose. It has no runtime or library compatibility impact.

## Validation

- `python scripts/test-check-doc-support.py` — passed (2 tests)
- `python scripts/check-doc-support.py .` — passed
- `git diff --check` — passed

Not run: `sbt scalafmtAll`, `sbt scalafixAll`, `sbt compile`, and `sbt test`. The repository requires sbt, which was not installed in the execution environment; a WinGet installation was attempted but did not complete before validation ended.

No AI-generated code disclosure is required for this contribution.
