### PR TITLE
ci: deploy docs from the release workflow, gated on the Maven publish

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,19 +9,17 @@ on:
       - 'modules/core/src/**'
       - '.github/workflows/pages.yml'
 
-  # A release redeploys the site so the install snippets pick up the new version.
+  # Releases deploy by calling this workflow from release.yml, gated on the Maven
+  # publish job alone. Two reasons it is a `workflow_call` rather than a trigger here:
   #
-  # This is deliberately gated on the Release workflow *succeeding* rather than on
-  # the tag push. Both workflows trigger on `v*` tags, but the snippet version comes
-  # from `git describe` over tags, so deploying on the tag itself would advertise a
-  # coordinate before `sbt ci-release` had published it -- and permanently, if the
-  # publish failed. Pages also wins that race easily, since Release runs full CI first.
-  #
-  # `git describe` finds the tag from main, so checking out the default branch here
-  # is sufficient; we need the tag to be reachable, not checked out.
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
+  #  - Gating on the Release *workflow* would suppress the docs deploy when a step
+  #    after `sbt ci-release` fails (the container image push), even though the
+  #    artifacts are already live on Maven Central.
+  #  - A called workflow inherits the caller's ref, so `git describe` sees exactly
+  #    the tag being released. Deriving it from the default branch instead could
+  #    pick a newer tag that has not published yet, or miss a tag not reachable
+  #    from main.
+  workflow_call:
 
   workflow_dispatch:
 
@@ -38,8 +36,6 @@ concurrency:
 
 jobs:
   build:
-    # Only deploy for a release that actually published.
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,49 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       
+  # Deploy the docs as soon as the Maven artifacts are live. Deliberately depends on
+  # `publish` and not on the container image below: a registry failure must not leave
+  # llm4s.org advertising the previous version when the release itself succeeded.
+  docs:
+    needs: publish
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/pages.yml
+
+  # Container image. Split out of `publish` so that a registry failure cannot fail the
+  # release after the artifacts are already on Maven Central and irreversible.
+  docker:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # Needed for sbt-dynver
+
+      - name: Setup JVM
+        uses: actions/setup-java@v6
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          cache: "sbt"
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Build and push Docker image
         run: |
           VERSION=${GITHUB_REF#refs/tags/}


### PR DESCRIPTION
Addresses both review findings on #1145. They turned out to share one fix.

## P2 — gate on publication, not the whole release

`release.yml` ran `sbt ci-release` and then GHCR login + image push **in the same job**. So a registry failure after a successful Maven publish failed the workflow, and the `workflow_run` gate suppressed the docs deploy — leaving llm4s.org on the previous version while the artifacts were already live and irreversible.

## P1 — derive the version from the release, not from main

`workflow_run` checked out the default branch, and `git describe` there returns the newest *reachable* tag. That can be a newer release that has not published yet, and misses a tag not reachable from main at all.

## Fix — invert the direction

`pages.yml` becomes `workflow_call`; `release.yml` calls it from a `docs` job depending only on `publish`:

```yaml
  docs:
    needs: publish
    permissions: { contents: read, pages: write, id-token: write }
    uses: ./.github/workflows/pages.yml
```

A called workflow inherits the caller's ref, so checkout lands on the tag being released and `git describe` returns exactly that tag — no ambiguity, no race with a newer tag, and no dependence on reachability from main.

The container image moves to its own `docker` job, also `needs: publish`. A registry failure can no longer fail a release whose artifacts are already on Maven Central.

Resulting graph:

```
ci → publish ─┬→ docs    (deploys llm4s.org at the released tag)
              └→ docker  (container image; independent)
```

## What is not verified

The real test is the next release tag; reusable-workflow behaviour cannot be exercised by a PR build. The `push`/`workflow_dispatch` paths through `pages.yml` are unchanged and still exercised by any docs change on main. Maven Central sync still lags a successful publish by a few minutes, so a brief window remains where the site names a version that is published but not yet resolvable — smaller than before, and removing it would mean polling Central.

Refs #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128YP9UhueHHpCRa8dyGyVC