### PR TITLE
Refresh README current project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,13 @@ LLM4S provides a simple, robust, and scalable framework for building LLM applica
 
 ## Current Status
 
-LLM4S is a broad pre-1.0 Scala AI framework. It already includes provider clients, agents, tool calling, RAG/vector stores, memory, guardrails, tracing, metrics, reliability wrappers, workspace isolation, and multimodal APIs.
+LLM4S is under active pre-1.0 development. The latest published release is [v0.4.1](https://github.com/llm4s/llm4s/releases/tag/v0.4.1), targeting Scala 3.7.1 and JDK 21. Its APIs are usable today but are still being stabilized ahead of the 1.0 compatibility commitment.
 
-The current roadmap is focused on production readiness rather than adding isolated features: stable API contracts, provider capability parity, Java/Kotlin/Spring/Gradle interop, security hardening, deterministic CI, runnable docs, and maintained reference applications. See the [roadmap](https://llm4s.org/reference/roadmap) for the June 2026 status.
+The framework already provides multi-provider clients, agents and tool calling, RAG and vector stores, memory, guardrails, tracing and metrics, reliability wrappers, workspace isolation, MCP support, and image and speech APIs.
+
+On `main`, the first three modularization slices are complete: RAG, knowledge graph, memory, MCP, shared media types, image, and speech have been carved out of `llm4s-core` into focused modules with smaller dependency footprints. These split modules are in the build but have not yet been published as separate artifacts; v0.4.1 still ships this functionality through `llm4s-core`. See the [1.0 scope](https://llm4s.org/reference/v1-scope) and [migration guide](https://github.com/llm4s/llm4s/blob/main/docs/reference/migration.md) for module maturity and upgrade details.
+
+The path to 1.0 is focused on stable API boundaries, provider capability parity and contract tests, Java/Kotlin/Spring/Gradle interoperability, security hardening, deterministic CI, production observability and cost controls, runnable documentation, and maintained reference applications. See the [roadmap](https://llm4s.org/reference/roadmap) for the full stabilization plan.
 
 ## Why Scala for LLMs?
 


### PR DESCRIPTION
## What does this PR do?

Updates the README's Current Status section to match the repository's present state rather than summarizing LLM4S only as a broad pre-1.0 framework.

The revised section now explains:

- The v0.4.1 published baseline and Scala 3.7.1/JDK 21 targets.
- The major capabilities available today.
- The first three modularization slices completed on main.
- Which split modules are in the build but not yet separately published.
- The production-readiness work remaining before the 1.0 compatibility commitment.

It also links readers to the 1.0 scope, migration guide, and roadmap for detailed maturity and upgrade information.

## Related issue

No related issue.

## How was this tested?

- Cross-checked the release tag, Scala/JDK support, module state, changelog, 1.0 scope, migration guide, and roadmap against the repository.
- Confirmed every named carved module is declared in build.sbt.
- Confirmed all four links in the revised section return HTTP 200.
- Ran git diff --check.
- Code tests were not run because this is a README-only change.

## Checklist

- [x] I have read the Contributing Guide
- [x] PR is small and focused — one change, one reason
- [ ] sbt scalafmtAll — not applicable; no Scala files changed
- [ ] sbt test — not applicable; documentation-only change
- [ ] New code includes tests — not applicable; no code changed
- [x] No unrelated changes included (branched from main, not from another PR)
- [x] Commit messages explain the why
- [ ] Updated CHANGELOG.md under Unreleased — not applicable; documentation-only status refresh