### PR TITLE
docs: correct the Llm4sConfig examples in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ EMBEDDING_MODEL=ollama/nomic-embed-text        # or mxbai-embed-large, all-minil
 
 ```scala
 // GOOD - Return Result
-def loadProviderConfig(): Result[ProviderConfig] = Llm4sConfig.provider()
+def loadProviderConfig(): Result[ProviderConfig] = Llm4sConfig.defaultProvider()
 
 // BAD - Don't throw
 def parseConfig(): Config = throw new RuntimeException()
@@ -133,7 +133,9 @@ Try("123".toInt).toResult
 
 ```scala
 // GOOD
-val provider: Result[ProviderConfig] = Llm4sConfig.provider()
+val provider: Result[ProviderConfig] = Llm4sConfig.defaultProvider()
+// or a specific named provider from config:
+val named: Result[ProviderConfig] = Llm4sConfig.provider("openai-main")
 
 // BAD
 val apiKey = sys.env.get("OPENAI_API_KEY")
@@ -158,7 +160,9 @@ val apiKey = sys.env.get("OPENAI_API_KEY")
 
 ```scala
 for {
-  providerConfig <- Llm4sConfig.provider()
+  providerConfig  <- Llm4sConfig.defaultProvider()
+  registryService <- Llm4sConfig.modelRegistryService()
+  given ModelRegistryService = registryService
   client <- LLMConnect.getClient(providerConfig)
   agent = new Agent(client)
   tools = new ToolRegistry(Seq(myTool))


### PR DESCRIPTION
CLAUDE.md's configuration examples do not compile against the current API.

| CLAUDE.md line | Claimed | Actual |
|---|---|---|
| 122 | `Llm4sConfig.provider()` | no zero-arg overload — `provider(name: String)` / `defaultProvider()` |
| 136 | `Llm4sConfig.provider()` | same |
| 161–162 | `LLMConnect.getClient(providerConfig)` | requires a `given ModelRegistryService` |

Verified against `modules/core/src/main/scala/org/llm4s/config/Llm4sConfig.scala` (`provider` at :81, `defaultProvider` at :134, `modelRegistryService` at :69) and `LLMConnect.scala:114`.

Found while porting the g8 starter template to the 0.3.4 API (llm4s/llm4s.g8#4) — following CLAUDE.md there produced code that would not build.

This matters more than a normal docs fix: CLAUDE.md is what agents read before touching this repo, and the modularisation programme (#1126) is agent-driven. A wrong core-API example propagates into every slice.

Part of the same theme as #1134 and #967 — documented claims that nothing verifies. #967 tracks building a check for exactly this class of drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128YP9UhueHHpCRa8dyGyVC