### PR TITLE
build: drop seven unused dependencies from workspaceClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plus `MediaExtractor` matching on raw MIME prefixes with no type to name the answer.
 
 ### Changed
+- **`llm4s-workspace-client` sheds seven unused dependencies.** Tika, POI, PDFBox, jsoup,
+  Postgres, HikariCP and commons-io were declared on `workspaceClient` but referenced by
+  nothing in it. The module is nine source files that speak WebSocket JSON to a container;
+  across all of them the only third-party imports are `org.java_websocket.*`,
+  `org.slf4j.LoggerFactory`, `pureconfig.*`, `upickle.default._` and scalatest. There is no
+  `Class.forName`, no `ServiceLoader`, no `src/main/resources` and so no
+  `META-INF/services` - nothing that could reach these libraries reflectively - and no
+  document-extraction or JDBC string anywhere in the module or in `workspaceShared`.
+
+  These were the last remnants of the era when `commonSettings` put JDBC drivers on every
+  module's classpath; they were declarations `workspace-client` inherited by copy rather than
+  by need. `llm4s-workspace-client` is published, so this also stops those seven artifacts
+  reaching downstream users through its POM - a Postgres driver and a 5 MB document-parsing
+  stack that arrived with a container-execution client. Anyone who was relying on that
+  transitively should declare what they actually use.
+
+  Each removed dependency appeared exactly once in `workspaceClient/dependencyTree`, at the
+  top level: none of them was a version pin winning a conflict over a transitive of something
+  the module really uses, which is what made the JNA declaration removed above load-bearing
+  until Vosk went with it. commons-io is the one exception worth naming - it stays on the
+  runtime classpath at the same 2.22.0, because `llm4s-core` declares it and uses it in
+  `assistant/SessionManager.scala`; removing the duplicate declaration here changes the POM,
+  not the classpath.
+
+  **`Deps.config` is deliberately kept**, with a comment in `build.sbt` saying why: pureconfig
+  is a facade over Typesafe Config and needs it at runtime, but nothing here imports
+  `com.typesafe.config`, so an import-based audit reads it as dead when it is not.
 - **`llm4s-speech` is carved out of `llm4s-core`, completing slice 3**
   ([#1130](https://github.com/llm4s/llm4s/issues/1130)). `org.llm4s.speech` and its
   subpackages move whole - package names unchanged, no source breaks.

--- a/build.sbt
+++ b/build.sbt
@@ -542,14 +542,11 @@ lazy val workspaceClient = (project in file("modules/workspace/workspaceClient")
       Deps.scalatest % Test,
       Deps.scalamock % Test,
       Deps.ujson,
-      Deps.pdfbox,
-      Deps.commonsIO,
-      Deps.tika,
-      Deps.poi,
-      Deps.jsoup,
-      Deps.postgres,
-      Deps.config,
-      Deps.hikariCP
+      // Kept deliberately: pureconfig (from commonSettings) is a facade over Typesafe Config
+      // and needs it at runtime, but no source file here imports com.typesafe.config, so an
+      // import-based audit reads it as dead. Tika/POI/PDFBox/jsoup/Postgres/HikariCP/commons-io
+      // were removed alongside this line - none of them was on any code path in this module.
+      Deps.config
     )
   )
 


### PR DESCRIPTION
`modules/workspace/workspaceClient` is nine source files that speak WebSocket JSON to a container. It declared fifteen library dependencies. This removes the seven that nothing in it references, and keeps the one that looks unused but is not.

Targets `carve/speech-1130` rather than `main`, because #1158 edits the same `libraryDependencies` block (it removes `Deps.vosk` and `Deps.jna`). GitHub will retarget this to `main` when #1158 merges.

## How each candidate was checked

Three questions per dependency, because an unused *import* is not an unused *dependency*:

**1. Is it referenced in source?** Every `import` line across the module's 9 files (7 main, 2 test), deduplicated:

```
org.java_websocket.client.WebSocketClient      org.llm4s.{agent,config,error,http,
org.java_websocket.handshake.ServerHandshake     llmconnect,shared,toolapi,types}.*
org.slf4j.LoggerFactory                        org.scalatest.*
pureconfig.{ConfigReader, ConfigSource}        java.*, scala.*
upickle.default._
```

Import lists alone would not settle this — `workspaceRunner` uses cask heavily (`extends cask.MainRoutes`, `@cask.websocket`) with no `import cask` anywhere, so fully-qualified use is a real pattern in this codebase. So the check was a grep for the *package prefixes* over `workspaceClient/src` **and** `workspaceShared/src`: `org.apache.tika|org.apache.poi|org.apache.pdfbox|org.jsoup|org.apache.commons.io|com.zaxxer|org.postgresql|java.sql|javax.sql` — zero matches. A case-insensitive grep for `jdbc|postgres|hikari|tika|pdf|jsoup|FileUtils|IOUtils` over the same two modules also returns nothing, so not as a string literal, a driver class name or a comment either.

**2. Could it be reached reflectively?** `grep -rn "Class.forName\|ServiceLoader\|getClassLoader\|reflect"` over `workspaceClient/src`: no matches. The module has **no `src/main/resources` directory**, so there is no `META-INF/services` file and no `reference.conf` that could name a driver or a parser.

**3. Is it a version pin over a transitive?** This is the JNA case from #1158 — Vosk's POM already depended on JNA, so the explicit declaration was winning a conflict, and removing it would have downgraded rather than removed. Checked against `sbt "workspaceClient/dependencyTree"` (3741 lines). Occurrence counts in the whole tree:

| Artifact | Occurrences | Depth |
|---|---|---|
| `org.apache.tika:tika-core` | 1 | top level |
| `org.apache.poi:poi-ooxml` | 1 | top level |
| `org.apache.pdfbox:pdfbox` | 1 | top level |
| `org.jsoup:jsoup` | 1 | top level |
| `com.zaxxer:HikariCP` | 1 | top level |
| `org.postgresql:postgresql` | 1 | top level |
| `commons-io:commons-io` | 5 | top level, **under `llm4s-core`**, and under poi/tika |

Six of the seven appear once, at the root, pulled in by nothing else — no conflict to win, so removing the declaration removes the artifact outright. That is the intent.

commons-io is the interesting one and worth stating precisely: `llm4s-core` declares `Deps.commonsIO` itself (build.sbt:310) and uses it — `assistant/SessionManager.scala:16` imports `org.apache.commons.io.FileUtils`. So commons-io was already arriving transitively at the identical 2.22.0. The tree also shows poi pulling 2.20.0/2.21.0 and both being evicted by 2.22.0; with poi gone that eviction is moot, and core's declaration still supplies 2.22.0. **Removing this line changes the published POM, not the classpath.**

Verified after the edit — `workspaceClient/Runtime/fullClasspath`, filtered:

```
commons-io/commons-io/2.22.0/commons-io-2.22.0.jar
config-1.4.9.jar
```

tika, poi, pdfbox, jsoup, postgresql and HikariCP are gone from the runtime classpath; commons-io is unchanged.

## Kept: `Deps.config`

pureconfig (from `commonSettings`) is a facade over Typesafe Config and loads it at runtime, but no file here imports `com.typesafe.config` — so any import-based audit, including the one above, reads this as dead when it is not. The tree shows pureconfig-core requesting `config:1.4.5`, evicted by our `1.4.9`, so the declaration is also doing pin work. There is now a comment in `build.sbt` at the line saying so, to stop the next audit from removing it.

## Containerised execution

`sbt testWorkspace` does not run in normal CI, so the usual suite cannot catch a runtime break here. Three things bound that risk:

- **The container image does not come from this module.** `workspaceRunner` is a separate project — `.dependsOn(workspaceShared)` only, never `workspaceClient` — and declares its own `Deps.postgres`, `Deps.config`, `Deps.hikariCP`. `WorkspaceRunnerDocker.settings` packages *its* classpath. Nothing on `workspaceClient` reaches the image.
- **`workspaceRunner`'s own sources** reference none of the seven either, by import or fully-qualified name.
- **The one @Workspace-tier suite**, `modules/it/.../ContainerisedWorkspaceTest.scala`, imports only `org.llm4s.shared._`, scalatest, `java.io.File`, `java.nio.file.Files` and the tier tags. And `it` `.dependsOn(rag, memoryPostgres, ...)` anyway, both of which declare postgres/hikari/tika/poi/pdfbox/jsoup, so `it`'s classpath is unaffected by this change regardless.

Residual risk is therefore that a code path from `workspaceClient` into `llm4s-core` needs one of these at runtime without an import. Core does not declare tika, poi, pdfbox, jsoup, postgres or HikariCP at all (they left in slices 1–2), so there is no such path for six of the seven, and commons-io is still present.

## Verification

- `sbt "Test/compile"` — clean (this compiles `workspaceSamples`, the other `workspaceClient` consumer).
- `sbt test` — full suite green, 2900+ tests across all modules, 0 failures.
- `sbt scalafmtCheckAll "scalafixAll --check" coveragePolicyCheck "it/itTierCheck"` — all green.
- `build.sbt` edited by hand; `scalafmtSbt` deliberately not run.

## Noticed, not changed

`workspaceClient` also declares `Deps.azureOpenAI`, `Deps.anthropic`, `Deps.jtokkit` and `Deps.ujson`, none of which it imports either — all four arrive transitively from `llm4s-core`, which declares and uses them. Same shape as commons-io: removing them would change the POM and not the classpath. Left alone here to keep this PR to the one question it set out to answer; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv72ZeUqCtwsHVynQ5u9jX
