### PR TITLE
build: drop seven unused dependencies from workspaceClient (recovers #1159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plus `MediaExtractor` matching on raw MIME prefixes with no type to name the answer.
 
 ### Changed
+- **`llm4s-workspace-client` sheds seven unused dependencies.** Tika, POI, PDFBox, jsoup,
+  Postgres, HikariCP and commons-io were declared on `workspaceClient` but referenced by
+  nothing in it. The module is nine source files that speak WebSocket JSON to a container;
+  across all of them the only third-party imports are `org.java_websocket.*`,
+  `org.slf4j.LoggerFactory`, `pureconfig.*`, `upickle.default._` and scalatest. There is no
+  `Class.forName`, no `ServiceLoader`, no `src/main/resources` and so no
+  `META-INF/services` - nothing that could reach these libraries reflectively - and no
+  document-extraction or JDBC string anywhere in the module or in `workspaceShared`.
+
+  These were the last remnants of the era when `commonSettings` put JDBC drivers on every
+  module's classpath; they were declarations `workspace-client` inherited by copy rather than
+  by need. `llm4s-workspace-client` is published, so this also stops those seven artifacts
+  reaching downstream users through its POM - a Postgres driver and a 5 MB document-parsing
+  stack that arrived with a container-execution client. Anyone who was relying on that
+  transitively should declare what they actually use.
+
+  Each removed dependency appeared exactly once in `workspaceClient/dependencyTree`, at the
+  top level: none of them was a version pin winning a conflict over a transitive of something
+  the module really uses, which is what made the JNA declaration removed above load-bearing
+  until Vosk went with it. commons-io is the one exception worth naming - it stays on the
+  runtime classpath at the same 2.22.0, because `llm4s-core` declares it and uses it in
+  `assistant/SessionManager.scala`; removing the duplicate declaration here changes the POM,
+  not the classpath.
+
+  **`Deps.config` is deliberately kept**, with a comment in `build.sbt` saying why: pureconfig
+  is a facade over Typesafe Config and needs it at runtime, but nothing here imports
+  `com.typesafe.config`, so an import-based audit reads it as dead when it is not.
 - **`llm4s-speech` is carved out of `llm4s-core`, completing slice 3**
   ([#1130](https://github.com/llm4s/llm4s/issues/1130)). `org.llm4s.speech` and its
   subpackages move whole - package names unchanged, no source breaks.

--- a/build.sbt
+++ b/build.sbt
@@ -542,14 +542,11 @@ lazy val workspaceClient = (project in file("modules/workspace/workspaceClient")
       Deps.scalatest % Test,
       Deps.scalamock % Test,
       Deps.ujson,
-      Deps.pdfbox,
-      Deps.commonsIO,
-      Deps.tika,
-      Deps.poi,
-      Deps.jsoup,
-      Deps.postgres,
-      Deps.config,
-      Deps.hikariCP
+      // Kept deliberately: pureconfig (from commonSettings) is a facade over Typesafe Config
+      // and needs it at runtime, but no source file here imports com.typesafe.config, so an
+      // import-based audit reads it as dead. Tika/POI/PDFBox/jsoup/Postgres/HikariCP/commons-io
+      // were removed alongside this line - none of them was on any code path in this module.
+      Deps.config
     )
   )
 


### PR DESCRIPTION
Recovers the change from #1159, which never reached `main`.

## What happened

#1159 was opened against `carve/speech-1130` rather than `main`, because at the time that branch held the unmerged `llm4s-speech` carve (#1158) and edited the exact `libraryDependencies` block this touches. The intent was for GitHub to retarget it to `main` once #1158 landed.

Instead: #1158 was squash-merged into `main` first, and #1159's squash landed on `carve/speech-1130` **afterwards** — commit `67f30ed0`, which is not an ancestor of `main`. GitHub then marked #1159 as `MERGED` on the strength of its base branch having been merged, so it looks done while `main` still carries all seven dependencies.

This PR is that same commit replayed onto `main`, plus the `Signed-off-by` trailer the squash dropped. No content change from what was reviewed on #1159.

## The change

Removes from `workspaceClient`: `Deps.tika`, `Deps.poi`, `Deps.pdfbox`, `Deps.jsoup`, `Deps.postgres`, `Deps.hikariCP`, `Deps.commonsIO`.

Evidence, per the original PR:

- **Zero source references.** Across its nine files the only third-party imports are `org.java_websocket.*`, `org.slf4j.LoggerFactory`, `pureconfig.*`, `upickle.default._` and scalatest. Verified by package-prefix grep (`org.apache.tika|org.apache.poi|org.apache.pdfbox|org.jsoup|org.apache.commons.io|com.zaxxer|org.postgresql|java.sql|javax.sql`) over both `workspaceClient/src` and `workspaceShared/src`, not by import list alone — see the cask note below for why that distinction matters.
- **No reflective reach.** No `Class.forName` / `ServiceLoader` / `getClassLoader`. The module has no `src/main/resources` at all, so no `META-INF/services` and no `reference.conf`.
- **Not version pins.** In the 3741-line `workspaceClient/dependencyTree`, tika, poi, pdfbox, jsoup, HikariCP and postgresql each appear **exactly once, at top level** — nothing else pulls them, so no conflict is being won. This is the check that distinguishes them from the JNA case in #1158, where the explicit declaration existed to win a conflict and removing it would have silently downgraded rather than removed.
- **commons-io is the exception worth stating:** it stays on the classpath at 2.22.0 because `llm4s-core` declares and uses it (`assistant/SessionManager.scala:16`). Removing the duplicate declaration changes the published POM, not the classpath.

`Deps.config` is **kept**, with a comment. pureconfig is a facade over Typesafe Config and needs it at runtime, but nothing here imports `com.typesafe.config`, so an import-based audit reads it as dead. It is also doing pin work — pureconfig-core requests `config:1.4.5`, evicted by our `1.4.9`.

## Why an import audit was not sufficient

`workspaceRunner` uses cask entirely fully-qualified — `extends cask.MainRoutes`, `@cask.websocket`, `cask.WsChannelActor` — with **no `import cask` anywhere**. Concrete proof in this repo that "no import" does not mean "unused", which is why the analysis was re-run as package-prefix greps.

## Residual risk

`sbt testWorkspace` needs a built workspace-runner image and does not run in normal CI, so the containerised path is argued structurally rather than executed:

- `workspaceRunner` is `.dependsOn(workspaceShared)` only — never `workspaceClient` — and declares its own postgres/config/hikariCP, so the Docker image classpath is untouched.
- `ContainerisedWorkspaceTest` (the one `@Workspace` suite) imports only `org.llm4s.shared._`, scalatest and `java.io`/`java.nio`.
- `modules/it` depends on `rag` and `memoryPostgres`, both of which declare all six removed artifacts, so `it`'s classpath is unchanged regardless.

Low risk, but one `sbt testWorkspace` run before merge would close it properly.

## User-visible

`llm4s-workspace-client` is published, so this also stops a Postgres driver and a document-parsing stack reaching downstream users through its POM. Called out in the CHANGELOG as a deliberate change.

## Noticed, not touched

`workspaceClient` also declares `Deps.azureOpenAI`, `Deps.anthropic`, `Deps.jtokkit` and `Deps.ujson` and imports none of them — same POM-only shape as commons-io. Left for a follow-up.

## Verification

`sbt test` (full suite), `scalafmtCheckAll`, `scalafixAll --check`, `coveragePolicyCheck` and `it/itTierCheck` all pass on top of `8838f25d`. `build.sbt` edited by hand; `scalafmtSbt` not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv72ZeUqCtwsHVynQ5u9jX
