### PR TITLE
Document LLM4S onboarding to LFX Insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@
 ![GitHub issues](https://img.shields.io/github/issues/llm4s/llm4s?style=for-the-badge&label=Open%20Issues&color=purple)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/llm4s/llm4s)
 
+### Linux Foundation LFX Insights
+
+LLM4S is now onboarded and tracked on **Linux Foundation LFX Insights**, providing an independent, data-driven view of project health, maintainer activity, development, contributors, and security practices. LFX Insights tracking does not mean that LLM4S is hosted by or part of the Linux Foundation.
+
+**[View LLM4S on LFX Insights →](https://insights.linuxfoundation.org/project/llm4s)**
+
 ## Overview
 
 LLM4S provides a simple, robust, and scalable framework for building LLM applications in Scala. While most LLM work is done in Python, we believe that Scala offers a fundamentally better foundation for building reliable, maintainable AI-powered applications.
@@ -57,10 +63,6 @@ LLM4S provides a simple, robust, and scalable framework for building LLM applica
 LLM4S is a broad pre-1.0 Scala AI framework. It already includes provider clients, agents, tool calling, RAG/vector stores, memory, guardrails, tracing, metrics, reliability wrappers, workspace isolation, and multimodal APIs.
 
 The current roadmap is focused on production readiness rather than adding isolated features: stable API contracts, provider capability parity, Java/Kotlin/Spring/Gradle interop, security hardening, deterministic CI, runnable docs, and maintained reference applications. See the [roadmap](https://llm4s.org/reference/roadmap) for the June 2026 status.
-
-### LFX Insights
-
-LLM4S has been onboarded to and is now tracked on [Linux Foundation LFX Insights](https://insights.linuxfoundation.org/project/llm4s), providing independent visibility into project activity, contributors, and ecosystem health. This listing does not mean that LLM4S is hosted by or part of the Linux Foundation.
 
 ## Why Scala for LLMs?
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ LLM4S is a broad pre-1.0 Scala AI framework. It already includes provider client
 
 The current roadmap is focused on production readiness rather than adding isolated features: stable API contracts, provider capability parity, Java/Kotlin/Spring/Gradle interop, security hardening, deterministic CI, runnable docs, and maintained reference applications. See the [roadmap](https://llm4s.org/reference/roadmap) for the June 2026 status.
 
+### LFX Insights
+
+LLM4S has been onboarded to and is now tracked on [Linux Foundation LFX Insights](https://insights.linuxfoundation.org/project/llm4s), providing independent visibility into project activity, contributors, and ecosystem health. This listing does not mean that LLM4S is hosted by or part of the Linux Foundation.
+
 ## Why Scala for LLMs?
 
 - **Type Safety**: Catch errors at compile time, not in production.


### PR DESCRIPTION
## What does this PR do?

Adds a prominent Linux Foundation LFX Insights announcement immediately after Project Momentum and before Overview, with a direct link to the LLM4S profile.

This gives contributors, adopters, and organizations an independent, data-driven place to view project health, maintainer activity, development, contributors, and security practices. The wording explicitly clarifies that LLM4S is onboarded to and tracked on LFX Insights, not hosted by or part of the Linux Foundation.

## Related issue

No related issue.

## How was this tested?

- Confirmed the LFX Insights project URL returns HTTP 200.
- Ran git diff --check.
- Reviewed the Markdown structure and final diff.
- Code tests were not run because this is a README-only change.

## Checklist

- [x] I have read the Contributing Guide
- [x] PR is small and focused — one change, one reason
- [ ] sbt scalafmtAll — not applicable; no Scala files changed
- [ ] sbt test — not applicable; documentation-only change
- [ ] New code includes tests — not applicable; no code changed
- [x] No unrelated changes included (branched from main, not from another PR)
- [x] Commit messages explain the why
- [ ] Updated CHANGELOG.md under Unreleased — not applicable; no feature, bug fix, or breaking change