### PR TITLE
release: prepare 0.4.1, carrying the relocation stubs 0.4.0 missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-29
+
 ### Fixed
 - `Neo4jGraphStore.traverse` never worked against a real Neo4j. The variable-length pattern
   was built from a non-interpolated string, so `$maxDepth` reached Cypher as a parameter
@@ -45,6 +47,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build stopped producing long ago. The tag now comes from the build itself.
 
 ### Added
+- The old artifact coordinates retired in 0.4.0 now publish a Maven **relocation** stub, so
+  a build that bumps `"org.llm4s" %% "core"` (or `workspaceclient`, `workspaceshared`,
+  `trace-opentelemetry`, `knowledgegraph-neo4j`) to 0.4.1 resolves the renamed artifact
+  instead of failing with an unresolved dependency. The stubs are POM-only and carry no code.
+
+  Two limits worth stating. A build pinned to 0.3.4 sees no signal at all - no Maven mechanism
+  reaches it. And coursier, sbt's resolver, follows a relocation *silently*: the build simply
+  starts working again without printing anything, so update the coordinate by hand rather than
+  waiting to be told. The stubs were written for 0.4.0
+  ([#1146](https://github.com/llm4s/llm4s/pull/1146)) but landed after the tag, so 0.4.0 itself
+  has no redirect ([#1150](https://github.com/llm4s/llm4s/issues/1150)).
 - `sbt testIntegration` runs the containerised tier (pgvector, Qdrant, Neo4j) and a CI job
   runs it on **every PR** with those services as service containers - the suites covering
   pgvector, the Postgres keyword index, Qdrant, permission-aware RAG, Postgres-backed agent
@@ -345,7 +358,8 @@ Initial release. Versions 0.1.0 through 0.1.7 were primarily focused on establis
 
 ---
 
-[Unreleased]: https://github.com/llm4s/llm4s/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/llm4s/llm4s/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/llm4s/llm4s/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/llm4s/llm4s/compare/v0.3.4...v0.4.0
 [0.3.4]: https://github.com/llm4s/llm4s/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/llm4s/llm4s/compare/v0.3.2...v0.3.3

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -34,7 +34,29 @@ ci → publish → github-release → docs
 | `docs` | Deploys llm4s.org with the new version in the install snippets |
 | `docker` | Builds and pushes the container image |
 
-### 3. Do NOT create the GitHub Release by hand
+### 3. What gets published is whatever the tagged commit aggregates
+
+`sbt ci-release` publishes the root aggregate **as it exists on the tagged commit**. Work that
+is on `main` but not on that commit is simply not in the release, and because Maven Central is
+immutable there is no way to add it to that version afterwards -- it waits for the next one.
+
+This has bitten us once already. The Maven relocation stubs that redirect the pre-0.4.0
+coordinates ([#1146](https://github.com/llm4s/llm4s/pull/1146)) merged shortly after `v0.4.0`
+was tagged, so 0.4.0 shipped without them and `org.llm4s:core % 0.4.0` still fails to resolve
+rather than redirecting ([#1150](https://github.com/llm4s/llm4s/issues/1150)).
+
+So before tagging, check that anything the release is *for* is on the commit you are about to
+tag, not merely on `main`:
+
+```bash
+git merge-base --is-ancestor <commit> <tag-or-HEAD> && echo "in the release" || echo "NOT in the release"
+```
+
+A new published module needs the same check twice over: it must be on the tagged commit **and**
+aggregated by the root project in `build.sbt`. A module outside the aggregate publishes nothing
+and does so silently.
+
+### 4. Do NOT create the GitHub Release by hand
 
 The `github-release` job creates it for you, and it runs **after** `publish` succeeds. That
 ordering is the point: a GitHub Release is the signal that a version is available, it is
@@ -49,7 +71,7 @@ never reached Maven Central.
 **Editing the generated notes afterwards is fine and encouraged.** The job only ever creates;
 it never overwrites. Write whatever the release deserves once it exists.
 
-### 4. Verify Release
+### 5. Verify Release
 
 - Check GitHub Actions: https://github.com/llm4s/llm4s/actions/workflows/release.yml
 - Verify Maven Central: https://central.sonatype.com/namespace/org.llm4s
@@ -94,4 +116,4 @@ We follow semantic versioning (MAJOR.MINOR.PATCH):
 - MINOR: New features, backwards compatible
 - PATCH: Bug fixes, backwards compatible
 
-Current documented version series: 0.3.x (pre-1.0 development)
+Current documented version series: 0.4.x (pre-1.0 development)


### PR DESCRIPTION
Prepares the 0.4.1 release. Closes #1150 once the tag is pushed.

## Why 0.4.1 exists

The relocation stubs from #1146 landed on `main` after `v0.4.0` was tagged, so `ci-release`
never saw them. On Central today:

```
org/llm4s/core_3/0.4.0/core_3-0.4.0.pom   -> 404
org/llm4s/core_3/maven-metadata.xml       -> 0.3.3, 0.3.4, 2.1.593
org/llm4s/llm4s-core_3/0.4.0/...pom       -> 200
```

So the exact failure #1146 was written to prevent is live: bumping `"org.llm4s" %% "core"` to
0.4.0 gives a bare unresolved dependency with no hint that the artifact moved.

0.4.1 rather than waiting for 0.5.0 — that is the far side of the whole carve (#1133), and
`Unreleased` already carries fixes that should not wait either: the `Neo4jGraphStore.traverse`
fix, both `QdrantVectorStore` fixes, and the integration tiers from #1143.

## Verification done before tagging

A Central publish is irreversible, so the stubs were checked against a real `publishM2` rather
than by reading the build:

- **POM-only.** Each of the five stub directories contains a `.pom` and nothing else — no jar,
  no sources, no javadoc.
- **`<packaging>pom</packaging>`** on all five, and zero `<dependency>` entries.
- **`<relocation>` names the full suffixed artifactId** — `llm4s-core_3`, not `llm4s-core`.
  This is the detail that would have silently produced an unresolvable redirect.

| Stub coordinate | Relocates to |
|---|---|
| `org.llm4s:core_3` | `org.llm4s:llm4s-core_3` |
| `org.llm4s:workspaceclient_3` | `org.llm4s:llm4s-workspace-client_3` |
| `org.llm4s:workspaceshared_3` | `org.llm4s:llm4s-workspace-shared_3` |
| `org.llm4s:trace-opentelemetry_3` | `org.llm4s:llm4s-observability-otel_3` |
| `org.llm4s:knowledgegraph-neo4j_3` | `org.llm4s:llm4s-knowledgegraph-neo4j_3` |

**End-to-end, not just structurally.** A scratch sbt build declaring the *retired* coordinate
against the local m2 snapshot:

```scala
libraryDependencies += "org.llm4s" %% "core" % "0.4.0+56483999e-SNAPSHOT"
```

resolved `llm4s-core_3-0.4.0+56483999e-SNAPSHOT.jar` onto the classpath. The redirect works —
and, as `Relocation.scala` warns, coursier printed nothing at all while doing it.

## Changes

- `CHANGELOG.md` — `Unreleased` becomes `## [0.4.1]`, with a new entry for the stubs that states
  both limits honestly: a build pinned to 0.3.4 gets no signal any mechanism can reach, and
  coursier follows the redirect silently, so the coordinate still needs updating by hand.
- `docs/reference/release.md` — a new step 3, *What gets published is whatever the tagged commit
  aggregates*, with the `git merge-base --is-ancestor` check and the note that a new module must
  be both on the tagged commit **and** in the root aggregate. This is the rule whose absence
  caused #1150. Also corrects the version series line, still reading 0.3.x.

## Not in this PR

Tagging. `git tag v0.4.1 && git push origin v0.4.1` is yours to run once this merges — the
publish is irreversible and #1141 records what that cost last time.

Bumping the g8 template to 0.4.1 also waits: it can only be verified against a published
artifact, so it follows the tag rather than preceding it (#1150 tracks it).
