### PR TITLE
ci: publish a GitHub Release, and source the docs version from it

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Extract version from sbt
         id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Working version of this commit. On an untagged main, sbt-dynver returns
           # something like 0.4.0+3-abc1234-SNAPSHOT, which is NOT resolvable from
@@ -73,10 +75,16 @@ jobs:
           # install snippet.
           VERSION=$(sbt -no-colors 'print version' | tail -1 | tr -d '\n')
 
-          # Latest published release: the newest v* tag. Install snippets use this.
-          LATEST=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null | sed 's/^v//')
+          # Latest published release, from the GitHub Releases API. Install snippets use
+          # this, and it is deliberately NOT `git describe`: a tag exists from the moment
+          # it is pushed, whereas a Release is created only after `sbt ci-release` has
+          # actually published (see release.yml). `git describe` also answers "newest tag
+          # reachable from this ref", which silently gives the wrong answer when a newer
+          # release is still publishing, or when a release was cut from a branch other
+          # than the one being built.
+          LATEST=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>/dev/null | sed 's/^v//')
           if [ -z "$LATEST" ]; then
-            echo "::error::No v* release tag found; cannot determine the published version."
+            echo "::error::No published GitHub Release found; cannot determine the published version."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,11 +51,44 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       
-  # Deploy the docs as soon as the Maven artifacts are live. Deliberately depends on
-  # `publish` and not on the container image below: a registry failure must not leave
-  # llm4s.org advertising the previous version when the release itself succeeded.
-  docs:
+  # Publish the GitHub Release. This is what makes a release visible in the repo UI and
+  # what notifies anyone watching "Releases only" -- neither happened automatically
+  # before, so every release relied on someone remembering.
+  #
+  # It runs after `publish` so a Release can only ever exist for a version that actually
+  # reached Maven Central, and *before* `docs`, because the docs deploy reads the
+  # published version from the Releases API.
+  github-release:
     needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Idempotent: re-running a release must not fail on an existing Release.
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; leaving it untouched."
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --verify-tag \
+              --title "$GITHUB_REF_NAME" \
+              --generate-notes
+          fi
+
+  # Deploy the docs once the release is published and visible. Deliberately independent
+  # of the container image below: a registry failure must not leave llm4s.org advertising
+  # the previous version when the release itself succeeded.
+  docs:
+    needs: github-release
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,14 +74,36 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Idempotent: re-running a release must not fail on an existing Release.
+          # A semver pre-release identifier (v1.0.0-RC1) must be marked as such, or it
+          # becomes GitHub's "latest" release -- which the docs deploy reads to decide
+          # which version the install snippets name. An RC must not displace the last
+          # stable version there.
+          PRERELEASE=""
+          case "$GITHUB_REF_NAME" in
+            *-*) PRERELEASE="--prerelease" ;;
+          esac
+
+          # Idempotent, and specifically draft-aware. `gh release view` succeeds for a
+          # DRAFT release, so an existence check alone would skip creation and leave the
+          # draft in place. Drafts are excluded from the `releases/latest` endpoint the
+          # docs deploy reads, so the site would then keep advertising the previous
+          # version while the new artifacts were already on Maven Central. Deleting a tag
+          # that has a Release attached leaves exactly such a draft behind, which is a
+          # documented recovery path in docs/reference/release.md -- so this is reachable,
+          # not hypothetical.
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            echo "Release $GITHUB_REF_NAME already exists; leaving it untouched."
+            if [ "$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft)" = "true" ]; then
+              echo "Release $GITHUB_REF_NAME exists as a draft; publishing it."
+              gh release edit "$GITHUB_REF_NAME" --draft=false $PRERELEASE
+            else
+              echo "Release $GITHUB_REF_NAME already published; leaving it untouched."
+            fi
           else
             gh release create "$GITHUB_REF_NAME" \
               --verify-tag \
               --title "$GITHUB_REF_NAME" \
-              --generate-notes
+              --generate-notes \
+              $PRERELEASE
           fi
 
   # Deploy the docs once the release is published and visible. Deliberately independent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-29
+
 ### Changed
 - **Breaking (coordinates only):** every published artifact was renamed to carry an `llm4s-`
   prefix in consistent kebab-case. No API, package or source changes accompany the rename.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,7 +294,8 @@ Initial release. Versions 0.1.0 through 0.1.7 were primarily focused on establis
 
 ---
 
-[Unreleased]: https://github.com/llm4s/llm4s/compare/v0.3.4...HEAD
+[Unreleased]: https://github.com/llm4s/llm4s/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/llm4s/llm4s/compare/v0.3.4...v0.4.0
 [0.3.4]: https://github.com/llm4s/llm4s/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/llm4s/llm4s/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/llm4s/llm4s/compare/v0.3.1...v0.3.2

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -16,22 +16,38 @@ git pull origin main
 git tag v0.3.2
 git push origin v0.3.2
 
-# 3. The GitHub Actions release workflow will automatically:
-#    - Run all CI checks
-#    - Build and sign artifacts
-#    - Publish to Maven Central
-#    - Build and push Docker images
+# 3. The GitHub Actions release workflow does the rest -- see below.
 ```
 
-### 3. Creating GitHub Release (Optional)
+Pushing the tag is the whole procedure. Everything after it is automated, in this order:
 
-After the tag is pushed, you can create a GitHub Release:
+```
+ci → publish → github-release → docs
+             └───────────────→ docker
+```
 
-1. Go to https://github.com/llm4s/llm4s/releases/new
-2. Select the tag you just created (e.g., `v0.3.2`)
-3. Set release title (e.g., "v0.3.2")
-4. Add release notes
-5. Click "Publish release"
+| Job | Does |
+|-----|------|
+| `ci` | Full CI on the tagged commit |
+| `publish` | Signs and publishes artifacts to Maven Central |
+| `github-release` | Creates the GitHub Release for the tag |
+| `docs` | Deploys llm4s.org with the new version in the install snippets |
+| `docker` | Builds and pushes the container image |
+
+### 3. Do NOT create the GitHub Release by hand
+
+The `github-release` job creates it for you, and it runs **after** `publish` succeeds. That
+ordering is the point: a GitHub Release is the signal that a version is available, it is
+what notifies everyone watching "Releases only", and it is what `docs` reads to decide which
+version the install snippets should name.
+
+Creating the Release manually defeats all of that. The job skips creation when a Release
+already exists, so a hand-made one is accepted regardless of whether the publish went on to
+succeed -- leaving a Release, a notification, and a documented coordinate for a version that
+never reached Maven Central.
+
+**Editing the generated notes afterwards is fine and encouraged.** The job only ever creates;
+it never overwrites. Write whatever the release deserves once it exists.
 
 ### 4. Verify Release
 
@@ -49,13 +65,27 @@ After the tag is pushed, you can create a GitHub Release:
 
 ### Re-triggering a failed release
 
-```bash
-# Delete and recreate the tag
-git tag -d v0.3.2
-git push origin :v0.3.2
-git tag v0.3.2
-git push origin v0.3.2
-```
+**Check what actually failed first.** Maven Central is immutable: once `publish` has
+succeeded, those coordinates exist forever and cannot be replaced. Re-running a release whose
+`publish` step already completed will fail on the existing version, and re-tagging will not
+help.
+
+- **Failed before or during `publish`** — nothing was published. Delete and recreate the tag:
+
+  ```bash
+  git tag -d v0.3.2
+  git push origin :v0.3.2
+  git tag v0.3.2
+  git push origin v0.3.2
+  ```
+
+  Note that deleting a tag that already has a GitHub Release attached leaves the Release
+  behind as a draft. Delete it too before retrying, or the recreated tag's `github-release`
+  job will skip creation.
+
+- **Failed after `publish`** (`github-release`, `docs` or `docker`) — the artifacts are live
+  and the release is real. Do **not** re-tag. Re-run the failed job from the Actions UI, or
+  cut the next patch version if the failure needs a code change.
 
 ## Version Numbering
 


### PR DESCRIPTION
Closes the gap behind the two P2 review findings on #1147, and the "no GitHub Release" gap noticed after v0.4.0.

## 1. Releases are now published automatically

`release.yml` published to Maven Central and nothing else. The repo UI kept showing the previous version as **Latest**, and nobody watching "Releases only" was notified — so every release so far depended on a maintainer remembering to do it by hand. v0.4.0 shipped on 29 Aug and the repo still advertised v0.3.4 until it was backfilled.

A `github-release` job now creates it, after `publish`, so **a Release can only ever exist for a version that actually reached Maven Central**. It is idempotent — re-running a release leaves an existing Release untouched rather than failing.

## 2. The docs version comes from the Releases API, not `git describe`

This is what closes both review findings on #1147:

> *"the existing `git describe` at line 77 can only select a tag reachable from that branch"*

> *"this later invocation then checks out the older tag and overwrites the site with that version"*

Both are the same root cause: `git describe` answers *"newest tag reachable from this ref"*, which is not the question. The install snippet needs *"what version is actually published"* — and those differ when a newer release is mid-publish, when a release is cut from another branch, or when two releases overlap and finish out of order.

A tag exists the instant it is pushed. A **Release** exists only after publishing succeeded. So the Releases API is the correct source, and it is unordered-race-proof because `releases/latest` is a single authoritative answer rather than a computation over local refs.

```bash
LATEST=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name | sed 's/^v//')
```

Still fails loudly if no Release is found, rather than falling back to something plausible-but-wrong.

## Job graph

```
ci → publish → github-release → docs    (deploys llm4s.org)
             └───────────────→ docker   (container image; independent)
```

`docs` moved from `needs: publish` to `needs: github-release`, so the Release exists before the docs deploy reads it.

## Also

Moves the 0.4.0 rename entry out of `[Unreleased]` in `CHANGELOG.md`, where it was left after the release shipped.

## Not verified

Reusable-workflow and release-job behaviour cannot be exercised by a PR build; the real test is the next release tag. The `push` and `workflow_dispatch` paths through `pages.yml` are unchanged and still covered by any docs change on main — and those paths now also read the Releases API, so a main-push deploy will exercise the new lookup as soon as this merges.

Refs #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128YP9UhueHHpCRa8dyGyVC