### PR TITLE
test: give every integration suite a tier that actually runs it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,11 @@ jobs:
       - name: Compile
         run: sbt compile
 
+      # Fails when an integration suite in modules/it declares no tier, i.e. when no command
+      # and no CI job below would run it. Eleven of eighteen suites were in that state.
+      - name: Check every integration suite declares a test tier
+        run: sbt it/itTierCheck
+
   scaladoc:
     name: ScalaDoc
     needs: quick-checks
@@ -229,11 +234,106 @@ jobs:
             **/target/scala-3.7.1/test-reports/
           retention-days: 5
 
+  # Tier 2: containerised integration tests — pgvector, Qdrant and Neo4j as service
+  # containers. Reproducible and secret-free, so unlike the Ollama and cloud tiers this
+  # runs on every PR. `LLM4S_IT_STRICT=true` makes a suite that cannot reach its service
+  # fail instead of skip: this job promises the services are there, so a skip here would be
+  # the same silent non-execution that #1143 was about.
+  integration-tests:
+    name: Integration Tests
+    needs: quick-checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+      qdrant:
+        image: qdrant/qdrant:v1.13.0
+        ports:
+          - 6333:6333
+
+      neo4j:
+        image: neo4j:5
+        env:
+          NEO4J_AUTH: neo4j/llm4stest
+        ports:
+          - 7687:7687
+          - 7474:7474
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v6
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+
+      # Postgres is covered by the service health check above. The Qdrant and Neo4j images
+      # ship no shell tooling to health-check with, so poll them from the runner instead —
+      # and fail the job if they never come up, rather than letting the suites skip.
+      - name: Wait for Qdrant and Neo4j
+        run: |
+          wait_for() {
+            for _ in $(seq 1 60); do
+              if curl -sf "$2" > /dev/null; then echo "$1 is ready"; return 0; fi
+              sleep 2
+            done
+            echo "$1 did not become ready within 120s" >&2
+            exit 1
+          }
+          wait_for Qdrant http://localhost:6333/readyz
+          wait_for Neo4j http://localhost:7474
+
+      - name: Run containerised integration tests
+        env:
+          LLM4S_IT_STRICT: "true"
+          PGVECTOR_TEST_URL: jdbc:postgresql://localhost:5432/postgres
+          PGVECTOR_USER: postgres
+          PGVECTOR_PASSWORD: postgres
+          PGVECTOR_TEST_USER: postgres
+          PGVECTOR_TEST_PASSWORD: postgres
+          POSTGRES_TEST_ENABLED: "true"
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: "5432"
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          QDRANT_TEST_URL: http://localhost:6333
+          NEO4J_URI: bolt://localhost:7687
+          NEO4J_USER: neo4j
+          NEO4J_PASSWORD: llm4stest
+        run: sbt testIntegration
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-reports-integration
+          path: |
+            modules/it/target/**/test-reports/
+          retention-days: 5
+
   # All tests must pass
   all-tests-pass:
     name: All Tests Pass
     if: always()
-    needs: [test, coverage, config-policy-check, scaladoc]
+    needs: [test, coverage, config-policy-check, scaladoc, integration-tests]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -257,9 +357,13 @@ jobs:
             echo "ScalaDoc job failed"
             exit 1
           fi
+          if [[ "${{ needs.integration-tests.result }}" != "success" ]]; then
+            echo "Integration tests failed"
+            exit 1
+          fi
           echo "All tests passed!"
 
-  # Tier 2: Ollama integration tests — verifies full round-trip against a real
+  # Tier 3: Ollama integration tests — verifies full round-trip against a real
   # local LLM. Only runs on pushes to main to avoid slowing down PR builds.
   ollama-integration:
     name: Ollama Integration
@@ -299,9 +403,59 @@ jobs:
         run: ollama pull qwen2.5:0.5b
 
       - name: Run Ollama integration tests
+        env:
+          # This job installs Ollama and pulls the model, so "Ollama not available" here is a
+          # failure, not a reason to skip.
+          LLM4S_IT_STRICT: "true"
         run: sbt testOllama
 
-  # Tier 3: Cloud smoke tests — minimal sanity checks against real cloud APIs.
+  # Tier 2: containerised workspace tests. Split from the `integration-tests` job because
+  # this one has to build the workspace-runner image first (apt + sdkman + two Scala
+  # versions), which is far too slow for every PR. The image tag comes from the build
+  # itself — `it / Test / envVars` passes `workspaceRunner / Docker / version` to the suite.
+  workspace-integration:
+    name: Workspace Integration
+    needs: quick-checks
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The image tag is derived from the version, which sbt-dynver reads from git
+          # describe; a shallow clone with no tags yields a different tag than the test
+          # is told to expect.
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v6
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+
+      - name: Build the workspace-runner image
+        run: sbt workspaceRunner/Docker/publishLocal
+
+      - name: Run containerised workspace tests
+        env:
+          LLM4S_IT_STRICT: "true"
+          LLM4S_DOCKER_TESTS: "true"
+        run: sbt testWorkspace
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-reports-workspace
+          path: |
+            modules/it/target/**/test-reports/
+          retention-days: 5
+
+  # Tier 4: Cloud smoke tests — minimal sanity checks against real cloud APIs.
   # Manual trigger only (workflow_dispatch) to avoid unintended API costs.
   cloud-smoke:
     name: Cloud Smoke Tests
@@ -323,9 +477,15 @@ jobs:
 
       - name: Run cloud smoke tests
         env:
+          # `LLM4S_IT_STRICT=true` turns a missing key into a failure. Without it this job
+          # reported success while testing nothing — which is what GeminiSmokeSpec has been
+          # doing all along: it reads GEMINI_API_KEY, and only GOOGLE_API_KEY was passed.
+          LLM4S_IT_STRICT: "true"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY || secrets.GOOGLE_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
         run: sbt testSmoke

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 - Place tests under `src/test/scala`, mirroring the package of the code under test.
 - Keep version-specific tests inside the owning module only when Scala-version behavior genuinely differs.
 - Typical flow: `sbt test` for quick checks or `sbt buildAll` before PR. Coverage (when needed): `sbt coverage test coverageReport`.
+- Suites needing an external service live in `modules/it` and must declare a tier by class annotation (`@Local`, `@Docker`, `@Workspace`, `@Ollama`, `@Cloud` from `org.llm4s.it.tags`); `sbt it/itTierCheck` fails the build if one does not. Run a tier with `sbt testIntegration` / `testWorkspace` / `testOllama` / `testSmoke`, and gate on `Tier.require` rather than `assume` so `LLM4S_IT_STRICT=true` runs turn a missing service into a failure.
 
 ## Issue Templates
 - We provide structured GitHub templates to streamline contributions and improve issue quality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `Neo4jGraphStore.traverse` never worked against a real Neo4j. The variable-length pattern
+  was built from a non-interpolated string, so `$maxDepth` reached Cypher as a parameter
+  reference, which is illegal in a `MATCH` pattern ("Parameter maps cannot be used in MATCH
+  patterns") and failed every traversal. The bound is now inlined - it is an `Int`, so there
+  is nothing to inject - and the `Int.MaxValue` default maps to Cypher's open bound.
+- `QdrantVectorStore` could not store a record whose ID was not already a UUID. Qdrant accepts
+  only an unsigned integer or a UUID as a point ID and rejected everything else with
+  `"test-1" is not a valid point ID`, so `upsert`, `get`, `delete` and `search` all failed.
+  Non-UUID IDs are now mapped to a UUID derived from the ID, with the record's own ID carried
+  in the payload and read back from there; UUID IDs are unchanged. A mocked-HTTP unit test had
+  been asserting the broken request shape, which is why nothing caught this.
 - 11 of the 18 integration suites in `modules/it` were executed by nothing - not locally, not
   in CI, not on release - because the tier aliases named two `testOnly` patterns and every
   suite outside them matched nothing. Tier membership is now declared per suite by class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Neo4jGraphStore.traverse` never worked against a real Neo4j. The variable-length pattern
   was built from a non-interpolated string, so `$maxDepth` reached Cypher as a parameter
   reference, which is illegal in a `MATCH` pattern ("Parameter maps cannot be used in MATCH
-  patterns") and failed every traversal. The bound is now inlined - it is an `Int`, so there
-  is nothing to inject - and the `Int.MaxValue` default maps to Cypher's open bound.
+  patterns") and failed every traversal. It is now a breadth-first expansion of one level per
+  query, which also avoids the path enumeration a variable-length pattern implies: `[*0..]`
+  matches every relationship-unique path before `min(length(p))` reduces them to one row per
+  node, which grows exponentially on a cyclic or dense graph - and unbounded is the default
+  depth. Semantics follow `GraphTraversal.bfs`, which backs the in-memory store.
 - `QdrantVectorStore` could not store a record whose ID was not already a UUID. Qdrant accepts
   only an unsigned integer or a UUID as a point ID and rejected everything else with
   `"test-1" is not a valid point ID`, so `upsert`, `get`, `delete` and `search` all failed.
   Non-UUID IDs are now mapped to a UUID derived from the ID, with the record's own ID carried
-  in the payload and read back from there; UUID IDs are unchanged. A mocked-HTTP unit test had
-  been asserting the broken request shape, which is why nothing caught this.
+  in the payload and read back from there; UUID IDs are unchanged. Derived IDs are version 8
+  UUIDs (RFC 9562's "custom" space) and an ID that is itself a version 8 UUID is derived from
+  rather than passed through, so a caller cannot land two records on one point by supplying
+  the UUID that another ID maps to. A mocked-HTTP unit test had been asserting the broken
+  request shape, which is why nothing caught this.
 - `QdrantVectorStore` reported absence as failure. Qdrant answers 404 both for a point that
   does not exist and for a collection that does not exist - and the collection is created
   lazily on first upsert and deleted outright by `clear()` - so `get` returned a `Left`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Non-UUID IDs are now mapped to a UUID derived from the ID, with the record's own ID carried
   in the payload and read back from there; UUID IDs are unchanged. A mocked-HTTP unit test had
   been asserting the broken request shape, which is why nothing caught this.
+- `QdrantVectorStore` reported absence as failure. Qdrant answers 404 both for a point that
+  does not exist and for a collection that does not exist - and the collection is created
+  lazily on first upsert and deleted outright by `clear()` - so `get` returned a `Left`
+  instead of `Right(None)`, and `count`, `list`, `search` and `stats` failed on an empty
+  store rather than reporting it empty. Reads now treat 404 as empty; writes still error.
 - 11 of the 18 integration suites in `modules/it` were executed by nothing - not locally, not
   in CI, not on release - because the tier aliases named two `testOnly` patterns and every
   suite outside them matched nothing. Tier membership is now declared per suite by class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- 11 of the 18 integration suites in `modules/it` were executed by nothing - not locally, not
+  in CI, not on release - because the tier aliases named two `testOnly` patterns and every
+  suite outside them matched nothing. Tier membership is now declared per suite by class
+  annotation (`@Local`, `@Docker`, `@Workspace`, `@Ollama`, `@Cloud` in `org.llm4s.it.tags`)
+  and `sbt it/itTierCheck` fails the build when a suite declares none or more than one.
+  ([#1143](https://github.com/llm4s/llm4s/issues/1143))
+- Suites no longer report a pass when their dependency is absent. `Tier.require` cancels
+  locally and, under `LLM4S_IT_STRICT=true` (set by every tier's CI job), fails - so a
+  service that did not start is visible instead of green. This also exposes that
+  `GeminiSmokeSpec` reads `GEMINI_API_KEY` while the cloud job only passed `GOOGLE_API_KEY`;
+  the workflow now passes both, plus `COHERE_API_KEY`.
+- `ContainerisedWorkspaceTest` pinned a `workspace-runner:0.1.0-SNAPSHOT` image tag that the
+  build stopped producing long ago. The tag now comes from the build itself.
+
+### Added
+- `sbt testIntegration` runs the containerised tier (pgvector, Qdrant, Neo4j) and a CI job
+  runs it on **every PR** with those services as service containers - the suites covering
+  pgvector, the Postgres keyword index, Qdrant, permission-aware RAG, Postgres-backed agent
+  memory and Neo4j now have execution signal ahead of the modularisation carve
+  ([#1126](https://github.com/llm4s/llm4s/issues/1126)), which moves most of that code.
+- `sbt testWorkspace` runs the containerised workspace tier, in a CI job on pushes to `main`
+  that first builds the `workspace-runner` image.
+
+### Changed
+- `modules/it` joined the root aggregate, so it is compiled, formatted and linted with every
+  other module; it had been outside it, where its suites could stop compiling unnoticed.
+  Default `sbt test` runs only its `@Local` tier, so the dependency-free tier stays fast.
+
 ## [0.4.0] - 2026-08-29
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,13 @@ Slice order — each is an issue with its own scope and gotchas:
 3. **`reference.conf` keys move with their code.** HOCON merges across jars; keys left behind become defaults that apply to nothing.
 4. **Coverage floor and codecov flag land in the same commit as the carve.** A missing flag makes the moved code untracked rather than failing.
 5. **One migration note per slice**, in CHANGELOG and docs.
-6. **Never add a provider by editing shared registration files** once slice 4 lands. Before then, note that `NamedProviderLoader`, `ProviderConfig`, `ProviderModelTypes`, `LLMConnect`, `ProviderCapabilities*` and `NamedProviderValidator` are the most contended files in the repo.
+6. **Integration suites move with their code, and keep a tier.** A suite that needs a
+   database, a container, a model server or an API key lives in `modules/it` and declares
+   exactly one tier tag from `org.llm4s.it.tags`; `sbt it/itTierCheck` fails the build
+   otherwise. Carving code out of `core` without carrying its integration suite - or moving
+   the suite and leaving it untagged - removes the only signal the carve has (see
+   [#1143](https://github.com/llm4s/llm4s/issues/1143)).
+7. **Never add a provider by editing shared registration files** once slice 4 lands. Before then, note that `NamedProviderLoader`, `ProviderConfig`, `ProviderModelTypes`, `LLMConnect`, `ProviderCapabilities*` and `NamedProviderValidator` are the most contended files in the repo.
 
 Current per-module coverage floors are recorded in [#1127](https://github.com/llm4s/llm4s/issues/1127); floors ratchet upward and are never lowered.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,11 @@ sbt buildAll           # Clean, compile, test
 sbt test               # Run tests
 sbt scalafmtAll        # Format code
 sbt cov                # Run coverage
+sbt testIntegration    # modules/it @Docker tier (Postgres/pgvector, Qdrant, Neo4j)
+sbt testWorkspace      # modules/it @Workspace tier (needs a built workspace-runner image)
+sbt testOllama         # modules/it @Ollama tier
+sbt testSmoke          # modules/it @Cloud tier (live API keys)
+sbt it/itTierCheck     # every suite in modules/it must declare exactly one tier
 sbt "samples/runMain org.llm4s.samples.basic.BasicLLMCallingExample"
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,26 @@ See [AGENTS.md](AGENTS.md#testing-guidelines) for details:
 - Test both happy path and error cases
 - Maintain 80%+ coverage
 
+### Tests that need a real service
+
+Suites needing a database, a container, a local model server or an API key go in
+`modules/it`, and each one must declare which tier runs it by annotating the class with
+exactly one tag from `org.llm4s.it.tags`. `sbt it/itTierCheck` (run in CI) fails the build
+if a suite declares none, so a new suite cannot end up being run by nothing:
+
+| Tag | Needs | Command |
+|---|---|---|
+| `@Local` | nothing external | `sbt test` |
+| `@Docker` | Postgres/pgvector, Qdrant or Neo4j | `sbt testIntegration` |
+| `@Workspace` | Docker + a built `workspace-runner` image | `sbt testWorkspace` |
+| `@Ollama` | a local Ollama server | `sbt testOllama` |
+| `@Cloud` | live provider API keys | `sbt testSmoke` |
+
+Gate on `Tier.require(...)` rather than `assume(...)`: with `LLM4S_IT_STRICT=true`, which
+every tier's CI job sets, an unavailable dependency then fails the build instead of skipping
+quietly. Full details in the
+[Testing Guide](docs/reference/testing-guide.md#9-integration-test-tiers-modulesit).
+
 ## Build Commands
 
 See [AGENTS.md](AGENTS.md#build-test-and-development-commands) for complete list:

--- a/build.sbt
+++ b/build.sbt
@@ -434,7 +434,12 @@ lazy val it = (project in file("modules/it"))
     // The default run - including the aggregated `sbt test` - is the Local tier only.
     // Everything else needs a database, an image build, a model server or a paid API key.
     // The tier aliases replace this setting rather than adding to it (see ItTiers.alias).
-    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-n", ItTiers.Local),
+    //
+    // Scoped to `test` rather than to the whole Test configuration on purpose: `testOnly`
+    // names a suite explicitly, so `it/testOnly org.llm4s.vectorstore.PgVectorStoreSpec`
+    // must run that suite whatever tier it is in. A filter there would answer a request for
+    // one suite by running nothing, which is the failure this whole change is about.
+    Test / test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-n", ItTiers.Local),
     // ContainerisedWorkspaceTest runs against whatever `workspaceRunner/Docker/publishLocal`
     // produced; take the tag from the build so the test and the image cannot drift apart.
     Test / envVars += "LLM4S_WORKSPACE_IMAGE" -> s"llm4s/workspace-runner:${(workspaceRunner / Docker / version).value}",

--- a/build.sbt
+++ b/build.sbt
@@ -95,18 +95,23 @@ addCommandAlias(
   "testFast",
   """;set core / Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "org.llm4s.tags.SlowTest"); test"""
 )
-// ---- Three-tier test aliases ----
-// Default `test` runs unit + local HTTP server tests (Tier 1), excluding tagged tests.
-// testOllama: Tier 2 — integration tests against a local Ollama instance (requires `ollama pull qwen2.5:0.5b`)
-// testSmoke:  Tier 3 — cloud smoke tests against real APIs (requires API keys in .env or environment)
-addCommandAlias(
-  "testOllama",
-  """;it/testOnly org.llm4s.llmconnect.provider.OllamaIntegrationSpec"""
-)
-addCommandAlias(
-  "testSmoke",
-  """;it/testOnly org.llm4s.llmconnect.smoke.*"""
-)
+// ---- Tiered test aliases ----
+// Every suite in `modules/it` declares its tier by class annotation (see project/ItTiers.scala);
+// `it/itTierCheck` fails the build if one declares none. Each alias selects a tier by tag, so a
+// new suite lands in a tier that actually runs instead of matching no `testOnly` pattern.
+//
+//   sbt test             Tier 1 - unit tests plus the `@Local` suites in modules/it
+//   sbt testIntegration  Tier 2 - `@Docker`: needs Postgres/pgvector, Qdrant, Neo4j
+//   sbt testWorkspace    Tier 2 - `@Workspace`: needs a built workspace-runner image + Docker
+//   sbt testOllama       Tier 3 - `@Ollama`: needs a local Ollama with `qwen2.5:0.5b` pulled
+//   sbt testSmoke        Tier 4 - `@Cloud`: real provider APIs, real money
+//
+// The aliases *replace* `it / Test / testOptions` because the default value restricts the run
+// to the Local tier; adding a second `-n` would intersect to nothing.
+addCommandAlias("testIntegration", ItTiers.alias(ItTiers.Docker))
+addCommandAlias("testWorkspace", ItTiers.alias(ItTiers.Workspace))
+addCommandAlias("testOllama", ItTiers.alias(ItTiers.Ollama))
+addCommandAlias("testSmoke", ItTiers.alias(ItTiers.Cloud))
 
 // ---- shared settings ----
 lazy val commonSettings = Seq(
@@ -150,6 +155,13 @@ lazy val coveragePolicyCheck = taskKey[Unit](
   "Fail the build if any module has not explicitly declared a coverage floor or opt-out"
 )
 
+// ---- integration tier check ----
+// Same principle one level down: an integration suite that declares no tier is run by no
+// command and no CI job, and says nothing about it. See project/ItTiers.scala.
+lazy val itTierCheck = taskKey[Unit](
+  "Fail the build if any suite in modules/it has not declared exactly one test tier"
+)
+
 // ---- projects ----
 lazy val llm4s = (project in file("."))
   .aggregate(
@@ -163,6 +175,10 @@ lazy val llm4s = (project in file("."))
     traceOpentelemetry,
     knowledgegraphNeo4j,
     benchmarks,
+    // Aggregated so `it` is compiled, formatted and linted with everything else - it was
+    // outside the aggregate entirely, so its suites could stop compiling unnoticed. Only the
+    // `@Local` tier actually runs under `sbt test`; see `it / Test / testOptions` below.
+    it,
     // Relocation stubs must be aggregated here: `sbt ci-release` publishes the root
     // aggregate, so a stub outside it would simply never be published.
     relocationCore,
@@ -415,6 +431,21 @@ lazy val it = (project in file("modules/it"))
     // policy (and a codecov flag) when it is populated with sources in a later slice.
     coverageDisabled,
     Test / fork := true,
+    // The default run - including the aggregated `sbt test` - is the Local tier only.
+    // Everything else needs a database, an image build, a model server or a paid API key.
+    // The tier aliases replace this setting rather than adding to it (see ItTiers.alias).
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-n", ItTiers.Local),
+    // ContainerisedWorkspaceTest runs against whatever `workspaceRunner/Docker/publishLocal`
+    // produced; take the tag from the build so the test and the image cannot drift apart.
+    Test / envVars += "LLM4S_WORKSPACE_IMAGE" -> s"llm4s/workspace-runner:${(workspaceRunner / Docker / version).value}",
+    itTierCheck := ItTiers.check(
+      (Test / definedTests).value.map(_.name),
+      (Test / fullClasspath).value.map(_.data),
+      streams.value.log
+    ),
+    // Any tier run proves its own membership first, so a mistagged suite fails where it is
+    // noticed rather than by quietly running nothing.
+    Test / test := (Test / test).dependsOn(itTierCheck).value,
     libraryDependencies ++= Seq(
       Deps.scalatest % Test
     )

--- a/docs/reference/testing-guide.md
+++ b/docs/reference/testing-guide.md
@@ -180,6 +180,7 @@ The project provides a handful of sbt commands that contributors use frequently.
 | Run all tests              | `sbt test`                  | Default; runs tests for the current Scala version              |
 | Full CI‑like pipeline      | `sbt buildAll`              | Compiles and tests every aggregated module for the current build |
 | Format code                | `sbt scalafmtAll`           | Apply project‑wide formatting (required before PRs)            |
+| Run an integration tier    | `sbt testIntegration`       | Suites in `modules/it` that need a real service — see section 9 |
 
 ### Using the table
 
@@ -199,7 +200,74 @@ sbt ~test                # continuous feedback as you code
 
 ---
 
-## 9. Tests in CI
+## 9. Integration Test Tiers (`modules/it`)
+
+Suites that need something the machine may not have - a database, a container image, a local
+model server, a paid API key - live in `modules/it`, not in the module they exercise. That
+module is deliberately outside the default `sbt test` dependency-free tier, so each suite has
+to say which tier does run it.
+
+**A suite declares its tier by annotating the class**, with exactly one tag from
+`org.llm4s.it.tags`:
+
+| Tag | Needs | Command | CI |
+|---|---|---|---|
+| `@Local` | nothing external | `sbt test` | every PR |
+| `@Docker` | Postgres/pgvector, Qdrant or Neo4j | `sbt testIntegration` | every PR (service containers) |
+| `@Workspace` | Docker + a built `workspace-runner` image | `sbt testWorkspace` | pushes to `main` |
+| `@Ollama` | a local Ollama with `qwen2.5:0.5b` pulled | `sbt testOllama` | pushes to `main` |
+| `@Cloud` | live provider API keys (real money) | `sbt testSmoke` | manual `workflow_dispatch` |
+
+```scala
+import org.llm4s.it.tags.Docker
+
+@Docker
+class PgVectorStoreSpec extends AnyWordSpec with Matchers {
+```
+
+Tiers are tags rather than name patterns in a `testOnly` argument because a name pattern
+fails silently: a suite matching no pattern is run by nothing and reports nothing. `sbt
+it/itTierCheck` - part of Quick Checks in CI - fails the build when a suite declares no tier
+or more than one.
+
+### Skipping is a local convenience, not a CI outcome
+
+A suite whose dependency is missing cancels its tests, which ScalaTest reports as skipped.
+That is right on a laptop and wrong in the CI job that exists to provide that dependency:
+there, a skip is indistinguishable from a pass.
+
+So each tier's CI job sets `LLM4S_IT_STRICT=true`, and `Tier.require` turns "not available"
+into a failure instead of a cancellation:
+
+```scala
+import org.llm4s.it.Tier
+
+Tier.require(pgUrl.isDefined, "PGVECTOR_TEST_URL not set")
+```
+
+Use `Tier.require` in place of `assume(...)` for anything the tier's job is meant to supply.
+It is also worth running strictly by hand once the services are up locally, to confirm a suite
+really executes:
+
+```bash
+docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres pgvector/pgvector:pg16
+docker run -d -p 6333:6333 qdrant/qdrant
+docker run -d -p 7687:7687 -e NEO4J_AUTH=neo4j/llm4stest neo4j:5
+
+export PGVECTOR_TEST_URL=jdbc:postgresql://localhost:5432/postgres
+export PGVECTOR_USER=postgres PGVECTOR_PASSWORD=postgres
+export PGVECTOR_TEST_USER=postgres PGVECTOR_TEST_PASSWORD=postgres
+export POSTGRES_TEST_ENABLED=true POSTGRES_PASSWORD=postgres
+export QDRANT_TEST_URL=http://localhost:6333
+export NEO4J_URI=bolt://localhost:7687 NEO4J_USER=neo4j NEO4J_PASSWORD=llm4stest
+export LLM4S_IT_STRICT=true
+
+sbt testIntegration
+```
+
+---
+
+## 10. Tests in CI
 
 * All PRs must pass the full test suite
 * Flaky tests will be rejected
@@ -213,7 +281,7 @@ If your test fails in CI but not locally, it is usually a **non-determinism issu
 
 ---
 
-## 10. When to Add or Update Tests
+## 11. When to Add or Update Tests
 
 You should add or update tests when:
 
@@ -229,7 +297,7 @@ You usually do **not** need new tests for:
 
 ---
 
-## 11. Getting Help
+## 12. Getting Help
 
 If you're unsure how to test something:
 

--- a/modules/core/src/main/scala/org/llm4s/vectorstore/QdrantVectorStore.scala
+++ b/modules/core/src/main/scala/org/llm4s/vectorstore/QdrantVectorStore.scala
@@ -4,7 +4,9 @@ import org.llm4s.types.Result
 import org.llm4s.error.ProcessingError
 import org.llm4s.http.Llm4sHttpClient
 
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.util.UUID
 import scala.util.Try
 
@@ -41,16 +43,23 @@ final class QdrantVectorStore private (
 
   /**
    * Qdrant point IDs must be an unsigned integer or a UUID - it rejects anything else with
-   * "not a valid point ID" - while a `VectorRecord` ID is an arbitrary string. IDs that are
-   * already UUIDs are used as-is; every other ID is mapped to a UUID derived from it, so the
-   * mapping is stable across processes and stores.
+   * "not a valid point ID" - while a `VectorRecord` ID is an arbitrary string. A UUID ID is
+   * used as-is, so records already stored under one stay reachable; every other ID is mapped
+   * to a UUID derived from it, stably across processes and stores.
+   *
+   * The two must not meet. Deriving a UUID that a caller could also supply literally would
+   * let two distinct records share one point and silently overwrite each other - and the
+   * derivation is public, so such an ID is constructible rather than merely unlucky. Derived
+   * IDs therefore live in UUID version 8, which RFC 9562 reserves for exactly this kind of
+   * custom value, and an ID that is itself a version 8 UUID is derived from rather than
+   * passed through. The two spaces cannot overlap, and within the derived space a collision
+   * would take a SHA-256 collision.
    *
    * The record's own ID is what callers search, get and delete by, so it travels in the
    * payload under `llm4s_id` and is read back from there rather than from the point ID.
    */
   private def pointId(id: String): String =
-    if (QdrantVectorStore.isUuid(id)) id
-    else UUID.nameUUIDFromBytes(id.getBytes(StandardCharsets.UTF_8)).toString
+    if (QdrantVectorStore.isPassthroughUuid(id)) id else QdrantVectorStore.derivedPointId(id)
 
   /** The record ID a point carries, falling back to its point ID for foreign-written points. */
   private def recordId(point: ujson.Value): String =
@@ -510,7 +519,21 @@ object QdrantVectorStore {
 
   private val UuidPattern = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}".r
 
-  private[vectorstore] def isUuid(id: String): Boolean = UuidPattern.matches(id)
+  /** The UUID version reserved here for derived point IDs (RFC 9562 "custom"). */
+  private val DerivedVersion = 8
+
+  /** True for a record ID usable as a point ID as it stands - any UUID outside the derived space. */
+  private[vectorstore] def isPassthroughUuid(id: String): Boolean =
+    UuidPattern.matches(id) && !Try(UUID.fromString(id).version()).toOption.contains(DerivedVersion)
+
+  /** A version 8 UUID derived from the record ID; see `pointId` for why the version matters. */
+  private[vectorstore] def derivedPointId(id: String): String = {
+    val digest = MessageDigest.getInstance("SHA-256").digest(s"llm4s:$id".getBytes(StandardCharsets.UTF_8))
+    digest(6) = ((digest(6) & 0x0f) | (DerivedVersion << 4)).toByte
+    digest(8) = ((digest(8) & 0x3f) | 0x80).toByte // IETF variant
+    val buffer = ByteBuffer.wrap(digest, 0, 16)
+    new UUID(buffer.getLong, buffer.getLong).toString
+  }
 
   /**
    * Configuration for QdrantVectorStore.

--- a/modules/core/src/main/scala/org/llm4s/vectorstore/QdrantVectorStore.scala
+++ b/modules/core/src/main/scala/org/llm4s/vectorstore/QdrantVectorStore.scala
@@ -4,6 +4,8 @@ import org.llm4s.types.Result
 import org.llm4s.error.ProcessingError
 import org.llm4s.http.Llm4sHttpClient
 
+import java.nio.charset.StandardCharsets
+import java.util.UUID
 import scala.util.Try
 
 /**
@@ -36,6 +38,34 @@ final class QdrantVectorStore private (
 
   private val collectionsUrl = s"$baseUrl/collections/$collectionName"
   private val pointsUrl      = s"$collectionsUrl/points"
+
+  /**
+   * Qdrant point IDs must be an unsigned integer or a UUID - it rejects anything else with
+   * "not a valid point ID" - while a `VectorRecord` ID is an arbitrary string. IDs that are
+   * already UUIDs are used as-is; every other ID is mapped to a UUID derived from it, so the
+   * mapping is stable across processes and stores.
+   *
+   * The record's own ID is what callers search, get and delete by, so it travels in the
+   * payload under `llm4s_id` and is read back from there rather than from the point ID.
+   */
+  private def pointId(id: String): String =
+    if (QdrantVectorStore.isUuid(id)) id
+    else UUID.nameUUIDFromBytes(id.getBytes(StandardCharsets.UTF_8)).toString
+
+  /** The record ID a point carries, falling back to its point ID for foreign-written points. */
+  private def recordId(point: ujson.Value): String =
+    point.obj
+      .get("payload")
+      .flatMap(_.objOpt)
+      .flatMap(_.get(QdrantVectorStore.IdKey))
+      .collect { case ujson.Str(value) => value }
+      .getOrElse(pointIdString(point("id")))
+
+  private def pointIdString(id: ujson.Value): String = id match {
+    case ujson.Str(value) => value
+    case ujson.Num(value) => value.toLong.toString
+    case other            => other.toString
+  }
 
   // Initialize collection if it doesn't exist
   ensureCollection()
@@ -79,7 +109,7 @@ final class QdrantVectorStore private (
         Try {
           val points = ujson.Arr(records.map { record =>
             ujson.Obj(
-              "id"      -> record.id,
+              "id"      -> pointId(record.id),
               "vector"  -> ujson.Arr(record.embedding.toIndexedSeq.map(f => ujson.Num(f.toDouble)): _*),
               "payload" -> recordToPayload(record)
             )
@@ -111,7 +141,7 @@ final class QdrantVectorStore private (
       httpPost(s"$pointsUrl/search", body).map { response =>
         val results = response("result").arr
         results.map { point =>
-          val id       = point("id").str
+          val id       = recordId(point)
           val score    = point("score").num
           val vector   = point("vector").arr.map(_.num.toFloat).toArray
           val payload  = point("payload").obj
@@ -133,7 +163,7 @@ final class QdrantVectorStore private (
 
   override def get(id: String): Result[Option[VectorRecord]] =
     Try {
-      httpGet(s"$pointsUrl/$id?with_payload=true&with_vector=true").map { response =>
+      httpGet(s"$pointsUrl/${pointId(id)}?with_payload=true&with_vector=true").map { response =>
         val result = response("result")
         if (result.isNull) None
         else Some(pointToRecord(result))
@@ -147,7 +177,7 @@ final class QdrantVectorStore private (
     else
       Try {
         val body = ujson.Obj(
-          "ids"          -> ujson.Arr(ids.map(ujson.Str(_)): _*),
+          "ids"          -> ujson.Arr(ids.map(id => ujson.Str(pointId(id))): _*),
           "with_payload" -> true,
           "with_vector"  -> true
         )
@@ -165,7 +195,7 @@ final class QdrantVectorStore private (
     else
       Try {
         val body = ujson.Obj(
-          "points" -> ujson.Arr(ids.map(ujson.Str(_)): _*)
+          "points" -> ujson.Arr(ids.map(id => ujson.Str(pointId(id))): _*)
         )
         httpPost(s"$pointsUrl/delete?wait=true", body).map(_ => ())
       }.toEither.left
@@ -181,7 +211,9 @@ final class QdrantVectorStore private (
       var hasMore                = true
 
       while (hasMore) {
-        val body = ujson.Obj("limit" -> 100, "with_payload" -> false, "with_vector" -> false)
+        // Payloads are needed here even though the vectors are not: the prefix belongs to the
+        // record ID, and the point ID is a UUID derived from it.
+        val body = ujson.Obj("limit" -> 100, "with_payload" -> true, "with_vector" -> false)
         offset.foreach(o => body("offset") = o)
 
         val result = httpPost(s"$pointsUrl/scroll", body)
@@ -192,8 +224,7 @@ final class QdrantVectorStore private (
               hasMore = false
             } else {
               val matchingIds = points.flatMap { p =>
-                val id = p("id").str
-                if (id.startsWith(prefix)) Some(id) else None
+                if (recordId(p).startsWith(prefix)) Some(pointIdString(p("id"))) else None
               }.toSeq
 
               if (matchingIds.nonEmpty) {
@@ -346,6 +377,7 @@ final class QdrantVectorStore private (
 
   private def recordToPayload(record: VectorRecord): ujson.Obj = {
     val payload = ujson.Obj()
+    payload(QdrantVectorStore.IdKey) = record.id
     record.content.foreach(c => payload("content") = c)
     record.metadata.foreach { case (k, v) =>
       payload(s"meta_$k") = v
@@ -360,7 +392,7 @@ final class QdrantVectorStore private (
       .toMap
 
   private def pointToRecord(point: ujson.Value): VectorRecord = {
-    val id       = point("id").str
+    val id       = recordId(point)
     val vector   = point("vector").arr.map(_.num.toFloat).toArray
     val payload  = point("payload").obj
     val content  = payload.get("content").flatMap(v => if (v.isNull) None else Some(v.str))
@@ -439,6 +471,13 @@ final class QdrantVectorStore private (
 }
 
 object QdrantVectorStore {
+
+  /** Payload key holding the record's own ID; see `pointId` for why it is not the point ID. */
+  private[vectorstore] val IdKey = "llm4s_id"
+
+  private val UuidPattern = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}".r
+
+  private[vectorstore] def isUuid(id: String): Boolean = UuidPattern.matches(id)
 
   /**
    * Configuration for QdrantVectorStore.

--- a/modules/core/src/main/scala/org/llm4s/vectorstore/QdrantVectorStore.scala
+++ b/modules/core/src/main/scala/org/llm4s/vectorstore/QdrantVectorStore.scala
@@ -138,8 +138,8 @@ final class QdrantVectorStore private (
 
       filter.foreach(f => body("filter") = filterToQdrant(f))
 
-      httpPost(s"$pointsUrl/search", body).map { response =>
-        val results = response("result").arr
+      httpPostOptional(s"$pointsUrl/search", body).map { responseOpt =>
+        val results = responseOpt.map(_("result").arr).getOrElse(ujson.Arr().arr)
         results.map { point =>
           val id       = recordId(point)
           val score    = point("score").num
@@ -163,10 +163,8 @@ final class QdrantVectorStore private (
 
   override def get(id: String): Result[Option[VectorRecord]] =
     Try {
-      httpGet(s"$pointsUrl/${pointId(id)}?with_payload=true&with_vector=true").map { response =>
-        val result = response("result")
-        if (result.isNull) None
-        else Some(pointToRecord(result))
+      httpGetOptional(s"$pointsUrl/${pointId(id)}?with_payload=true&with_vector=true").map {
+        _.map(_("result")).filterNot(_.isNull).map(pointToRecord)
       }
     }.toEither.left
       .map(e => ProcessingError("qdrant-store", s"Failed to get: ${e.getMessage}"))
@@ -262,7 +260,8 @@ final class QdrantVectorStore private (
       val body = ujson.Obj("exact" -> true)
       filter.foreach(f => body("filter") = filterToQdrant(f))
 
-      httpPost(s"$pointsUrl/count", body).map(response => response("result")("count").num.toLong)
+      httpPostOptional(s"$pointsUrl/count", body)
+        .map(_.map(_("result")("count").num.toLong).getOrElse(0L))
     }.toEither.left
       .map(e => ProcessingError("qdrant-store", s"Failed to count: ${e.getMessage}"))
       .flatMap(identity)
@@ -277,7 +276,8 @@ final class QdrantVectorStore private (
       )
       filter.foreach(f => body("filter") = filterToQdrant(f))
 
-      httpPost(s"$pointsUrl/scroll", body).map(response => response("result")("points").arr.map(pointToRecord).toSeq)
+      httpPostOptional(s"$pointsUrl/scroll", body)
+        .map(_.map(_("result")("points").arr.map(pointToRecord).toSeq).getOrElse(Seq.empty))
     }.toEither.left
       .map(e => ProcessingError("qdrant-store", s"Failed to list: ${e.getMessage}"))
       .flatMap(identity)
@@ -288,22 +288,22 @@ final class QdrantVectorStore private (
 
   override def stats(): Result[VectorStoreStats] =
     Try {
-      httpGet(collectionsUrl).map { response =>
-        val result        = response("result")
-        val totalRecords  = result("points_count").num.toLong
-        val vectorsConfig = result("config")("params")("vectors")
+      httpGetOptional(collectionsUrl).map {
+        // A collection that does not exist yet is an empty store, not a failure.
+        case None => VectorStoreStats(totalRecords = 0L, dimensions = Set.empty, sizeBytes = None)
+        case Some(response) =>
+          val result        = response("result")
+          val vectorsConfig = result("config")("params")("vectors")
 
-        val dimensions = if (vectorsConfig.obj.contains("size")) {
-          Set(vectorsConfig("size").num.toInt)
-        } else {
-          Set.empty[Int]
-        }
+          val dimensions =
+            if (vectorsConfig.obj.contains("size")) Set(vectorsConfig("size").num.toInt)
+            else Set.empty[Int]
 
-        VectorStoreStats(
-          totalRecords = totalRecords,
-          dimensions = dimensions,
-          sizeBytes = None // Qdrant doesn't expose this directly
-        )
+          VectorStoreStats(
+            totalRecords = result("points_count").num.toLong,
+            dimensions = dimensions,
+            sizeBytes = None // Qdrant doesn't expose this directly
+          )
       }
     }.toEither.left
       .map(e => ProcessingError("qdrant-store", s"Failed to get stats: ${e.getMessage}"))
@@ -316,6 +316,37 @@ final class QdrantVectorStore private (
   // ============================================================
   // HTTP Helpers
   // ============================================================
+
+  /**
+   * A read of something that is not there.
+   *
+   * Qdrant answers 404 both for a point that does not exist and for a collection that does
+   * not exist - and the collection legitimately does not exist much of the time here, since
+   * it is created lazily on the first upsert and removed outright by `clear()`. Absence is
+   * not a failure for a read: `get` has an `Option` in its return type precisely to say so,
+   * and an empty store counts 0 rather than erroring. Writes keep the 404 as an error.
+   */
+  private def httpGetOptional(url: String): Result[Option[ujson.Value]] =
+    Try(httpClient.get(url, headers = authHeaders)).toEither.left
+      .map(e => ProcessingError("qdrant-store", s"HTTP GET failed: ${e.getMessage}"))
+      .flatMap {
+        case response if response.statusCode == 404 => Right(None)
+        case response                               => handleResponse(response).map(Some(_))
+      }
+
+  private def httpPostOptional(url: String, body: ujson.Value): Result[Option[ujson.Value]] =
+    Try(
+      httpClient.post(
+        url,
+        headers = authHeaders ++ Map("Content-Type" -> "application/json"),
+        body = ujson.write(body)
+      )
+    ).toEither.left
+      .map(e => ProcessingError("qdrant-store", s"HTTP POST failed: ${e.getMessage}"))
+      .flatMap {
+        case response if response.statusCode == 404 => Right(None)
+        case response                               => handleResponse(response).map(Some(_))
+      }
 
   private def httpGet(url: String): Result[ujson.Value] =
     Try {

--- a/modules/core/src/main/scala/org/llm4s/vectorstore/QdrantVectorStore.scala
+++ b/modules/core/src/main/scala/org/llm4s/vectorstore/QdrantVectorStore.scala
@@ -221,12 +221,14 @@ final class QdrantVectorStore private (
             if (points.isEmpty) {
               hasMore = false
             } else {
+              // Carry the ID as the JSON value Qdrant gave us: a point written by another
+              // tool may have an integer ID, and re-sending it as a string is not the same ID.
               val matchingIds = points.flatMap { p =>
-                if (recordId(p).startsWith(prefix)) Some(pointIdString(p("id"))) else None
+                if (recordId(p).startsWith(prefix)) Some(p("id")) else None
               }.toSeq
 
               if (matchingIds.nonEmpty) {
-                val deleteBody = ujson.Obj("points" -> ujson.Arr(matchingIds.map(ujson.Str(_)): _*))
+                val deleteBody = ujson.Obj("points" -> ujson.Arr(matchingIds: _*))
                 httpPost(s"$pointsUrl/delete?wait=true", deleteBody)
                 deleted += matchingIds.size
               }

--- a/modules/core/src/test/scala/org/llm4s/vectorstore/QdrantVectorStoreHttpSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/vectorstore/QdrantVectorStoreHttpSpec.scala
@@ -266,6 +266,56 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
     store.get("test-1").toOption.flatten.map(_.id) shouldBe Some("test-1")
   }
 
+  it should "fall back to the point ID for a point written without one" in {
+    val mockClient = createMockClient()
+    val store      = createStore(mockClient)
+
+    // A point put there by something other than llm4s carries no `llm4s_id`, and Qdrant's
+    // other legal ID form is an integer rather than a string.
+    (mockClient.post _)
+      .when(s"$pointsUrl/search", *, *, *)
+      .returns(
+        httpResponse(
+          200,
+          """{"result": [{ "id": 7, "score": 0.5, "vector": [0.1], "payload": { "content": "foreign" } }]}"""
+        )
+      )
+
+    store.search(Array(0.1f), topK = 1).toOption.flatMap(_.headOption).map(_.record.id) shouldBe Some("7")
+  }
+
+  it should "degrade to the raw JSON for a point ID that is neither string nor integer" in {
+    val mockClient = createMockClient()
+    val store      = createStore(mockClient)
+
+    // Not something Qdrant should ever send. Reading it as text keeps a malformed response
+    // from throwing inside what is otherwise a total read path.
+    (mockClient.post _)
+      .when(s"$pointsUrl/search", *, *, *)
+      .returns(httpResponse(200, """{"result": [{ "id": null, "score": 0.5, "vector": [0.1], "payload": {} }]}"""))
+
+    store.search(Array(0.1f), topK = 1).toOption.flatMap(_.headOption).map(_.record.id) shouldBe Some("null")
+  }
+
+  it should "be sent as derived UUIDs when deleting a batch" in {
+    val mockClient = createMockClient()
+    val store      = createStore(mockClient)
+
+    (mockClient.post _)
+      .when(s"$pointsUrl/delete?wait=true", *, *, *)
+      .returns(httpResponse(200, """{"result": "ok"}"""))
+
+    store.deleteBatch(Seq("test-1", "test-2")) shouldBe Right(())
+
+    (mockClient.post _).verify(
+      where { (url: String, _: Map[String, String], body: String, _: Int) =>
+        url == s"$pointsUrl/delete?wait=true" &&
+        ujson.read(body)("points").arr.map(_.str).toSeq ==
+          Seq(testPointId, QdrantVectorStore.derivedPointId("test-2"))
+      }
+    )
+  }
+
   // ============================================================
   // Reads of a store that does not exist yet
   // ============================================================
@@ -290,6 +340,30 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
 
     store.search(Array(0.1f, 0.2f, 0.3f), topK = 5) shouldBe Right(Seq.empty)
     store.list(limit = 10, offset = 0) shouldBe Right(Seq.empty)
+  }
+
+  it should "report no dimensions for a collection configured with named vectors" in {
+    val mockClient = createMockClient()
+    val store      = createStore(mockClient)
+
+    // Named-vector collections nest each vector's size under its name, so there is no single
+    // dimension to report.
+    val namedVectors = """{
+      "result": {
+        "points_count": 3,
+        "config": { "params": { "vectors": { "title": { "size": 4, "distance": "Cosine" } } } }
+      }
+    }"""
+
+    val freshClient = stub[Llm4sHttpClient]
+    (freshClient.get _).when(collectionsUrl, *, *, *).returns(httpResponse(200, namedVectors))
+    val namedStore = QdrantVectorStore(testConfig, freshClient) match {
+      case Right(s)  => s
+      case Left(err) => fail(s"Failed to create store: ${err.formatted}")
+    }
+
+    namedStore.stats() shouldBe Right(VectorStoreStats(totalRecords = 3L, dimensions = Set.empty, sizeBytes = None))
+    store.stats().isRight shouldBe true
   }
 
   it should "report a zero-record store rather than fail" in {

--- a/modules/core/src/test/scala/org/llm4s/vectorstore/QdrantVectorStoreHttpSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/vectorstore/QdrantVectorStoreHttpSpec.scala
@@ -234,6 +234,71 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
   }
 
   // ============================================================
+  // Reads of a store that does not exist yet
+  // ============================================================
+
+  "a read of a collection that does not exist" should "count zero rather than fail" in {
+    val mockClient = createMockClient()
+    val store      = createStore(mockClient)
+
+    // `clear()` deletes the collection outright and the next upsert recreates it, so an
+    // empty store legitimately 404s.
+    (mockClient.post _).when(s"$pointsUrl/count", *, *, *).returns(httpResponse(404, "Not found"))
+
+    store.count() shouldBe Right(0L)
+  }
+
+  it should "search and list as empty rather than fail" in {
+    val mockClient = createMockClient()
+    val store      = createStore(mockClient)
+
+    (mockClient.post _).when(s"$pointsUrl/search", *, *, *).returns(httpResponse(404, "Not found"))
+    (mockClient.post _).when(s"$pointsUrl/scroll", *, *, *).returns(httpResponse(404, "Not found"))
+
+    store.search(Array(0.1f, 0.2f, 0.3f), topK = 5) shouldBe Right(Seq.empty)
+    store.list(limit = 10, offset = 0) shouldBe Right(Seq.empty)
+  }
+
+  it should "report a zero-record store rather than fail" in {
+    val mockClient = createMockClient()
+    val store      = createStore(mockClient)
+
+    // The store's constructor already stubs this URL as a 404.
+    store.stats() shouldBe Right(VectorStoreStats(totalRecords = 0L, dimensions = Set.empty, sizeBytes = None))
+  }
+
+  // ============================================================
+  // deleteByPrefix
+  // ============================================================
+
+  "deleteByPrefix" should "match on the record ID and delete by the ID Qdrant gave it" in {
+    val mockClient = createMockClient()
+    val store      = createStore(mockClient)
+
+    // No `next_page_offset`, so one page ends the scroll. The integer ID is what a point
+    // written by another tool looks like; the record ID still comes from the payload.
+    val scrollJson = """{
+      "result": {
+        "points": [
+          { "id": 7, "payload": { "llm4s_id": "doc-1" } },
+          { "id": "70a37754-eb5a-3e7d-b8cd-887aaf11cda7", "payload": { "llm4s_id": "other-1" } }
+        ]
+      }
+    }"""
+
+    (mockClient.post _).when(s"$pointsUrl/scroll", *, *, *).returns(httpResponse(200, scrollJson))
+    (mockClient.post _).when(s"$pointsUrl/delete?wait=true", *, *, *).returns(httpResponse(200, """{"result": "ok"}"""))
+
+    store.deleteByPrefix("doc-") shouldBe Right(1L)
+
+    (mockClient.post _).verify(
+      where { (url: String, _: Map[String, String], body: String, _: Int) =>
+        url == s"$pointsUrl/delete?wait=true" && ujson.read(body)("points") == ujson.Arr(ujson.Num(7))
+      }
+    )
+  }
+
+  // ============================================================
   // httpPost tests (via search, count, getBatch methods)
   // ============================================================
 

--- a/modules/core/src/test/scala/org/llm4s/vectorstore/QdrantVectorStoreHttpSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/vectorstore/QdrantVectorStoreHttpSpec.scala
@@ -22,7 +22,7 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
   // "test-1" reaches it as a UUID derived from that string, with the record's own ID carried
   // in the payload. Spelled out as a literal rather than recomputed, so that a change to the
   // derivation - which would orphan every point already written - shows up as a test failure.
-  private val testPointId  = "70a37754-eb5a-3e7d-b8cd-887aaf11cda7"
+  private val testPointId  = "0d75226c-b7a2-849e-8abb-9be195dca8ec"
   private val testPointUrl = s"$pointsUrl/$testPointId?with_payload=true&with_vector=true"
 
   // Helper to create a mock HTTP client
@@ -213,13 +213,46 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
     store.get(uuid) shouldBe Right(None)
   }
 
+  it should "keep a caller-supplied UUID clear of the derived ID it looks like" in {
+    val mockClient = createMockClient()
+    val store      = createStore(mockClient)
+
+    // The derivation is public, so a caller can supply the UUID that "test-1" maps to as a
+    // record ID in its own right. The two records must not end up on the same point.
+    val literalUuidRecord = testPointId
+    val itsPoint          = QdrantVectorStore.derivedPointId(literalUuidRecord)
+    itsPoint should not be testPointId
+
+    (mockClient.get _)
+      .when(testPointUrl, *, *, *)
+      .returns(
+        httpResponse(
+          200,
+          s"""{"result": {"id": "$testPointId", "vector": [0.1],
+                                     "payload": {"llm4s_id": "test-1"}}}"""
+        )
+      )
+    (mockClient.get _)
+      .when(s"$pointsUrl/$itsPoint?with_payload=true&with_vector=true", *, *, *)
+      .returns(
+        httpResponse(
+          200,
+          s"""{"result": {"id": "$itsPoint", "vector": [0.2],
+                                     "payload": {"llm4s_id": "$literalUuidRecord"}}}"""
+        )
+      )
+
+    store.get("test-1").toOption.flatten.map(_.id) shouldBe Some("test-1")
+    store.get(literalUuidRecord).toOption.flatten.map(_.id) shouldBe Some(literalUuidRecord)
+  }
+
   it should "be read back from the payload rather than from the point ID" in {
     val mockClient = createMockClient()
     val store      = createStore(mockClient)
 
     val responseJson = """{
       "result": {
-        "id": "70a37754-eb5a-3e7d-b8cd-887aaf11cda7",
+        "id": "0d75226c-b7a2-849e-8abb-9be195dca8ec",
         "vector": [0.1, 0.2, 0.3],
         "payload": {
           "llm4s_id": "test-1",
@@ -281,7 +314,7 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
       "result": {
         "points": [
           { "id": 7, "payload": { "llm4s_id": "doc-1" } },
-          { "id": "70a37754-eb5a-3e7d-b8cd-887aaf11cda7", "payload": { "llm4s_id": "other-1" } }
+          { "id": "0d75226c-b7a2-849e-8abb-9be195dca8ec", "payload": { "llm4s_id": "other-1" } }
         ]
       }
     }"""

--- a/modules/core/src/test/scala/org/llm4s/vectorstore/QdrantVectorStoreHttpSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/vectorstore/QdrantVectorStoreHttpSpec.scala
@@ -18,6 +18,13 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
   private val collectionsUrl = s"$testUrl/collections/$testCollection"
   private val pointsUrl      = s"$collectionsUrl/points"
 
+  // Qdrant only accepts an unsigned integer or a UUID as a point ID, so a record ID like
+  // "test-1" reaches it as a UUID derived from that string, with the record's own ID carried
+  // in the payload. Spelled out as a literal rather than recomputed, so that a change to the
+  // derivation - which would orphan every point already written - shows up as a test failure.
+  private val testPointId  = "70a37754-eb5a-3e7d-b8cd-887aaf11cda7"
+  private val testPointUrl = s"$pointsUrl/$testPointId?with_payload=true&with_vector=true"
+
   // Helper to create a mock HTTP client
   private def createMockClient(): Llm4sHttpClient = stub[Llm4sHttpClient]
 
@@ -62,7 +69,7 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
     }"""
 
     (mockClient.get _)
-      .when(s"$pointsUrl/test-1?with_payload=true&with_vector=true", *, *, *)
+      .when(testPointUrl, *, *, *)
       .returns(httpResponse(200, responseJson))
 
     val result = store.get("test-1")
@@ -75,7 +82,7 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
     val store      = createStore(mockClient)
 
     (mockClient.get _)
-      .when(s"$pointsUrl/test-1?with_payload=true&with_vector=true", *, *, *)
+      .when(testPointUrl, *, *, *)
       .returns(httpResponse(404, "Not found"))
 
     val result = store.get("test-1")
@@ -88,7 +95,7 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
     val store      = createStore(mockClient)
 
     (mockClient.get _)
-      .when(s"$pointsUrl/test-1?with_payload=true&with_vector=true", *, *, *)
+      .when(testPointUrl, *, *, *)
       .returns(httpResponse(500, "Internal server error"))
 
     val result = store.get("test-1")
@@ -104,7 +111,7 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
     val store      = createStore(mockClient)
 
     (mockClient.get _)
-      .when(s"$pointsUrl/test-1?with_payload=true&with_vector=true", *, *, *)
+      .when(testPointUrl, *, *, *)
       .returns(httpResponse(403, "Forbidden"))
 
     val result = store.get("test-1")
@@ -120,7 +127,7 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
     val store      = createStore(mockClient)
 
     (mockClient.get _)
-      .when(s"$pointsUrl/test-1?with_payload=true&with_vector=true", *, *, *)
+      .when(testPointUrl, *, *, *)
       .throws(new RuntimeException("Connection timeout"))
 
     val result = store.get("test-1")
@@ -166,6 +173,63 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
         stats.dimensions shouldBe Set(3)
       case Left(err) => fail(s"Expected Right but got Left: ${err.formatted}")
     }
+  }
+
+  // ============================================================
+  // Point ID mapping
+  // ============================================================
+
+  "point IDs" should "be sent to Qdrant as a UUID, with the record ID kept in the payload" in {
+    val mockClient = createMockClient()
+    val store      = createStore(mockClient)
+
+    // The store creates the collection first, since the mocked existence check 404s.
+    (mockClient.put _).when(collectionsUrl, *, *, *).returns(httpResponse(200, """{"result": "ok"}"""))
+    (mockClient.put _).when(s"$pointsUrl?wait=true", *, *, *).returns(httpResponse(200, """{"result": "ok"}"""))
+
+    store.upsert(VectorRecord("test-1", Array(0.1f, 0.2f, 0.3f), Some("Test content"))) shouldBe Right(())
+
+    (mockClient.put _).verify(
+      // Guard on the URL first: the collection-creation PUT above carries no points array.
+      where { (url: String, _: Map[String, String], body: String, _: Int) =>
+        url == s"$pointsUrl?wait=true" && {
+          val point = ujson.read(body)("points").arr.head
+          point("id").str == testPointId && point("payload")("llm4s_id").str == "test-1"
+        }
+      }
+    )
+  }
+
+  it should "pass a record ID that is already a UUID through unchanged" in {
+    val mockClient = createMockClient()
+    val store      = createStore(mockClient)
+    val uuid       = "123e4567-e89b-12d3-a456-426614174000"
+
+    (mockClient.get _)
+      .when(s"$pointsUrl/$uuid?with_payload=true&with_vector=true", *, *, *)
+      .returns(httpResponse(404, "Not found"))
+
+    store.get(uuid).isLeft shouldBe true
+  }
+
+  it should "be read back from the payload rather than from the point ID" in {
+    val mockClient = createMockClient()
+    val store      = createStore(mockClient)
+
+    val responseJson = """{
+      "result": {
+        "id": "70a37754-eb5a-3e7d-b8cd-887aaf11cda7",
+        "vector": [0.1, 0.2, 0.3],
+        "payload": {
+          "llm4s_id": "test-1",
+          "content": "Test content"
+        }
+      }
+    }"""
+
+    (mockClient.get _).when(testPointUrl, *, *, *).returns(httpResponse(200, responseJson))
+
+    store.get("test-1").toOption.flatten.map(_.id) shouldBe Some("test-1")
   }
 
   // ============================================================
@@ -550,7 +614,7 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
 
     // Test 405 Method Not Allowed
     (mockClient.get _)
-      .when(s"$pointsUrl/test-1?with_payload=true&with_vector=true", *, *, *)
+      .when(testPointUrl, *, *, *)
       .returns(httpResponse(405, "Method Not Allowed"))
 
     val result = store.get("test-1")
@@ -564,7 +628,7 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
 
     // Return invalid JSON
     (mockClient.get _)
-      .when(s"$pointsUrl/test-1?with_payload=true&with_vector=true", *, *, *)
+      .when(testPointUrl, *, *, *)
       .returns(httpResponse(200, "not valid json"))
 
     val result = store.get("test-1")

--- a/modules/core/src/test/scala/org/llm4s/vectorstore/QdrantVectorStoreHttpSpec.scala
+++ b/modules/core/src/test/scala/org/llm4s/vectorstore/QdrantVectorStoreHttpSpec.scala
@@ -77,7 +77,7 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
     result.toOption.flatten.map(_.id) shouldBe Some("test-1")
   }
 
-  it should "handle 404 Not Found error" in {
+  it should "report a 404 as an absent record, not as an error" in {
     val mockClient = createMockClient()
     val store      = createStore(mockClient)
 
@@ -85,9 +85,9 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
       .when(testPointUrl, *, *, *)
       .returns(httpResponse(404, "Not found"))
 
-    val result = store.get("test-1")
-    result.isLeft shouldBe true
-    result.left.map(error => error.formatted should include("Not found"))
+    // Qdrant 404s for a point that does not exist, and for a collection not created yet.
+    // `get` returns an Option precisely so that absence has somewhere to go other than Left.
+    store.get("test-1") shouldBe Right(None)
   }
 
   it should "handle 500 Internal Server Error" in {
@@ -209,7 +209,8 @@ class QdrantVectorStoreHttpSpec extends AnyFlatSpec with Matchers with MockFacto
       .when(s"$pointsUrl/$uuid?with_payload=true&with_vector=true", *, *, *)
       .returns(httpResponse(404, "Not found"))
 
-    store.get(uuid).isLeft shouldBe true
+    // Reaching the stub at all is the assertion: an unmapped URL would not match it.
+    store.get(uuid) shouldBe Right(None)
   }
 
   it should "be read back from the payload rather than from the point ID" in {

--- a/modules/it/README.md
+++ b/modules/it/README.md
@@ -6,26 +6,64 @@ This module is not published. It exists so the main published artifacts can keep
 fast, self-contained unit tests while live integration suites remain available
 on demand and in CI.
 
-## Running the Tests
+## Tiers
+
+Every suite here declares, by class annotation, what it needs to run - and therefore
+which command and which CI job runs it. `sbt it/itTierCheck` fails the build if a suite
+declares no tier or more than one, so a suite cannot end up being run by nothing.
+
+| Tag | Needs | Command | CI |
+|---|---|---|---|
+| `@Local` | nothing external | `sbt test` | every PR |
+| `@Docker` | Postgres/pgvector, Qdrant or Neo4j | `sbt testIntegration` | every PR (service containers) |
+| `@Workspace` | Docker + a built `workspace-runner` image | `sbt testWorkspace` | pushes to `main` |
+| `@Ollama` | a local Ollama with `qwen2.5:0.5b` pulled | `sbt testOllama` | pushes to `main` |
+| `@Cloud` | live provider API keys | `sbt testSmoke` | manual `workflow_dispatch` |
+
+```scala
+import org.llm4s.it.tags.Docker
+
+@Docker
+class PgVectorStoreSpec extends AnyWordSpec with Matchers {
+```
+
+Tags come from `org.llm4s.it.tags` (see `src/test/java/org/llm4s/it/tags/`). They are Java
+annotations because ScalaTest only honours a whole-suite tag in that form.
+
+`sbt "it/testOnly org.llm4s.vectorstore.PgVectorStoreSpec"` still runs a single suite
+whatever tier it is in - the tier filter applies to `test`, not to `testOnly`.
+
+## Running the containerised tier
 
 ```bash
 # Start Neo4j (Docker, easiest):
-docker run --rm -p 7687:7687 -e NEO4J_AUTH=neo4j/neo4j neo4j:5
+docker run --rm -p 7687:7687 -e NEO4J_AUTH=neo4j/llm4stest neo4j:5
 
 # Start PostgreSQL + pgvector:
-docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=password pgvector/pgvector:pg16
+docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres pgvector/pgvector:pg16
 
 # Start Qdrant:
 docker run --rm -p 6333:6333 qdrant/qdrant
 
-# Run the integration suite:
-sbt "it/test"
+export PGVECTOR_TEST_URL=jdbc:postgresql://localhost:5432/postgres
+export PGVECTOR_USER=postgres PGVECTOR_PASSWORD=postgres
+export PGVECTOR_TEST_USER=postgres PGVECTOR_TEST_PASSWORD=postgres
+export POSTGRES_TEST_ENABLED=true POSTGRES_PASSWORD=postgres
+export QDRANT_TEST_URL=http://localhost:6333
+export NEO4J_URI=bolt://localhost:7687 NEO4J_USER=neo4j NEO4J_PASSWORD=llm4stest
+
+sbt testIntegration
 ```
 
-The current integration suites use:
+A suite whose service is missing cancels its tests, which ScalaTest reports as skipped.
+Set `LLM4S_IT_STRICT=true` - as every tier's CI job does - to make that a failure instead,
+so a service that did not start cannot pass for a suite that did.
+
+## Environment variables
+
 - Neo4j via `NEO4J_URI`, `NEO4J_USER`, and `NEO4J_PASSWORD`
 - PostgreSQL/pgvector via `PGVECTOR_TEST_URL`, `PGVECTOR_TEST_USER`, `PGVECTOR_TEST_PASSWORD`, or the `POSTGRES_*` variables used by memory tests
 - Qdrant via `QDRANT_TEST_URL` and `QDRANT_TEST_API_KEY`
-- Docker-backed workspace tests via `LLM4S_DOCKER_TESTS=true`
+- Docker-backed workspace tests via `LLM4S_DOCKER_TESTS=true`; the image tag comes from the build as `LLM4S_WORKSPACE_IMAGE`
 - Ollama via a local server at `http://localhost:11434` with `qwen2.5:0.5b` pulled
-- Cloud provider smoke tests via credentials such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, and `DEEPSEEK_API_KEY`
+- Cloud provider smoke tests via credentials such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `DEEPSEEK_API_KEY`, and `COHERE_API_KEY`

--- a/modules/it/src/test/java/org/llm4s/it/tags/Cloud.java
+++ b/modules/it/src/test/java/org/llm4s/it/tags/Cloud.java
@@ -1,0 +1,17 @@
+package org.llm4s.it.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.scalatest.TagAnnotation;
+
+/**
+ * Tier 4: needs live provider API keys and spends real money.
+ *
+ * <p>Run with {@code sbt testSmoke}; CI runs it only on manual {@code workflow_dispatch}.
+ */
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Cloud {}

--- a/modules/it/src/test/java/org/llm4s/it/tags/Docker.java
+++ b/modules/it/src/test/java/org/llm4s/it/tags/Docker.java
@@ -1,0 +1,18 @@
+package org.llm4s.it.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.scalatest.TagAnnotation;
+
+/**
+ * Tier 2: needs a containerised service - Postgres/pgvector, Qdrant or Neo4j.
+ *
+ * <p>Run with {@code sbt testIntegration}; CI runs it on every PR with the services provided as
+ * job service containers. Reproducible and secret-free, so it is not behind a manual gate.
+ */
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Docker {}

--- a/modules/it/src/test/java/org/llm4s/it/tags/Local.java
+++ b/modules/it/src/test/java/org/llm4s/it/tags/Local.java
@@ -1,0 +1,15 @@
+package org.llm4s.it.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.scalatest.TagAnnotation;
+
+/**
+ * Tier 1: needs nothing external. Included in the default {@code sbt test} run.
+ */
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Local {}

--- a/modules/it/src/test/java/org/llm4s/it/tags/Ollama.java
+++ b/modules/it/src/test/java/org/llm4s/it/tags/Ollama.java
@@ -1,0 +1,18 @@
+package org.llm4s.it.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.scalatest.TagAnnotation;
+
+/**
+ * Tier 3: needs a local Ollama server with the test model pulled
+ * ({@code ollama pull qwen2.5:0.5b}).
+ *
+ * <p>Run with {@code sbt testOllama}; CI runs it on pushes to main.
+ */
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Ollama {}

--- a/modules/it/src/test/java/org/llm4s/it/tags/Workspace.java
+++ b/modules/it/src/test/java/org/llm4s/it/tags/Workspace.java
@@ -1,0 +1,19 @@
+package org.llm4s.it.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.scalatest.TagAnnotation;
+
+/**
+ * Tier 2: needs a Docker daemon plus a locally built {@code workspace-runner} image
+ * ({@code sbt workspaceRunner/Docker/publishLocal}).
+ *
+ * <p>Run with {@code sbt testWorkspace}. Separate from {@link Docker} because the image build is
+ * expensive, so CI runs this tier on pushes to main rather than on every PR.
+ */
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Workspace {}

--- a/modules/it/src/test/java/org/llm4s/it/tags/package-info.java
+++ b/modules/it/src/test/java/org/llm4s/it/tags/package-info.java
@@ -1,0 +1,25 @@
+/**
+ * Tier tags for the integration-test module.
+ *
+ * <p>Every suite in {@code modules/it} must carry exactly one of these annotations. The tag
+ * names the external thing the suite needs, and therefore which CI job runs it; a suite with
+ * no tag is executed by nothing, which is the failure {@code it/itTierCheck} exists to
+ * prevent (see issue #1143).
+ *
+ * <p>The tiers:
+ *
+ * <ul>
+ *   <li>{@link org.llm4s.it.tags.Local} - nothing external. Runs in every {@code sbt test}.
+ *   <li>{@link org.llm4s.it.tags.Docker} - a containerised service (Postgres/pgvector, Qdrant,
+ *       Neo4j). Runs on every PR via CI service containers ({@code sbt testIntegration}).
+ *   <li>{@link org.llm4s.it.tags.Workspace} - a locally built {@code workspace-runner} image
+ *       plus a Docker daemon ({@code sbt testWorkspace}).
+ *   <li>{@link org.llm4s.it.tags.Ollama} - a local Ollama server ({@code sbt testOllama}).
+ *   <li>{@link org.llm4s.it.tags.Cloud} - live provider API keys ({@code sbt testSmoke}).
+ * </ul>
+ *
+ * <p>These are Java annotations rather than ScalaTest {@code Tag} objects because ScalaTest
+ * only honours a whole-suite tag when it is a runtime-retained Java annotation that is itself
+ * annotated with {@link org.scalatest.TagAnnotation}.
+ */
+package org.llm4s.it.tags;

--- a/modules/it/src/test/scala/org/llm4s/agent/memory/PostgresMemoryStoreSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/agent/memory/PostgresMemoryStoreSpec.scala
@@ -8,6 +8,8 @@ import org.scalatest.matchers.should.Matchers
 
 import java.util.UUID
 import scala.util.Try
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Docker
 
 /**
  * Integration tests for PostgresMemoryStore.
@@ -18,6 +20,7 @@ import scala.util.Try
  *   2. Enable tests: export POSTGRES_TEST_ENABLED=true
  *   3. Run: sbt "it/testOnly org.llm4s.agent.memory.PostgresMemoryStoreSpec"
  */
+@Docker
 class PostgresMemoryStoreSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
   private val isEnabled = sys.env.get("POSTGRES_TEST_ENABLED").exists(_.toBoolean)
@@ -44,9 +47,10 @@ class PostgresMemoryStoreSpec extends AnyFlatSpec with Matchers with BeforeAndAf
   override def afterEach(): Unit =
     if (store != null) { Try(store.clear()); store.close() }
 
-  private def skipIfDisabled(testBody: => Unit): Unit =
-    if (isEnabled) testBody
-    else info("Skipping Postgres test (POSTGRES_TEST_ENABLED=true not set)")
+  private def skipIfDisabled(testBody: => Unit): Unit = {
+    Tier.require(isEnabled, "POSTGRES_TEST_ENABLED=true not set")
+    testBody
+  }
 
   it should "store and retrieve a conversation memory" in skipIfDisabled {
     val id = MemoryId(UUID.randomUUID().toString)
@@ -59,16 +63,18 @@ class PostgresMemoryStoreSpec extends AnyFlatSpec with Matchers with BeforeAndAf
 
     store.store(memory).isRight shouldBe true
 
-    store.get(id).fold(
-      e => fail(s"Get failed: ${e.message}"),
-      {
-        case Some(retrieved) =>
-          retrieved.content shouldBe "Hello, I am a test memory"
-          retrieved.metadata.get("conversation_id") shouldBe Some("conv-1")
-        case None =>
-          fail("Expected memory to be present, but got None")
-      }
-    )
+    store
+      .get(id)
+      .fold(
+        e => fail(s"Get failed: ${e.message}"),
+        {
+          case Some(retrieved) =>
+            retrieved.content shouldBe "Hello, I am a test memory"
+            retrieved.metadata.get("conversation_id") shouldBe Some("conv-1")
+          case None =>
+            fail("Expected memory to be present, but got None")
+        }
+      )
   }
 
   it should "persist data across store instances" in skipIfDisabled {
@@ -78,23 +84,27 @@ class PostgresMemoryStoreSpec extends AnyFlatSpec with Matchers with BeforeAndAf
     store.close()
     val store2 = PostgresMemoryStore(dbConfig).fold(e => fail(e.message), identity)
 
-    store2.get(id).fold(
-      e => fail(s"Get failed on store2: ${e.message}"),
-      {
-        case Some(retrieved) =>
-          retrieved.content shouldBe "Persistence Check"
-        case None =>
-          fail("Persistence check failed: Memory not found in new store instance")
-      }
-    )
+    store2
+      .get(id)
+      .fold(
+        e => fail(s"Get failed on store2: ${e.message}"),
+        {
+          case Some(retrieved) =>
+            retrieved.content shouldBe "Persistence Check"
+          case None =>
+            fail("Persistence check failed: Memory not found in new store instance")
+        }
+      )
     store2.close()
   }
 
   it should "perform semantic search" in skipIfDisabled {
-    val applesEmbedding = embeddingService.embed("apples").fold(
-      e => fail(s"Test setup embedding failed: ${e.message}"),
-      identity
-    )
+    val applesEmbedding = embeddingService
+      .embed("apples")
+      .fold(
+        e => fail(s"Test setup embedding failed: ${e.message}"),
+        identity
+      )
     val relevant = Memory(
       MemoryId("1"),
       "I like apples",
@@ -103,14 +113,16 @@ class PostgresMemoryStoreSpec extends AnyFlatSpec with Matchers with BeforeAndAf
     )
     store.store(relevant)
 
-    store.search("apple", 1, MemoryFilter.All).fold(
-      e => fail(s"Search failed: ${e.message}"),
-      results =>
-        results match {
-          case first +: _ => first.memory.content shouldBe "I like apples"
-          case Nil        => fail("Expected at least one search result")
-        }
-    )
+    store
+      .search("apple", 1, MemoryFilter.All)
+      .fold(
+        e => fail(s"Search failed: ${e.message}"),
+        results =>
+          results match {
+            case first +: _ => first.memory.content shouldBe "I like apples"
+            case Nil        => fail("Expected at least one search result")
+          }
+      )
   }
 
   it should "fallback gracefully when EmbeddingService is missing" in skipIfDisabled {
@@ -118,22 +130,26 @@ class PostgresMemoryStoreSpec extends AnyFlatSpec with Matchers with BeforeAndAf
     val id         = MemoryId("fallback-1")
     storeNoEmb.store(Memory(id, "test fallback", MemoryType.Task, Map.empty))
 
-    storeNoEmb.search("query", 5, MemoryFilter.All).fold(
-      e => fail(s"Fallback search failed: ${e.message}"),
-      memories =>
-        memories match {
-          case first +: _ => first.score shouldBe 0.0
-          case Nil        => fail("Expected fallback search to return at least one memory")
-        }
-    )
+    storeNoEmb
+      .search("query", 5, MemoryFilter.All)
+      .fold(
+        e => fail(s"Fallback search failed: ${e.message}"),
+        memories =>
+          memories match {
+            case first +: _ => first.score shouldBe 0.0
+            case Nil        => fail("Expected fallback search to return at least one memory")
+          }
+      )
     storeNoEmb.close()
   }
 
   it should "clamp similarity scores to [0, 1]" in skipIfDisabled {
-    val clampEmbedding = embeddingService.embed("clamp example").fold(
-      e => fail(s"Test setup embedding failed: ${e.message}"),
-      identity
-    )
+    val clampEmbedding = embeddingService
+      .embed("clamp example")
+      .fold(
+        e => fail(s"Test setup embedding failed: ${e.message}"),
+        identity
+      )
 
     val memory = Memory(
       MemoryId("clamp-test"),
@@ -143,19 +159,21 @@ class PostgresMemoryStoreSpec extends AnyFlatSpec with Matchers with BeforeAndAf
     )
     store.store(memory).isRight shouldBe true
 
-    store.search("clamp", 5, MemoryFilter.All).fold(
-      e => fail(s"Search failed: ${e.message}"),
-      results =>
-        results match {
-          case _ +: _ =>
-            results.foreach { sm =>
-              sm.score should be >= 0.0
-              sm.score should be <= 1.0
-            }
-          case Nil =>
-            fail("Expected non-empty results for clamp test")
-        }
-    )
+    store
+      .search("clamp", 5, MemoryFilter.All)
+      .fold(
+        e => fail(s"Search failed: ${e.message}"),
+        results =>
+          results match {
+            case _ +: _ =>
+              results.foreach { sm =>
+                sm.score should be >= 0.0
+                sm.score should be <= 1.0
+              }
+            case Nil =>
+              fail("Expected non-empty results for clamp test")
+          }
+      )
   }
 
   it should "fail when embedding service returns empty vector" in skipIfDisabled {
@@ -167,10 +185,12 @@ class PostgresMemoryStoreSpec extends AnyFlatSpec with Matchers with BeforeAndAf
 
     val storeWithEmpty = PostgresMemoryStore(dbConfig, Some(emptyService)).fold(e => fail(e.message), identity)
 
-    storeWithEmpty.search("query", 5, MemoryFilter.All).fold(
-      err => err.message should include("vector is empty"),
-      _ => fail("Expected search to fail due to empty embedding, but it succeeded")
-    )
+    storeWithEmpty
+      .search("query", 5, MemoryFilter.All)
+      .fold(
+        err => err.message should include("vector is empty"),
+        _ => fail("Expected search to fail due to empty embedding, but it succeeded")
+      )
     storeWithEmpty.close()
   }
 
@@ -183,10 +203,12 @@ class PostgresMemoryStoreSpec extends AnyFlatSpec with Matchers with BeforeAndAf
 
     val storeFailing = PostgresMemoryStore(dbConfig, Some(failingService)).fold(e => fail(e.message), identity)
 
-    storeFailing.search("query", 5, MemoryFilter.All).fold(
-      err => err.message should include("boom"),
-      _ => fail("Expected search to fail due to embedding service error, but it succeeded")
-    )
+    storeFailing
+      .search("query", 5, MemoryFilter.All)
+      .fold(
+        err => err.message should include("boom"),
+        _ => fail("Expected search to fail due to embedding service error, but it succeeded")
+      )
     storeFailing.close()
   }
 }

--- a/modules/it/src/test/scala/org/llm4s/imageprocessing/provider/AnthropicVisionClientTest.scala
+++ b/modules/it/src/test/scala/org/llm4s/imageprocessing/provider/AnthropicVisionClientTest.scala
@@ -15,6 +15,15 @@ import org.llm4s.it.tags.Local
 @Local
 class AnthropicVisionClientTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
+  /**
+   * The client's error paths are what these tests exercise; the real endpoint is not.
+   *
+   * Pointing the client at a closed local port keeps this suite in the `@Local` tier
+   * honestly - `sbt test` neither reaches api.openai.com nor waits on its 30-second connect
+   * timeout - while the calls below still take the failure path they assert on.
+   */
+  private val UnreachableBaseUrl = "http://127.0.0.1:1"
+
   var tempFile: java.nio.file.Path  = _
   var config: AnthropicVisionConfig = _
 
@@ -22,7 +31,7 @@ class AnthropicVisionClientTest extends AnyFlatSpec with Matchers with BeforeAnd
     tempFile = Files.createTempFile("test", ".png")
     config = AnthropicVisionConfig(
       apiKey = "test-api-key",
-      baseUrl = "https://api.anthropic.com",
+      baseUrl = UnreachableBaseUrl,
       model = "claude-3-sonnet-20240229"
     )
 

--- a/modules/it/src/test/scala/org/llm4s/imageprocessing/provider/AnthropicVisionClientTest.scala
+++ b/modules/it/src/test/scala/org/llm4s/imageprocessing/provider/AnthropicVisionClientTest.scala
@@ -10,7 +10,9 @@ import java.nio.file.Files
 import java.awt.image.BufferedImage
 import java.awt.Color
 import javax.imageio.ImageIO
+import org.llm4s.it.tags.Local
 
+@Local
 class AnthropicVisionClientTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
   var tempFile: java.nio.file.Path  = _

--- a/modules/it/src/test/scala/org/llm4s/imageprocessing/provider/OpenAIVisionClientTest.scala
+++ b/modules/it/src/test/scala/org/llm4s/imageprocessing/provider/OpenAIVisionClientTest.scala
@@ -9,7 +9,9 @@ import java.nio.file.Files
 import java.awt.image.BufferedImage
 import java.awt.Color
 import javax.imageio.ImageIO
+import org.llm4s.it.tags.Local
 
+@Local
 class OpenAIVisionClientTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
   var tempFile: java.nio.file.Path = _

--- a/modules/it/src/test/scala/org/llm4s/imageprocessing/provider/OpenAIVisionClientTest.scala
+++ b/modules/it/src/test/scala/org/llm4s/imageprocessing/provider/OpenAIVisionClientTest.scala
@@ -14,6 +14,15 @@ import org.llm4s.it.tags.Local
 @Local
 class OpenAIVisionClientTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
+  /**
+   * The client's error paths are what these tests exercise; the real endpoint is not.
+   *
+   * Pointing the client at a closed local port keeps this suite in the `@Local` tier
+   * honestly - `sbt test` neither reaches api.openai.com nor waits on its 30-second connect
+   * timeout - while the calls below still take the failure path they assert on.
+   */
+  private val UnreachableBaseUrl = "http://127.0.0.1:1"
+
   var tempFile: java.nio.file.Path = _
   var config: OpenAIVisionConfig   = _
 
@@ -21,7 +30,7 @@ class OpenAIVisionClientTest extends AnyFlatSpec with Matchers with BeforeAndAft
     tempFile = Files.createTempFile("test", ".png")
     config = OpenAIVisionConfig(
       apiKey = "test-api-key",
-      baseUrl = "https://api.openai.com/v1",
+      baseUrl = UnreachableBaseUrl,
       model = "gpt-4-vision-preview"
     )
 

--- a/modules/it/src/test/scala/org/llm4s/it/Tier.scala
+++ b/modules/it/src/test/scala/org/llm4s/it/Tier.scala
@@ -1,0 +1,40 @@
+package org.llm4s.it
+
+import org.scalatest.Assertions
+
+/**
+ * Availability gate for tiered integration suites.
+ *
+ * Every suite here needs something the machine may not have - a database, a container, a live
+ * API key - and so has to decide what to do when it is missing. Skipping is right on a laptop
+ * and wrong in the CI job whose entire purpose is to provide that dependency: there a silent
+ * skip is indistinguishable from a pass, which is how these suites came to be trusted while
+ * running nothing (see issue #1143).
+ *
+ * `require` resolves that by making the decision depend on who is asking. With
+ * `LLM4S_IT_STRICT=true` - set by the tier's CI job - an unreachable dependency fails the
+ * build. Everywhere else it cancels the test, which ScalaTest reports as skipped.
+ */
+object Tier {
+
+  private val StrictEnvVar = "LLM4S_IT_STRICT"
+
+  /** True when the caller has promised the tier's dependencies are present. */
+  def strict: Boolean = sys.env.get(StrictEnvVar).exists(_.equalsIgnoreCase("true"))
+
+  /**
+   * Cancels the test when `available` is false - or fails it, if `LLM4S_IT_STRICT=true`.
+   *
+   * @param available whether the dependency this suite needs was reachable
+   * @param what      what is missing, phrased so the message reads as a cause
+   */
+  def require(available: Boolean, what: String): Unit =
+    if (!available) {
+      if (strict)
+        Assertions.fail(
+          s"$what. $StrictEnvVar=true, so this tier is required to run rather than skip: " +
+            "either the service failed to start or its connection settings are wrong."
+        )
+      else Assertions.cancel(what)
+    }
+}

--- a/modules/it/src/test/scala/org/llm4s/knowledgegraph/neo4j/Neo4jGraphStoreSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/knowledgegraph/neo4j/Neo4jGraphStoreSpec.scala
@@ -6,6 +6,8 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Docker
 
 /**
  * Integration tests for Neo4jGraphStore.
@@ -23,6 +25,7 @@ import org.scalatest.matchers.should.Matchers
  * Netty 4.1.115.Final's NioIoHandler in a way that does not support
  * LocalServerChannel, causing it to crash on startup regardless of the JVM version.
  */
+@Docker
 class Neo4jGraphStoreSpec extends AnyFunSuite with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
 
   private var store: Neo4jGraphStore = _
@@ -61,7 +64,7 @@ class Neo4jGraphStoreSpec extends AnyFunSuite with Matchers with BeforeAndAfterA
 
   /** Skip the current test if Neo4j is not reachable. */
   private def requireNeo4j(): Unit =
-    assume(neo4jAvailable, "No Neo4j at bolt://localhost:7687 — start one to run this test")
+    Tier.require(neo4jAvailable, s"No Neo4j reachable at $neo4jUri")
 
   // ─── Node CRUD ────────────────────────────────────────────────────────────
 

--- a/modules/it/src/test/scala/org/llm4s/llmconnect/provider/OllamaIntegrationSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/provider/OllamaIntegrationSpec.scala
@@ -8,6 +8,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.util.Try
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Ollama
 
 /**
  * Integration tests that verify full round-trip against a running Ollama instance.
@@ -22,6 +24,7 @@ import scala.util.Try
  * Non-determinism strategy: never assert on specific content text. Only assert
  * structural properties: isRight, nonEmpty, > 0, correct types.
  */
+@Ollama
 class OllamaIntegrationSpec extends AnyFlatSpec with Matchers {
 
   private given ModelRegistryService = ModelRegistryService.default().toOption.get
@@ -62,7 +65,7 @@ class OllamaIntegrationSpec extends AnyFlatSpec with Matchers {
   }
 
   "OllamaClient" should "complete a basic request" in {
-    assume(ollamaAvailable, s"Ollama not available with model $testModel")
+    Tier.require(ollamaAvailable, s"Ollama not available with model $testModel")
 
     withClient { client =>
       val result = client.complete(conversation("Say hi in one word"), CompletionOptions())
@@ -74,7 +77,7 @@ class OllamaIntegrationSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "stream a response with chunks" in {
-    assume(ollamaAvailable, s"Ollama not available with model $testModel")
+    Tier.require(ollamaAvailable, s"Ollama not available with model $testModel")
 
     withClient { client =>
       val chunks = scala.collection.mutable.ListBuffer.empty[StreamedChunk]
@@ -92,7 +95,7 @@ class OllamaIntegrationSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "handle a multi-turn conversation" in {
-    assume(ollamaAvailable, s"Ollama not available with model $testModel")
+    Tier.require(ollamaAvailable, s"Ollama not available with model $testModel")
 
     withClient { client =>
       val multiTurnConv = Conversation(
@@ -109,7 +112,7 @@ class OllamaIntegrationSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "report token usage" in {
-    assume(ollamaAvailable, s"Ollama not available with model $testModel")
+    Tier.require(ollamaAvailable, s"Ollama not available with model $testModel")
 
     withClient { client =>
       val result = client.complete(conversation("Say yes"), CompletionOptions())
@@ -123,9 +126,9 @@ class OllamaIntegrationSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return ConfigurationError after close" in {
-    assume(ollamaAvailable, s"Ollama not available with model $testModel")
+    Tier.require(ollamaAvailable, s"Ollama not available with model $testModel")
 
-    val client = new OllamaClient(config)
+    val client      = new OllamaClient(config)
     val beforeClose = client.complete(conversation("hi"), CompletionOptions())
     beforeClose.isRight shouldBe true
 

--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/AnthropicSmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/AnthropicSmokeSpec.scala
@@ -7,6 +7,8 @@ import org.llm4s.llmconnect.provider.AnthropicClient
 import org.llm4s.model.ModelRegistryService
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Cloud
 
 /**
  * Cloud smoke tests for Anthropic.
@@ -17,10 +19,11 @@ import org.scalatest.matchers.should.Matchers
  *
  * Requires: `ANTHROPIC_API_KEY` environment variable.
  */
+@Cloud
 class AnthropicSmokeSpec extends AnyFlatSpec with Matchers {
 
   private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
-  private given ContextWindowResolver = ContextWindowResolver(mrs)
+  private given ContextWindowResolver     = ContextWindowResolver(mrs)
 
   private val apiKey: Option[String] = Option(System.getenv("ANTHROPIC_API_KEY")).filter(_.nonEmpty)
 
@@ -34,7 +37,7 @@ class AnthropicSmokeSpec extends AnyFlatSpec with Matchers {
   private def conversation: Conversation = Conversation(Seq(UserMessage("Say hi in one word")))
 
   "Anthropic" should "complete a basic request" in {
-    assume(apiKey.isDefined, "ANTHROPIC_API_KEY not set")
+    Tier.require(apiKey.isDefined, "ANTHROPIC_API_KEY not set")
 
     val clientResult = AnthropicClient(config(apiKey.get))
     withClue(s"Client creation failed: ${clientResult.swap.toOption}") {
@@ -51,7 +54,7 @@ class AnthropicSmokeSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "stream a response" in {
-    assume(apiKey.isDefined, "ANTHROPIC_API_KEY not set")
+    Tier.require(apiKey.isDefined, "ANTHROPIC_API_KEY not set")
 
     val client = AnthropicClient(config(apiKey.get)).toOption.get
     val chunks = scala.collection.mutable.ListBuffer.empty[StreamedChunk]

--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/CohereSmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/CohereSmokeSpec.scala
@@ -7,6 +7,8 @@ import org.llm4s.llmconnect.provider.CohereClient
 import org.llm4s.model.ModelRegistryService
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Cloud
 
 /**
  * Cloud smoke tests for Cohere.
@@ -23,10 +25,11 @@ import org.scalatest.matchers.should.Matchers
  * `Left(ConfigurationError)` rather than throwing an exception, in accordance
  * with the project's `Result[A]` error handling contract.
  */
+@Cloud
 class CohereSmokeSpec extends AnyFlatSpec with Matchers {
 
   private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
-  private given ContextWindowResolver = ContextWindowResolver(mrs)
+  private given ContextWindowResolver     = ContextWindowResolver(mrs)
 
   private val apiKey: Option[String] = Option(System.getenv("COHERE_API_KEY")).filter(_.nonEmpty)
 
@@ -40,7 +43,7 @@ class CohereSmokeSpec extends AnyFlatSpec with Matchers {
   private def conversation: Conversation = Conversation(Seq(UserMessage("Say hi in one word")))
 
   "Cohere" should "complete a basic request" in {
-    assume(apiKey.isDefined, "COHERE_API_KEY not set")
+    Tier.require(apiKey.isDefined, "COHERE_API_KEY not set")
 
     val clientResult = CohereClient(config(apiKey.get))
     withClue(s"Client creation failed: ${clientResult.swap.toOption}") {

--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/CohereSmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/CohereSmokeSpec.scala
@@ -18,7 +18,7 @@ import org.llm4s.it.tags.Cloud
  * or the `sbt testSmoke` alias.
  *
  * Requires: `COHERE_API_KEY` environment variable.
- * Tag: CloudSmoke
+ * Tier: `@Cloud` - `sbt testSmoke`.
  *
  * Note: The current CohereClient implementation (v2 scope) does not support
  * streaming. The `streamComplete` test verifies that calling it returns a

--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/DeepSeekSmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/DeepSeekSmokeSpec.scala
@@ -7,6 +7,8 @@ import org.llm4s.llmconnect.provider.DeepSeekClient
 import org.llm4s.model.ModelRegistryService
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Cloud
 
 /**
  * Cloud smoke tests for DeepSeek.
@@ -17,10 +19,11 @@ import org.scalatest.matchers.should.Matchers
  *
  * Requires: `DEEPSEEK_API_KEY` environment variable.
  */
+@Cloud
 class DeepSeekSmokeSpec extends AnyFlatSpec with Matchers {
 
   private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
-  private given ContextWindowResolver = ContextWindowResolver(mrs)
+  private given ContextWindowResolver     = ContextWindowResolver(mrs)
 
   private val apiKey: Option[String] = Option(System.getenv("DEEPSEEK_API_KEY")).filter(_.nonEmpty)
 
@@ -34,7 +37,7 @@ class DeepSeekSmokeSpec extends AnyFlatSpec with Matchers {
   private def conversation: Conversation = Conversation(Seq(UserMessage("Say hi in one word")))
 
   "DeepSeek" should "complete a basic request" in {
-    assume(apiKey.isDefined, "DEEPSEEK_API_KEY not set")
+    Tier.require(apiKey.isDefined, "DEEPSEEK_API_KEY not set")
 
     val clientResult = DeepSeekClient(config(apiKey.get))
     withClue(s"Client creation failed: ${clientResult.swap.toOption}") {
@@ -51,7 +54,7 @@ class DeepSeekSmokeSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "stream a response" in {
-    assume(apiKey.isDefined, "DEEPSEEK_API_KEY not set")
+    Tier.require(apiKey.isDefined, "DEEPSEEK_API_KEY not set")
 
     val client = DeepSeekClient(config(apiKey.get)).toOption.get
     val chunks = scala.collection.mutable.ListBuffer.empty[StreamedChunk]

--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/GeminiSmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/GeminiSmokeSpec.scala
@@ -7,6 +7,8 @@ import org.llm4s.llmconnect.provider.GeminiClient
 import org.llm4s.model.ModelRegistryService
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Cloud
 
 /**
  * Cloud smoke tests for Gemini.
@@ -17,10 +19,11 @@ import org.scalatest.matchers.should.Matchers
  *
  * Requires: `GEMINI_API_KEY` environment variable.
  */
+@Cloud
 class GeminiSmokeSpec extends AnyFlatSpec with Matchers {
 
   private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
-  private given ContextWindowResolver = ContextWindowResolver(mrs)
+  private given ContextWindowResolver     = ContextWindowResolver(mrs)
 
   private val apiKey: Option[String] = Option(System.getenv("GEMINI_API_KEY")).filter(_.nonEmpty)
 
@@ -34,7 +37,7 @@ class GeminiSmokeSpec extends AnyFlatSpec with Matchers {
   private def conversation: Conversation = Conversation(Seq(UserMessage("Say hi in one word")))
 
   "Gemini" should "complete a basic request" in {
-    assume(apiKey.isDefined, "GEMINI_API_KEY not set")
+    Tier.require(apiKey.isDefined, "GEMINI_API_KEY not set")
 
     val clientResult = GeminiClient(config(apiKey.get))
     withClue(s"Client creation failed: ${clientResult.swap.toOption}") {
@@ -51,7 +54,7 @@ class GeminiSmokeSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "stream a response" in {
-    assume(apiKey.isDefined, "GEMINI_API_KEY not set")
+    Tier.require(apiKey.isDefined, "GEMINI_API_KEY not set")
 
     val client = GeminiClient(config(apiKey.get)).toOption.get
     val chunks = scala.collection.mutable.ListBuffer.empty[StreamedChunk]

--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/OpenAISmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/OpenAISmokeSpec.scala
@@ -7,6 +7,8 @@ import org.llm4s.llmconnect.provider.OpenAIClient
 import org.llm4s.model.ModelRegistryService
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Cloud
 
 /**
  * Cloud smoke tests for OpenAI.
@@ -17,10 +19,11 @@ import org.scalatest.matchers.should.Matchers
  *
  * Requires: `OPENAI_API_KEY` environment variable.
  */
+@Cloud
 class OpenAISmokeSpec extends AnyFlatSpec with Matchers {
 
   private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
-  private given ContextWindowResolver = ContextWindowResolver(mrs)
+  private given ContextWindowResolver     = ContextWindowResolver(mrs)
 
   private val apiKey: Option[String] = Option(System.getenv("OPENAI_API_KEY")).filter(_.nonEmpty)
 
@@ -35,7 +38,7 @@ class OpenAISmokeSpec extends AnyFlatSpec with Matchers {
   private def conversation: Conversation = Conversation(Seq(UserMessage("Say hi in one word")))
 
   "OpenAI" should "complete a basic request" in {
-    assume(apiKey.isDefined, "OPENAI_API_KEY not set")
+    Tier.require(apiKey.isDefined, "OPENAI_API_KEY not set")
 
     val clientResult = OpenAIClient(config(apiKey.get))
     withClue(s"Client creation failed: ${clientResult.swap.toOption}") {
@@ -52,7 +55,7 @@ class OpenAISmokeSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "stream a response" in {
-    assume(apiKey.isDefined, "OPENAI_API_KEY not set")
+    Tier.require(apiKey.isDefined, "OPENAI_API_KEY not set")
 
     val client = OpenAIClient(config(apiKey.get)).toOption.get
     val chunks = scala.collection.mutable.ListBuffer.empty[StreamedChunk]

--- a/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/OpenRouterSmokeSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/llmconnect/smoke/OpenRouterSmokeSpec.scala
@@ -7,6 +7,8 @@ import org.llm4s.llmconnect.provider.OpenRouterClient
 import org.llm4s.model.ModelRegistryService
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Cloud
 
 /**
  * Cloud smoke tests for OpenRouter.
@@ -17,10 +19,11 @@ import org.scalatest.matchers.should.Matchers
  *
  * Requires: `OPENROUTER_API_KEY` environment variable.
  */
+@Cloud
 class OpenRouterSmokeSpec extends AnyFlatSpec with Matchers {
 
   private given mrs: ModelRegistryService = ModelRegistryService.default().toOption.get
-  private given ContextWindowResolver = ContextWindowResolver(mrs)
+  private given ContextWindowResolver     = ContextWindowResolver(mrs)
 
   private val apiKey: Option[String] = Option(System.getenv("OPENROUTER_API_KEY")).filter(_.nonEmpty)
 
@@ -35,7 +38,7 @@ class OpenRouterSmokeSpec extends AnyFlatSpec with Matchers {
   private def conversation: Conversation = Conversation(Seq(UserMessage("Say hi in one word")))
 
   "OpenRouter" should "complete a basic request" in {
-    assume(apiKey.isDefined, "OPENROUTER_API_KEY not set")
+    Tier.require(apiKey.isDefined, "OPENROUTER_API_KEY not set")
 
     val client     = new OpenRouterClient(config(apiKey.get))
     val completion = client.complete(conversation, CompletionOptions())
@@ -47,7 +50,7 @@ class OpenRouterSmokeSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "stream a response" in {
-    assume(apiKey.isDefined, "OPENROUTER_API_KEY not set")
+    Tier.require(apiKey.isDefined, "OPENROUTER_API_KEY not set")
 
     val client = new OpenRouterClient(config(apiKey.get))
     val chunks = scala.collection.mutable.ListBuffer.empty[StreamedChunk]

--- a/modules/it/src/test/scala/org/llm4s/rag/RAGWithSearchIndexBugSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/rag/RAGWithSearchIndexBugSpec.scala
@@ -5,6 +5,8 @@ import org.llm4s.rag.permissions.pg.PgSearchIndex
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Docker
 
 /**
  * Integration tests for PostgreSQL-backed SearchIndex behavior when used through
@@ -13,6 +15,7 @@ import org.scalatest.matchers.should.Matchers
  * These tests require PostgreSQL with pgvector to fully validate.
  * Set `PGVECTOR_TEST_URL` to enable them.
  */
+@Docker
 class RAGWithSearchIndexBugSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   private val pgUrl      = sys.env.get("PGVECTOR_TEST_URL")
@@ -47,7 +50,7 @@ class RAGWithSearchIndexBugSpec extends AnyFlatSpec with Matchers with BeforeAnd
   }
 
   private def requirePg(): Unit =
-    assume(searchIndex.isDefined, "PostgreSQL with pgvector not available")
+    Tier.require(searchIndex.isDefined, "PostgreSQL with pgvector not available")
 
   "RAGConfig.withSearchIndex with PgSearchIndex" should "automatically configure pgVectorConnectionString" in {
     requirePg()

--- a/modules/it/src/test/scala/org/llm4s/rag/permissions/pg/PgSearchIndexSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/rag/permissions/pg/PgSearchIndexSpec.scala
@@ -4,6 +4,8 @@ import org.llm4s.rag.permissions._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Docker
 
 /**
  * Integration tests for PgSearchIndex.
@@ -17,13 +19,14 @@ import org.scalatest.matchers.should.Matchers
  *   export PGVECTOR_PASSWORD=postgres
  *   sbt "it/testOnly org.llm4s.rag.permissions.pg.PgSearchIndexSpec"
  */
+@Docker
 class PgSearchIndexSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   private val pgUrl      = sys.env.get("PGVECTOR_TEST_URL")
   private val pgUser     = sys.env.getOrElse("PGVECTOR_USER", "postgres")
   private val pgPassword = sys.env.getOrElse("PGVECTOR_PASSWORD", "postgres")
 
-  private val testTableName = "test_permission_vectors"
+  private val testTableName                      = "test_permission_vectors"
   private var searchIndex: Option[PgSearchIndex] = None
 
   override def beforeAll(): Unit = {
@@ -48,7 +51,7 @@ class PgSearchIndexSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll
   }
 
   private def requirePg(): Unit =
-    assume(searchIndex.isDefined, "PostgreSQL with pgvector not available")
+    Tier.require(searchIndex.isDefined, "PostgreSQL with pgvector not available")
 
   "PgPrincipalStore" should "create and lookup users" in {
     requirePg()

--- a/modules/it/src/test/scala/org/llm4s/trace/OpenTelemetryTracingSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/trace/OpenTelemetryTracingSpec.scala
@@ -6,7 +6,9 @@ import org.llm4s.llmconnect.config.{ OpenTelemetryConfig, TracingSettings }
 import org.llm4s.llmconnect.model.TokenUsage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.llm4s.it.tags.Local
 
+@Local
 class OpenTelemetryTracingSpec extends AnyFlatSpec with Matchers {
 
   val tracing = new OpenTelemetryTracing("test-service", "http://localhost:4317", Map.empty)

--- a/modules/it/src/test/scala/org/llm4s/vectorstore/PgKeywordIndexSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/vectorstore/PgKeywordIndexSpec.scala
@@ -5,6 +5,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.util.Try
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Docker
 
 /**
  * Tests for PgKeywordIndex.
@@ -22,6 +24,7 @@ import scala.util.Try
  * To run locally:
  *   sbt "it/testOnly org.llm4s.vectorstore.PgKeywordIndexSpec"
  */
+@Docker
 class PgKeywordIndexSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
   private val testUrl   = sys.env.get("PGVECTOR_TEST_URL")
@@ -51,9 +54,10 @@ class PgKeywordIndexSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
       index.close()
     }
 
-  private def skipIfNoPg(test: => Unit): Unit =
-    if (skipTests) info("Skipping test - PGVECTOR_TEST_URL not set")
-    else test
+  private def skipIfNoPg(test: => Unit): Unit = {
+    Tier.require(!skipTests, "PGVECTOR_TEST_URL not set")
+    test
+  }
 
   "PgKeywordIndex" should {
 
@@ -100,7 +104,10 @@ class PgKeywordIndexSpec extends AnyWordSpec with Matchers with BeforeAndAfterEa
 
     "search for matching documents" in skipIfNoPg {
       val docs = Seq(
-        KeywordDocument("scala-1", "Scala is a programming language that combines object-oriented and functional programming"),
+        KeywordDocument(
+          "scala-1",
+          "Scala is a programming language that combines object-oriented and functional programming"
+        ),
         KeywordDocument("java-1", "Java is a widely-used programming language designed for portability"),
         KeywordDocument("python-1", "Python is a high-level programming language known for readability"),
         KeywordDocument("scala-2", "Scala programming runs on the JVM and is compatible with Java libraries")

--- a/modules/it/src/test/scala/org/llm4s/vectorstore/PgVectorStoreSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/vectorstore/PgVectorStoreSpec.scala
@@ -4,6 +4,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.BeforeAndAfterEach
 import scala.util.Try
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Docker
 
 /**
  * Tests for PgVectorStore.
@@ -19,6 +21,7 @@ import scala.util.Try
  * To run locally:
  *   sbt "it/testOnly org.llm4s.vectorstore.PgVectorStoreSpec"
  */
+@Docker
 class PgVectorStoreSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
   // Skip tests if no PostgreSQL available
@@ -49,9 +52,10 @@ class PgVectorStoreSpec extends AnyWordSpec with Matchers with BeforeAndAfterEac
       store.close()
     }
 
-  private def skipIfNoPg(test: => Unit): Unit =
-    if (skipTests) info("Skipping test - PGVECTOR_TEST_URL not set")
-    else test
+  private def skipIfNoPg(test: => Unit): Unit = {
+    Tier.require(!skipTests, "PGVECTOR_TEST_URL not set")
+    test
+  }
 
   "PgVectorStore" should {
 

--- a/modules/it/src/test/scala/org/llm4s/vectorstore/QdrantVectorStoreSpec.scala
+++ b/modules/it/src/test/scala/org/llm4s/vectorstore/QdrantVectorStoreSpec.scala
@@ -5,6 +5,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.util.Try
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Docker
 
 /**
  * Tests for QdrantVectorStore.
@@ -19,6 +21,7 @@ import scala.util.Try
  * To run locally:
  *   sbt "it/testOnly org.llm4s.vectorstore.QdrantVectorStoreSpec"
  */
+@Docker
 class QdrantVectorStoreSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
   private val testUrl   = sys.env.get("QDRANT_TEST_URL")
@@ -47,9 +50,10 @@ class QdrantVectorStoreSpec extends AnyWordSpec with Matchers with BeforeAndAfte
       store.close()
     }
 
-  private def skipIfNoQdrant(test: => Unit): Unit =
-    if (skipTests) info("Skipping test - QDRANT_TEST_URL not set")
-    else test
+  private def skipIfNoQdrant(test: => Unit): Unit = {
+    Tier.require(!skipTests, "QDRANT_TEST_URL not set")
+    test
+  }
 
   "QdrantVectorStore" should {
 

--- a/modules/it/src/test/scala/org/llm4s/workspace/ContainerisedWorkspaceTest.scala
+++ b/modules/it/src/test/scala/org/llm4s/workspace/ContainerisedWorkspaceTest.scala
@@ -9,6 +9,8 @@ import java.io.File
 import java.nio.file.Files
 import scala.concurrent.duration._
 import scala.util.Try
+import org.llm4s.it.Tier
+import org.llm4s.it.tags.Workspace
 
 /**
  * Test suite for WebSocket-based ContainerisedWorkspace.
@@ -16,6 +18,7 @@ import scala.util.Try
  * This suite requires Docker plus `LLM4S_DOCKER_TESTS=true` and lives in the
  * dedicated integration-test module so it does not slow down default `sbt test`.
  */
+@Workspace
 class ContainerisedWorkspaceTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
 
   private val tempDir                           = Files.createTempDirectory("websocket-workspace-test").toString
@@ -25,7 +28,7 @@ class ContainerisedWorkspaceTest extends AnyFunSuite with Matchers with BeforeAn
     super.beforeAll()
 
     if (isDockerAvailable) {
-      workspace = new ContainerisedWorkspace(tempDir, "docker.io/library/workspace-runner:0.1.0-SNAPSHOT", 8080)
+      workspace = new ContainerisedWorkspace(tempDir, ContainerisedWorkspaceTest.image, 8080)
 
       val started = workspace.startContainer()
       if (!started) {
@@ -64,7 +67,7 @@ class ContainerisedWorkspaceTest extends AnyFunSuite with Matchers with BeforeAn
       }.getOrElse(false)
 
   test("WebSocket workspace can handle basic file operations") {
-    assume(isDockerAvailable, "Docker not available - skipping WebSocket tests")
+    Tier.require(isDockerAvailable, "Docker not available or LLM4S_DOCKER_TESTS!=true")
 
     val writeResponse = workspace.writeFile(
       "test.txt",
@@ -83,7 +86,7 @@ class ContainerisedWorkspaceTest extends AnyFunSuite with Matchers with BeforeAn
   }
 
   test("WebSocket workspace can execute commands without blocking heartbeats") {
-    assume(isDockerAvailable, "Docker not available - skipping WebSocket tests")
+    Tier.require(isDockerAvailable, "Docker not available or LLM4S_DOCKER_TESTS!=true")
 
     val startTime = System.currentTimeMillis()
 
@@ -103,7 +106,7 @@ class ContainerisedWorkspaceTest extends AnyFunSuite with Matchers with BeforeAn
   }
 
   test("WebSocket workspace supports concurrent operations") {
-    assume(isDockerAvailable, "Docker not available - skipping WebSocket tests")
+    Tier.require(isDockerAvailable, "Docker not available or LLM4S_DOCKER_TESTS!=true")
 
     import scala.concurrent.ExecutionContext.Implicits.global
     import scala.concurrent.Future
@@ -132,7 +135,7 @@ class ContainerisedWorkspaceTest extends AnyFunSuite with Matchers with BeforeAn
   }
 
   test("WebSocket workspace handles command streaming events") {
-    assume(isDockerAvailable, "Docker not available - skipping WebSocket tests")
+    Tier.require(isDockerAvailable, "Docker not available or LLM4S_DOCKER_TESTS!=true")
 
     val response = workspace.executeCommand(
       "echo 'Step 1'; echo 'Step 2'; echo 'Step 3'",
@@ -147,7 +150,7 @@ class ContainerisedWorkspaceTest extends AnyFunSuite with Matchers with BeforeAn
   }
 
   test("WebSocket workspace handles errors gracefully") {
-    assume(isDockerAvailable, "Docker not available - skipping WebSocket tests")
+    Tier.require(isDockerAvailable, "Docker not available or LLM4S_DOCKER_TESTS!=true")
 
     val response = workspace.executeCommand("exit 1", None, Some(5))
     response.exitCode shouldBe 1
@@ -164,8 +167,18 @@ class ContainerisedWorkspaceTest extends AnyFunSuite with Matchers with BeforeAn
 
 object ContainerisedWorkspaceTest {
 
+  /**
+   * The workspace-runner image to test against.
+   *
+   * The build passes the tag it would publish locally (see `it / Test / envVars` in build.sbt),
+   * so this tracks the project version instead of the hardcoded `0.1.0-SNAPSHOT` that had gone
+   * stale while nothing ran this suite.
+   */
+  def image: String =
+    sys.env.getOrElse("LLM4S_WORKSPACE_IMAGE", "llm4s/workspace-runner:latest")
+
   def createTestWorkspace(workspaceDir: String): ContainerisedWorkspace =
-    new ContainerisedWorkspace(workspaceDir, "docker.io/library/workspace-runner:0.1.0-SNAPSHOT", 8080)
+    new ContainerisedWorkspace(workspaceDir, image, 8080)
 
   def demonstrateThreadingFix(workspaceDir: String): Unit = {
     val workspace = createTestWorkspace(workspaceDir)

--- a/modules/knowledgegraph-neo4j/src/main/scala/org/llm4s/knowledgegraph/neo4j/Neo4jGraphStore.scala
+++ b/modules/knowledgegraph-neo4j/src/main/scala/org/llm4s/knowledgegraph/neo4j/Neo4jGraphStore.scala
@@ -199,13 +199,21 @@ final class Neo4jGraphStore private (
       // Follow-up: if GraphTraversal visibility is widened, shared traversal helpers can be reused across stores.
       val params = new java.util.HashMap[String, AnyRef]()
       params.put("startId", startId)
-      params.put("maxDepth", Integer.valueOf(config.maxDepth))
       params.put("excludedIds", config.visitedNodeIds.toList.asJava)
 
+      // The upper bound of a variable-length pattern is part of the query's shape, not a
+      // value: Cypher rejects `[*0..$maxDepth]` with "Parameter maps cannot be used in MATCH
+      // patterns". It has to be inlined, which is safe because it is an Int - the injection
+      // risk that `$`-parameters guard against does not arise. `TraversalConfig` defaults
+      // maxDepth to Int.MaxValue, meaning "no limit", which Cypher spells as an open bound.
+      val depth =
+        if (config.maxDepth == Int.MaxValue) "*0.."
+        else s"*0..${math.max(0, config.maxDepth)}"
+
       val pattern = config.direction match {
-        case Direction.Outgoing => "-[*0..$maxDepth]->"
-        case Direction.Incoming => "<-[*0..$maxDepth]-"
-        case Direction.Both     => "-[*0..$maxDepth]-"
+        case Direction.Outgoing => s"-[$depth]->"
+        case Direction.Incoming => s"<-[$depth]-"
+        case Direction.Both     => s"-[$depth]-"
       }
 
       Right(session.executeRead { tx =>

--- a/modules/knowledgegraph-neo4j/src/main/scala/org/llm4s/knowledgegraph/neo4j/Neo4jGraphStore.scala
+++ b/modules/knowledgegraph-neo4j/src/main/scala/org/llm4s/knowledgegraph/neo4j/Neo4jGraphStore.scala
@@ -195,37 +195,57 @@ final class Neo4jGraphStore private (
 
   override def traverse(startId: String, config: TraversalConfig = TraversalConfig()): Result[Seq[Node]] =
     withSession { session =>
-      // Uses one read query to avoid per-node session churn.
-      // Follow-up: if GraphTraversal visibility is widened, shared traversal helpers can be reused across stores.
-      val params = new java.util.HashMap[String, AnyRef]()
-      params.put("startId", startId)
-      params.put("excludedIds", config.visitedNodeIds.toList.asJava)
-
-      // The upper bound of a variable-length pattern is part of the query's shape, not a
-      // value: Cypher rejects `[*0..$maxDepth]` with "Parameter maps cannot be used in MATCH
-      // patterns". It has to be inlined, which is safe because it is an Int - the injection
-      // risk that `$`-parameters guard against does not arise. `TraversalConfig` defaults
-      // maxDepth to Int.MaxValue, meaning "no limit", which Cypher spells as an open bound.
-      val depth =
-        if (config.maxDepth == Int.MaxValue) "*0.."
-        else s"*0..${math.max(0, config.maxDepth)}"
-
-      val pattern = config.direction match {
-        case Direction.Outgoing => s"-[$depth]->"
-        case Direction.Incoming => s"<-[$depth]-"
-        case Direction.Both     => s"-[$depth]-"
+      // Breadth-first, one query per level, rather than one variable-length pattern.
+      //
+      // `MATCH p=(start)-[*0..]-(n)` enumerates every relationship-unique path before
+      // `min(length(p))` collapses them back to one row per node, so on a cyclic or densely
+      // connected graph the work grows exponentially in the number of edges - and
+      // TraversalConfig's default depth is unbounded, which is the worst case rather than a
+      // rare one. Expanding a whole frontier per level visits each node exactly once, at the
+      // cost of one round trip per level.
+      //
+      // Semantics follow GraphTraversal.bfs, which backs the in-memory store: nodes in
+      // `visitedNodeIds` are skipped rather than traversed through, and the start node is
+      // included at depth 0 when it exists.
+      val expand = config.direction match {
+        case Direction.Outgoing => "MATCH (a:LLM4S)-[]->(b:LLM4S)"
+        case Direction.Incoming => "MATCH (a:LLM4S)<-[]-(b:LLM4S)"
+        case Direction.Both     => "MATCH (a:LLM4S)-[]-(b:LLM4S)"
       }
+      val expandCypher =
+        s"$expand WHERE a.llm4s_id IN $$frontier AND NOT b.llm4s_id IN $$seen RETURN DISTINCT b ORDER BY b.llm4s_id ASC"
 
       Right(session.executeRead { tx =>
-        val rs = tx.run(
-          s"MATCH p=(start:LLM4S {llm4s_id: $$startId})$pattern(n:LLM4S) WHERE NOT n.llm4s_id IN $$excludedIds WITH n, min(length(p)) AS depth ORDER BY depth ASC, n.llm4s_id ASC RETURN n",
-          params
-        )
+        val startParams = new java.util.HashMap[String, AnyRef]()
+        startParams.put("startId", startId)
+        val startResult = tx.run("MATCH (n:LLM4S {llm4s_id: $startId}) RETURN n", startParams)
 
-        val buf = scala.collection.mutable.ArrayBuffer.empty[Node]
-        while (rs.hasNext)
-          buf += recordToNode(rs.next().get("n").asNode())
-        buf.toSeq
+        if (!startResult.hasNext || config.visitedNodeIds.contains(startId)) Seq.empty
+        else {
+          val startNode = recordToNode(startResult.next().get("n").asNode())
+
+          def expandLevel(frontier: Seq[String], seen: Set[String]): Seq[Node] = {
+            val params = new java.util.HashMap[String, AnyRef]()
+            params.put("frontier", frontier.asJava)
+            params.put("seen", seen.toList.asJava)
+            val rs  = tx.run(expandCypher, params)
+            val buf = scala.collection.mutable.ArrayBuffer.empty[Node]
+            while (rs.hasNext)
+              buf += recordToNode(rs.next().get("b").asNode())
+            buf.toSeq
+          }
+
+          @scala.annotation.tailrec
+          def loop(frontier: Seq[String], seen: Set[String], depth: Int, acc: Vector[Node]): Vector[Node] =
+            if (frontier.isEmpty || depth >= config.maxDepth) acc
+            else {
+              val next = expandLevel(frontier, seen)
+              if (next.isEmpty) acc
+              else loop(next.map(_.id), seen ++ next.map(_.id), depth + 1, acc ++ next)
+            }
+
+          loop(Seq(startId), config.visitedNodeIds + startId, 0, Vector(startNode))
+        }
       })
     }
 

--- a/project/ItTiers.scala
+++ b/project/ItTiers.scala
@@ -26,7 +26,7 @@ object ItTiers {
 
   /** The `sbt` command that runs one tier: select it by tag, replacing the Local-tier default. */
   def alias(tag: String): String =
-    s""";set it / Test / testOptions := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-n", "$tag")); it/test"""
+    s""";set it / Test / test / testOptions := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-n", "$tag")); it/test"""
 
   private def simpleName(tag: String): String = tag.split('.').last
 

--- a/project/ItTiers.scala
+++ b/project/ItTiers.scala
@@ -1,0 +1,85 @@
+import sbt._
+
+import java.net.URLClassLoader
+
+/**
+ * Test tiers for `modules/it`.
+ *
+ * Each tier names the external thing a suite needs - nothing, a containerised service, a
+ * locally built image, a local model server, or a paid API key - and therefore which command
+ * and which CI job runs it. Membership is declared by annotating the suite class with the
+ * matching tag in `org.llm4s.it.tags`, never by a name pattern in a `testOnly` argument: a
+ * suite that matches no pattern is run by nothing and says nothing about it, which is how 11
+ * of 18 suites here came to be dead weight (issue #1143).
+ *
+ * `check` turns that silence into a build failure, in the same spirit as `coveragePolicyCheck`.
+ */
+object ItTiers {
+
+  val Local     = "org.llm4s.it.tags.Local"
+  val Docker    = "org.llm4s.it.tags.Docker"
+  val Workspace = "org.llm4s.it.tags.Workspace"
+  val Ollama    = "org.llm4s.it.tags.Ollama"
+  val Cloud     = "org.llm4s.it.tags.Cloud"
+
+  val all: Seq[String] = Seq(Local, Docker, Workspace, Ollama, Cloud)
+
+  /** The `sbt` command that runs one tier: select it by tag, replacing the Local-tier default. */
+  def alias(tag: String): String =
+    s""";set it / Test / testOptions := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-n", "$tag")); it/test"""
+
+  private def simpleName(tag: String): String = tag.split('.').last
+
+  /**
+   * Fails unless every discovered suite declares exactly one tier.
+   *
+   * Reads the tags off the compiled classes rather than the sources, so the check sees what
+   * ScalaTest's own tag filtering will see.
+   */
+  def check(suites: Seq[String], classpath: Seq[File], log: Logger): Unit = {
+    // Platform loader as parent: the test classpath supplies ScalaTest and the tag
+    // annotations, and sbt's own loader must not shadow either of them.
+    val loader = new URLClassLoader(classpath.map(_.toURI.toURL).toArray, ClassLoader.getPlatformClassLoader)
+    val rows =
+      try suites.sorted.map { suite =>
+        val tiers = loader
+          .loadClass(suite)
+          .getAnnotations
+          .map(_.annotationType.getName)
+          .filter(all.contains)
+          .toSeq
+        suite -> tiers
+      } finally loader.close()
+
+    if (rows.isEmpty)
+      throw new MessageOnlyException("No integration suites were discovered in modules/it - is the module compiling?")
+
+    val width = rows.map(_._1.length).max
+    log.info("Integration test tier per suite:")
+    rows.foreach { case (suite, tiers) =>
+      val declared = if (tiers.isEmpty) "NO TIER DECLARED" else tiers.map(simpleName).mkString(" + ")
+      log.info(s"  ${suite.padTo(width, ' ')}  $declared")
+    }
+
+    val untagged = rows.collect { case (suite, Nil) => suite }
+    val multiple = rows.collect { case (suite, tiers) if tiers.size > 1 => suite }
+
+    if (untagged.nonEmpty || multiple.nonEmpty) {
+      val problems =
+        (if (untagged.nonEmpty) Seq(s"No tier declared for: ${untagged.mkString(", ")}") else Nil) ++
+          (if (multiple.nonEmpty) Seq(s"More than one tier declared for: ${multiple.mkString(", ")}") else Nil)
+      throw new MessageOnlyException(
+        s"""${problems.mkString("\n")}
+           |Every suite in modules/it must be annotated with exactly one tier tag, or nothing
+           |runs it. Add ONE of the following above the class declaration:
+           |  @Local      // needs nothing external; runs in the default `sbt test`
+           |  @Docker     // needs Postgres/pgvector, Qdrant or Neo4j; `sbt testIntegration`
+           |  @Workspace  // needs a built workspace-runner image; `sbt testWorkspace`
+           |  @Ollama     // needs a local Ollama server;  `sbt testOllama`
+           |  @Cloud      // needs live provider API keys;  `sbt testSmoke`
+           |The tags live in modules/it/src/test/java/org/llm4s/it/tags/ and the tiers are
+           |documented in docs/reference/testing-guide.md.""".stripMargin
+      )
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

11 of the 18 suites in `modules/it` were executed by nothing — not locally, not in CI, not on release. The module is outside the root aggregate, and the two tier aliases named one spec and one package pattern, so any suite matching neither ran nowhere and said nothing about it.

Two things turned up while fixing it, beyond what #1143 describes:

- Because `modules/it` was outside `.aggregate(...)`, it was never **compiled, formatted or scalafix'd** in CI either. `sbt scalafmtAll` reformatted 10 of its files on contact — that is why this diff touches suites it does not otherwise change.
- Several suites did worse than skip when their dependency was missing: `skipIfNoPg` / `skipIfDisabled` called `info(...)` and let the test **pass**.

**Tier membership is now a property of the suite.** Each class carries exactly one tag from `org.llm4s.it.tags` — `@Local`, `@Docker`, `@Workspace`, `@Ollama`, `@Cloud` — and `sbt it/itTierCheck` fails the build when a suite declares none or more than one, printing a per-suite table. Same "absence of a decision is an error" rule as `coveragePolicyCheck` (#1137). It runs in Quick Checks and as a dependency of `it/test`, so a new suite can no longer match no pattern and disappear.

| Tag | Needs | Command | CI |
|---|---|---|---|
| `@Local` | nothing external | `sbt test` | every PR |
| `@Docker` | Postgres/pgvector, Qdrant, Neo4j | `sbt testIntegration` | **every PR** (service containers) |
| `@Workspace` | Docker + a built `workspace-runner` image | `sbt testWorkspace` | pushes to `main` |
| `@Ollama` | local Ollama | `sbt testOllama` | pushes to `main` |
| `@Cloud` | live API keys | `sbt testSmoke` | manual dispatch |

**Being run is not enough.** A suite that skips when its dependency is missing turns the job that exists to *provide* that dependency green while testing nothing. `Tier.require` replaces `assume`/`info`: it cancels on a laptop, and fails under `LLM4S_IT_STRICT=true`, which every tier's job sets. That immediately exposes one such case — `GeminiSmokeSpec` reads `GEMINI_API_KEY` and the cloud job only ever passed `GOOGLE_API_KEY`, so it has been "passing" without ever calling Gemini. The workflow now passes both, plus the never-supplied `COHERE_API_KEY`.

**CI.** The Docker tier needs no secrets and is reproducible, so it runs on every PR with pgvector, Qdrant and Neo4j as service containers, and is in the `all-tests-pass` gate — which also puts it on the release path, since `release.yml` calls `ci.yml`. The job waits for each service and fails if one never comes up, rather than letting the suites skip. The workspace tier has to build the runner image first (apt + sdkman + two Scalas), far too slow for a PR, so it runs on pushes to main; its image tag now comes from `workspaceRunner / Docker / version` instead of the `workspace-runner:0.1.0-SNAPSHOT` the suite pinned long after the build stopped producing it.

This matters now because of #1126: the orphans cover pgvector, the Postgres keyword index, Qdrant, permission-aware RAG, Postgres-backed agent memory, Neo4j, OTel tracing and the containerised workspace — very nearly the list of code slices 1, 2, 3 and 6 relocate. Slice 1 (#1128) also planned to retarget #1036 and #1033 into this module, which would have produced two more suites nothing ran.

## Related issue

Fixes #1143

## How was this tested?

- `sbt scalafmtCheckAll scalafixAll coveragePolicyCheck compile it/itTierCheck` — all pass.
- `sbt test` — 7004 core tests plus the 38 `@Local` tests in `modules/it`, green.
- `sbt testIntegration` selects exactly the 7 `@Docker` suites: 70 tests, previously silent, now reported as cancelled. With `LLM4S_IT_STRICT=true` the same 70 **fail** instead of skipping.
- The check's failure path was verified with a scratch untagged suite: `No tier declared for: org.llm4s.it.ScratchUntaggedSpec`, with the list of tags to choose from.

## What the tier caught on its first run

Three defects in published code, each of which had either no test running or a mocked unit test asserting the broken behaviour. They are in separate commits.

**`Neo4jGraphStore.traverse` never worked against a real Neo4j.** The variable-length pattern was built from a plain string, not an interpolated one:

```scala
case Direction.Outgoing => "-[*0..$maxDepth]->"   // no s prefix
```

so `$maxDepth` reached Cypher verbatim, where it reads as a parameter reference — illegal inside a `MATCH` pattern, so every traversal failed. The bound is now inlined (it is an `Int`; the injection risk `$`-parameters guard against does not arise) and `TraversalConfig`'s `Int.MaxValue` default maps to Cypher's open bound rather than a literal 2147483647.

**`QdrantVectorStore` could not store a record whose ID was not already a UUID.** Qdrant accepts only an unsigned integer or a UUID as a point ID and rejects anything else outright, so `upsert`, `get`, `delete` and `search` all failed for ordinary string IDs. Non-UUID IDs now map to a UUID derived from the ID, with the record's own ID carried in the payload and read back from there. `QdrantVectorStoreHttpSpec` had been asserting the broken request shape against a mock — a test that could only ever agree with the code — and now pins the mapping, the payload round-trip and the UUID passthrough instead.

**`QdrantVectorStore` reported absence as failure.** Qdrant 404s both for a point that does not exist and for a collection that does not exist — and the collection is created lazily on first upsert and deleted outright by `clear()` — so `get` returned a `Left` where its own `Option` return type says `Right(None)`, and `count` on a freshly cleared store failed rather than answering 0. Reads now treat 404 as empty; writes still error. The unit spec had pinned that behaviour too.

A fourth, smaller one turned up while adding coverage: `deleteByPrefix` re-sent every matched point ID as a JSON string, so a point written by another tool with an integer ID was addressed by a different ID than it has. It now passes back the value Qdrant gave it.

## Review comments

Both addressed in 3aa5376:

- **Vision suites in `@Local` calling live endpoints** — they now point at a closed local port. Same failure path they assert on, no network, no 30s connect timeout.
- **`testOnly` selecting zero tests** — correct and important: the filter was answering a request for a named suite by running nothing, the exact failure this PR removes. It moved to `it / Test / test / testOptions`, so it applies to `test` but not `testOnly`. Verified: `it/testOnly …PgVectorStoreSpec` reaches 11 tests (cancelled for want of Postgres) rather than selecting 0.

## Checklist

- [x] I have read the [Contributing Guide](https://llm4s.org/reference/contributing)
- [x] PR is small and focused — one change, one reason
- [x] `sbt scalafmtAll` — code is formatted
- [x] `sbt test` — tests pass on Scala 3
- [x] New code includes tests
- [x] No unrelated changes included (branched from `main`, not from another PR)
- [x] Commit messages explain the "why"
- [x] Updated `CHANGELOG.md` under `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128YP9UhueHHpCRa8dyGyVC
